### PR TITLE
Get previous timepoint from order in TIMEPOINTS set

### DIFF
--- a/gridpath/temporal/operations/horizons.py
+++ b/gridpath/temporal/operations/horizons.py
@@ -123,10 +123,6 @@ def previous_timepoint_init(mod, tmp):
     horizon boundary is linear, then no previous timepoint is defined. In all
     other cases, the previous timepoints is the one with an index of tmp-1.
     """
-    # TODO: can we make this determination more robust than subtracting 1 or
-    #  should we require a data check to ensure TIMEPOINTS ordered set has
-    #  increments of 1 only? Perhaps we should use the same approach as wth
-    #  previous_period and use the timepoint list index not its actual ID.
     prev_tmp_dict = {}
     for tmp in mod.TIMEPOINTS:
         if tmp == mod.first_horizon_timepoint[mod.horizon[tmp]]:
@@ -144,7 +140,8 @@ def previous_timepoint_init(mod, tmp):
                     "Horizon boundary must be either 'circular' or 'linear'"
                 )
         else:
-            prev_tmp_dict[tmp] = tmp-1
+            prev_tmp_dict[tmp] = \
+                list(mod.TIMEPOINTS)[list(mod.TIMEPOINTS).index(tmp)-1]
 
     return prev_tmp_dict
 

--- a/gridpath/temporal/operations/timepoints.py
+++ b/gridpath/temporal/operations/timepoints.py
@@ -36,11 +36,6 @@ def add_model_components(m, d):
 
     .. TODO:: we need to check there are no exceptions to the above statement
 
-    .. warning:: The *TIMEPOINTS* set must have increments of 1, for the
-        calculations of previous timepoint to work in the **horizons** module.
-    .. TODO:: see warning above and todo in horizons module; we need to
-        enforce increments of 1 or come up with a more robust method for
-        determining previous timepoint
     """
     m.TIMEPOINTS = Set(within=NonNegativeIntegers, ordered=True)
     m.number_of_hours_in_timepoint = \


### PR DESCRIPTION
Instead of taking the timepoint's ID minus 1, the previous timepoint for each
timepoint is now derived from the timepoint's index in the TIMEPOINTS set, i.e.
by the taking the timepoint with index i-1 as the previous timepoint for the
timepoint with index i. For the first timepoint of a horizon, no previous
timepoint is set if the horizon has a linear boundary and the last timepoint of
the horizon is assigned as the previous timepoint if the horizon has a circular
boundary.