### PR TITLE
Add reserve provision to ramp rate constraints

### DIFF
--- a/examples/2periods_new_build_rps_w_rps_eligible_storage/results/objective_function_value.txt
+++ b/examples/2periods_new_build_rps_w_rps_eligible_storage/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 945001614.79
+Objective function: 945001614.8

--- a/examples/2periods_new_build_rps_w_rps_ineligible_storage/results/objective_function_value.txt
+++ b/examples/2periods_new_build_rps_w_rps_ineligible_storage/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 940371813.22
+Objective function: 940371813.23

--- a/examples/test_ramp_up_and_down_constraints/inputs/projects.tab
+++ b/examples/test_ramp_up_and_down_constraints/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	unit_size_mw	startup_plus_ramp_up_rate	shutdown_plus_ramp_down_rate
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	6	0.005	0.0033333
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	6	0.0116667	0.0066667
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	6	0.0116667	0.0066667
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	6	0.005	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	6	.	0.015
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	6	.	.
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.	.

--- a/examples/test_ramp_up_and_down_constraints/results/objective_function_value.txt
+++ b/examples/test_ramp_up_and_down_constraints/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 80070611.95
+Objective function: 68909.08

--- a/examples/test_ramp_up_and_down_constraints/results/summary_results.txt
+++ b/examples/test_ramp_up_and_down_constraints/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   31            100
+Zone1     2020   unspecified                   30            100

--- a/examples/test_ramp_up_constraints/inputs/projects.tab
+++ b/examples/test_ramp_up_constraints/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	unit_size_mw	startup_plus_ramp_up_rate
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
 Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	6	0.005
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	6	0.0116667
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	6	0.0116667
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	6	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	6	.
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.

--- a/examples/test_ramp_up_constraints/results/objective_function_value.txt
+++ b/examples/test_ramp_up_constraints/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 68097.61
+Objective function: 67414.48

--- a/gridpath/project/operations/operational_types/dispatchable_binary_commit.py
+++ b/gridpath/project/operations/operational_types/dispatchable_binary_commit.py
@@ -897,7 +897,7 @@ def startup_shutdown_rule(mod, g, tmp):
             * mod.DispBinCommit_Pmax_MW[g, tmp]
 
 
-def ramp_rule(mod, g, tmp):
+def power_delta_rule(mod, g, tmp):
     """
     Ramp between this timepoint and the previous timepoint
     Actual ramp rate in MW/hr depends on the duration of the timepoints.

--- a/gridpath/project/operations/operational_types/dispatchable_continuous_commit.py
+++ b/gridpath/project/operations/operational_types/dispatchable_continuous_commit.py
@@ -903,7 +903,7 @@ def startup_shutdown_rule(mod, g, tmp):
             * mod.DispContCommit_Pmax_MW[g, tmp]
 
 
-def ramp_rule(mod, g, tmp):
+def power_delta_rule(mod, g, tmp):
     """
     Ramp between this timepoint and the previous timepoint
     Actual ramp rate in MW/hr depends on the duration of the timepoints.

--- a/gridpath/project/operations/operational_types/dispatchable_no_commit.py
+++ b/gridpath/project/operations/operational_types/dispatchable_no_commit.py
@@ -181,13 +181,12 @@ def startup_shutdown_rule(mod, g, tmp):
             mod.Provide_Power_DispNoCommit_MW[g, mod.previous_timepoint[tmp]]
 
 
-def ramp_rule(mod, g, tmp):
+def power_delta_rule(mod, g, tmp):
     """
-
-    :param mod: 
-    :param g: 
-    :param tmp: 
-    :return: 
+    :param mod:
+    :param g:
+    :param tmp:
+    :return:
     """
     if tmp == mod.first_horizon_timepoint[mod.horizon[tmp]] \
             and mod.boundary[mod.horizon[tmp]] == "linear":

--- a/gridpath/project/operations/operational_types/must_run.py
+++ b/gridpath/project/operations/operational_types/must_run.py
@@ -183,12 +183,11 @@ def startup_shutdown_rule(mod, g, tmp):
     )
 
 
-def ramp_rule(mod, g, tmp):
+def power_delta_rule(mod, g, tmp):
     """
-
-    :param mod: 
-    :param g: 
-    :param tmp: 
-    :return: 
+    :param mod:
+    :param g:
+    :param tmp:
+    :return:
     """
     return 0

--- a/gridpath/project/operations/operational_types/shiftable_load_generic.py
+++ b/gridpath/project/operations/operational_types/shiftable_load_generic.py
@@ -180,9 +180,8 @@ def startup_shutdown_rule(mod, g, tmp):
     )
 
 
-def ramp_rule(mod, l, tmp):
+def power_delta_rule(mod, l, tmp):
     """
-
     :param mod:
     :param l:
     :param tmp:

--- a/gridpath/project/operations/operational_types/storage_generic.py
+++ b/gridpath/project/operations/operational_types/storage_generic.py
@@ -428,13 +428,12 @@ def startup_shutdown_rule(mod, g, tmp):
     )
 
 
-def ramp_rule(mod, g, tmp):
+def power_delta_rule(mod, g, tmp):
     """
-
-    :param mod: 
-    :param g: 
-    :param tmp: 
-    :return: 
+    :param mod:
+    :param g:
+    :param tmp:
+    :return:
     """
     if tmp == mod.first_horizon_timepoint[mod.horizon[tmp]] \
             and mod.boundary[mod.horizon[tmp]] == "linear":

--- a/gridpath/project/operations/operational_types/variable.py
+++ b/gridpath/project/operations/operational_types/variable.py
@@ -312,13 +312,14 @@ def startup_shutdown_rule(mod, g, tmp):
     )
 
 
-def ramp_rule(mod, g, tmp):
+def power_delta_rule(mod, g, tmp):
     """
-    Curtailment is counted as part of the ramp here
-    :param mod: 
-    :param g: 
-    :param tmp: 
-    :return: 
+    Curtailment is counted as part of the ramp here; excludes any ramping from
+    reserve provision.
+    :param mod:
+    :param g:
+    :param tmp:
+    :return:
     """
     if tmp == mod.first_horizon_timepoint[mod.horizon[tmp]] \
             and mod.boundary[mod.horizon[tmp]] == "linear":

--- a/gridpath/project/operations/operational_types/variable_no_curtailment.py
+++ b/gridpath/project/operations/operational_types/variable_no_curtailment.py
@@ -201,13 +201,14 @@ def startup_shutdown_rule(mod, g, tmp):
     )
 
 
-def ramp_rule(mod, g, tmp):
+def power_delta_rule(mod, g, tmp):
     """
-    Exogenously defined ramp for variable generators (no curtailment)
-    :param mod: 
-    :param g: 
-    :param tmp: 
-    :return: 
+    Exogenously defined ramp for variable generators (no curtailment); excludes
+    any ramping from reserve provision.
+    :param mod:
+    :param g:
+    :param tmp:
+    :return:
     """
     if tmp == mod.first_horizon_timepoint[mod.horizon[tmp]] \
             and mod.boundary[mod.horizon[tmp]] == "linear":

--- a/gridpath/project/operations/tuning_costs.py
+++ b/gridpath/project/operations/tuning_costs.py
@@ -29,7 +29,9 @@ def add_model_components(m, d):
     imported_operational_modules = \
         load_operational_type_modules(getattr(d, required_operational_modules))
 
-    # Figure out how much each project ramped
+    # Figure out how much each project ramped (for simplicity, only look at
+    # the difference in power setpoints, i.e. ignore the effect of providing
+    # any reserves)
     def ramp_rule(mod, g, tmp):
         """
         :param mod:
@@ -39,7 +41,7 @@ def add_model_components(m, d):
         """
         gen_op_type = mod.operational_type[g]
         return imported_operational_modules[gen_op_type]. \
-            ramp_rule(mod, g, tmp)
+            power_delta_rule(mod, g, tmp)
 
     m.Ramp_Expression = Expression(
         m.PROJECT_OPERATIONAL_TIMEPOINTS,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -470,7 +470,7 @@ class TestExamples(unittest.TestCase):
                  "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 68097.61333333333
+        expected_objective = 67414.48
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -490,7 +490,7 @@ class TestExamples(unittest.TestCase):
                  "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 80070611.95440792
+        expected_objective = 68909.08
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)


### PR DESCRIPTION
When you are providing downward reserves in the previous timepoint, and/or upward reserves in the current timepoint should reduce the amount of upward ramping you can do between timepoint setpoints. E.g. if you're going from 50 MW in t-1 to 100 MW at t, but you were also providing 10 MW reg down in t-1 and 10 MW reg up in t, your unit must at least be able to ramp up 70 MW between timepoints.

Likewise, if you are providing upward reserves in the previous timepoint, and/or downward reserves in the current timepoint sould reduce the amount of downward ramping you can do between timepoint setpoints. E.g. if you're going from 100 MW in t-1 to 50 MW at t, but you were also provding 10 MW reg up in t-1 and 10 MW reg down in t, your unit must at least be able to ramp down 70 MW between timepoints.

This commit adjusts the ramp rate constraints to take into account the reserve provisions in the current and previous timepoint. The following operational types are affected:
 - always_on
 - dispatchable_capacity_commit
 - hydro_curtailable
 - hydro_noncurtailable

The binary and continuous commit operational types are being updated as part of another PR (#50) and will have the proper adjustments in their ramp rate constraints.

The no_commit operational type currently does not have ramp rate constraints, but if we add them we should make sure to properly adjust for the reserve-provision. 