### PR TITLE
Fix unconstrained reserve provision

### DIFF
--- a/gridpath/project/operations/operational_types/must_run.py
+++ b/gridpath/project/operations/operational_types/must_run.py
@@ -6,6 +6,7 @@ This module describes the operations of must-run generators. These
 generators can provide power but not reserves.
 """
 
+import warnings
 from pyomo.environ import Constraint, Set
 
 from gridpath.auxiliary.auxiliary import generator_subset_init
@@ -37,6 +38,14 @@ def add_module_specific_components(m, d):
     #  does not allow specifying a reserve_zone if 'must_run' type
     def no_upwards_reserve_rule(mod, g, tmp):
         if getattr(d, headroom_variables)[g]:
+            warnings.warn(
+                """project {} is of the 'must_run' operational type and should 
+                not be assigned any upward reserve BAs since it cannot provide 
+                upward reserves. Please replace the upward reserve BA for 
+                project {} with '.' (no value) in projects.tab. Model will add  
+                constraint to ensure project {} cannot provide upward reserves
+                """.format(g, g, g)
+            )
             return sum(getattr(mod, c)[g, tmp]
                        for c in getattr(d, headroom_variables)[g]) == 0
         else:
@@ -49,6 +58,14 @@ def add_module_specific_components(m, d):
     #  does not allow specifying a reserve_zone if 'must_run' type
     def no_downwards_reserve_rule(mod, g, tmp):
         if getattr(d, footroom_variables)[g]:
+            warnings.warn(
+                """project {} is of the 'must_run' operational type and should 
+                not be assigned any downward reserve BAs since it cannot provide 
+                upwards reserves. Please replace the downward reserve BA for 
+                project {} with '.' (no value) in projects.tab. Model will add  
+                constraint to ensure project {} cannot provide downward reserves
+                """.format(g, g, g)
+            )
             return sum(getattr(mod, c)[g, tmp]
                        for c in getattr(d, footroom_variables)[g]) == 0
         else:

--- a/gridpath/project/operations/operational_types/variable_no_curtailment.py
+++ b/gridpath/project/operations/operational_types/variable_no_curtailment.py
@@ -49,6 +49,15 @@ def add_module_specific_components(m, d):
     #  type
     def no_upwards_reserve_rule(mod, g, tmp):
         if getattr(d, headroom_variables)[g]:
+            warnings.warn(
+                """project {} is of the 'variable_no_curtailment' operational 
+                type and should not be assigned any upward reserve BAs since it 
+                cannot provide  upward reserves. Please replace the upward 
+                reserve BA for project {} with '.' (no value) in projects.tab. 
+                Model will add  constraint to ensure project {} cannot provide 
+                upward reserves
+                """.format(g, g, g)
+            )
             return sum(getattr(mod, c)[g, tmp]
                        for c in getattr(d, headroom_variables)[g]) == 0
         else:
@@ -62,6 +71,15 @@ def add_module_specific_components(m, d):
     #  type
     def no_downwards_reserve_rule(mod, g, tmp):
         if getattr(d, footroom_variables)[g]:
+            warnings.warn(
+                """project {} is of the 'variable_no_curtailment' operational 
+                type and should not be assigned any downward reserve BAs since 
+                it cannot provide downward reserves. Please replace the downward 
+                reserve BA for project {} with '.' (no value) in projects.tab. 
+                Model will add  constraint to ensure project {} cannot provide 
+                downward reserves
+                """.format(g, g, g)
+            )
             return sum(getattr(mod, c)[g, tmp]
                        for c in getattr(d, footroom_variables)[g]) == 0
         else:


### PR DESCRIPTION
Currently, operational types that are assumed not to provide
reserves have no constraints on their reserve provision in the
operational_type's module. However, if a user provides a reserve
sharing zone for any of these type of resources, the model will
create a decision variable for that type of reserve,
and the variable will be totally unconstrained.
This is a silent bug and won't show up until you add a reserve 
zone to one of these operational types. 

This bug currently applies to the following operational types:
 - must_run
 - variable_no_curtailment
 - always_on (will get reserve provision so won't be an issue,
   see PR #43)

This PR solves the issue by adding a constraint for the must_run
and variable_no_curtailment operational types that sets the sum of
all headroom variables and the sum of all footroom variables to zero.

Another option would be to disallow inputting any reserve sharing zone
for certain type of generators (must_run, variable_no_curtailment)

Closes: #39