### PR TITLE
20190624 47 change test examples gdm

### DIFF
--- a/examples/2horizons/inputs/projects.tab
+++ b/examples/2horizons/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.

--- a/examples/2horizons/results/objective_function_value.txt
+++ b/examples/2horizons/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 131016.83
+Objective function: 1733474484.69

--- a/examples/2horizons/results/summary_results.txt
+++ b/examples/2horizons/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                 60.0          100.0
+Zone1     2020   unspecified            61.333333          100.0

--- a/examples/2periods/inputs/projects.tab
+++ b/examples/2periods/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.

--- a/examples/2periods/results/objective_function_value.txt
+++ b/examples/2periods/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 1310168.26
+Objective function: 17334744846.93

--- a/examples/2periods/results/summary_results.txt
+++ b/examples/2periods/results/summary_results.txt
@@ -7,5 +7,5 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                 30.0          100.0
-          2030   unspecified                 30.0          100.0
+Zone1     2020   unspecified            30.666667          100.0
+          2030   unspecified            30.666667          100.0

--- a/examples/2periods_gen_bin_econ_retirement/inputs/projects.tab
+++ b/examples/2periods_gen_bin_econ_retirement/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	technology
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	Nuclear
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	Gas
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Gas
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	Coal
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	Gas
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	Wind

--- a/examples/2periods_gen_bin_econ_retirement/results/objective_function_value.txt
+++ b/examples/2periods_gen_bin_econ_retirement/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 1310168.26
+Objective function: 17334744846.93

--- a/examples/2periods_gen_bin_econ_retirement/results/summary_results.txt
+++ b/examples/2periods_gen_bin_econ_retirement/results/summary_results.txt
@@ -13,11 +13,11 @@ Zone1     Coal       2020                       10
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          3             10
-                 Gas                          12             41
-                 Nuclear                      12             40
-                 Wind                          3              9
-          2030   Coal                          3             10
-                 Gas                          12             41
-                 Nuclear                      12             40
-                 Wind                          3              9
+Zone1     2020   Coal                          4             14
+                 Gas                          13             44
+                 Nuclear                      12             39
+                 Wind                          1              3
+          2030   Coal                          4             14
+                 Gas                          13             44
+                 Nuclear                      12             39
+                 Wind                          1              3

--- a/examples/2periods_gen_lin_econ_retirement/inputs/projects.tab
+++ b/examples/2periods_gen_lin_econ_retirement/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	technology
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	Nuclear
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	Gas
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Gas
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	Coal
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	Gas
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	Wind

--- a/examples/2periods_gen_lin_econ_retirement/results/objective_function_value.txt
+++ b/examples/2periods_gen_lin_econ_retirement/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 1276508.27
+Objective function: 17334744846.93

--- a/examples/2periods_gen_lin_econ_retirement/results/summary_results.txt
+++ b/examples/2periods_gen_lin_econ_retirement/results/summary_results.txt
@@ -5,19 +5,19 @@
 --> Retired Capacity <--
                              Retired Capacity (MW)
 load_zone technology period                       
-Zone1     Coal       2020                        8
-                     2030                        8
+Zone1     Coal       2020                       10
+                     2030                       10
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          3             11
-                 Gas                          12             40
-                 Nuclear                      12             40
-                 Wind                          3              9
-          2030   Coal                          3             11
-                 Gas                          12             40
-                 Nuclear                      12             40
-                 Wind                          3              9
+Zone1     2020   Coal                          4             14
+                 Gas                          13             44
+                 Nuclear                      12             39
+                 Wind                          1              3
+          2030   Coal                          4             14
+                 Gas                          13             44
+                 Nuclear                      12             39
+                 Wind                          1              3

--- a/examples/2periods_new_build/inputs/projects.tab
+++ b/examples/2periods_new_build/inputs/projects.tab
@@ -1,8 +1,8 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.
-Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
-Gas_CT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.
+Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6
+Gas_CT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6

--- a/examples/2periods_new_build/results/objective_function_value.txt
+++ b/examples/2periods_new_build/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 110457853.09
+Objective function: 111439176.93

--- a/examples/2periods_new_build_2zones/inputs/projects.tab
+++ b/examples/2periods_new_build_2zones/inputs/projects.tab
@@ -1,15 +1,15 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.
-Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
-Gas_CT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
-Nuclear_z2	Zone2	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
-Gas_CCGT_z2	Zone2	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone2	Zone2	Zone2	Zone2	0.4	1	2	Gas
-Coal_z2	Zone2	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone2	.	Zone2	0.4	1	0	Coal
-Gas_CT_z2	Zone2	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
-Wind_z2	Zone2	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.
-Gas_CCGT_New_z2	Zone2	new_build_generator	2	dispatchable_continuous_commit	Zone2	Zone2	Zone2	Zone2	0.4	1	2	Gas
-Gas_CT_New_z2	Zone2	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.
+Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6
+Gas_CT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6
+Nuclear_z2	Zone2	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
+Gas_CCGT_z2	Zone2	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone2	Zone2	Zone2	Zone2	0.4	1	2	Gas	.
+Coal_z2	Zone2	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone2	.	Zone2	0.4	1	0	Coal	.
+Gas_CT_z2	Zone2	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
+Wind_z2	Zone2	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.
+Gas_CCGT_New_z2	Zone2	new_build_generator	2	dispatchable_capacity_commit	Zone2	Zone2	Zone2	Zone2	0.4	1	2	Gas	6
+Gas_CT_New_z2	Zone2	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6

--- a/examples/2periods_new_build_2zones/results/objective_function_value.txt
+++ b/examples/2periods_new_build_2zones/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 220915706.18
+Objective function: 222878353.86

--- a/examples/2periods_new_build_2zones_singleBA/inputs/projects.tab
+++ b/examples/2periods_new_build_2zones_singleBA/inputs/projects.tab
@@ -1,15 +1,15 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	BA	BA	BA	BA	0.4	1	2	Gas
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	BA	.	BA	0.4	1	0	Coal
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.
-Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	BA	BA	BA	BA	0.4	1	2	Gas
-Gas_CT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
-Nuclear_z2	Zone2	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
-Gas_CCGT_z2	Zone2	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	BA	BA	BA	BA	0.4	1	2	Gas
-Coal_z2	Zone2	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	BA	.	BA	0.4	1	0	Coal
-Gas_CT_z2	Zone2	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
-Wind_z2	Zone2	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.
-Gas_CCGT_New_z2	Zone2	new_build_generator	2	dispatchable_continuous_commit	BA	BA	BA	BA	0.4	1	2	Gas
-Gas_CT_New_z2	Zone2	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	BA	BA	BA	BA	0.4	1	2	Gas	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	BA	.	BA	0.4	1	0	Coal	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.
+Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	BA	BA	BA	BA	0.4	1	2	Gas	6
+Gas_CT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6
+Nuclear_z2	Zone2	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
+Gas_CCGT_z2	Zone2	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	BA	BA	BA	BA	0.4	1	2	Gas	.
+Coal_z2	Zone2	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	BA	.	BA	0.4	1	0	Coal	.
+Gas_CT_z2	Zone2	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
+Wind_z2	Zone2	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.
+Gas_CCGT_New_z2	Zone2	new_build_generator	2	dispatchable_capacity_commit	BA	BA	BA	BA	0.4	1	2	Gas	6
+Gas_CT_New_z2	Zone2	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6

--- a/examples/2periods_new_build_2zones_singleBA/results/objective_function_value.txt
+++ b/examples/2periods_new_build_2zones_singleBA/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 220874494.67
+Objective function: 222878353.86

--- a/examples/2periods_new_build_2zones_singleBA/results/summary_results.txt
+++ b/examples/2periods_new_build_2zones_singleBA/results/summary_results.txt
@@ -5,9 +5,10 @@
 --> New Generation Capacity <--
                               New Capacity (MW)
 load_zone technology  period                   
-Zone1     unspecified 2020                   25
-                      2030                    6
+Zone1     unspecified 2020                   24
+                      2030                    1
 Zone2     unspecified 2020                   28
+                      2030                    4
 
 ### OPERATIONAL RESULTS ###
 

--- a/examples/2periods_new_build_cumulative_min_max/inputs/projects.tab
+++ b/examples/2periods_new_build_cumulative_min_max/inputs/projects.tab
@@ -1,8 +1,8 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.
-Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
-Gas_CT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.
+Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6
+Gas_CT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6

--- a/examples/2periods_new_build_cumulative_min_max/results/objective_function_value.txt
+++ b/examples/2periods_new_build_cumulative_min_max/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 6295830632.16
+Objective function: 6296548240.93

--- a/examples/2periods_new_build_local_capacity/inputs/projects.tab
+++ b/examples/2periods_new_build_local_capacity/inputs/projects.tab
@@ -1,8 +1,8 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	local_capacity_zone	local_capacity_fraction
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	Zone1	0.8
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Zone1	0.8
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	Zone1	0.8
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	Zone1	0.8
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	Zone1	0.8
-Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Zone1	0.8
-Gas_CT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	Zone1	0.8
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	local_capacity_zone	local_capacity_fraction	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	Zone1	0.8	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Zone1	0.8	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	Zone1	0.8	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	Zone1	0.8	.
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	Zone1	0.8	.
+Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Zone1	0.8	6
+Gas_CT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	Zone1	0.8	6

--- a/examples/2periods_new_build_local_capacity/results/objective_function_value.txt
+++ b/examples/2periods_new_build_local_capacity/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 113881853.09
+Objective function: 114863176.93

--- a/examples/2periods_new_build_rps/inputs/projects.tab
+++ b/examples/2periods_new_build_rps/inputs/projects.tab
@@ -1,9 +1,9 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	rps_zone
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	.
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	RPSZone1
-Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.
-Gas_CT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
-Wind_New	Zone1	new_build_generator	0	variable	.	.	.	.	.	.	.	.	RPSZone1
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	rps_zone	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	.	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.	.
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	RPSZone1	.
+Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.	6
+Gas_CT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	.	6
+Wind_New	Zone1	new_build_generator	0	variable	.	.	.	.	.	.	.	.	RPSZone1	.

--- a/examples/2periods_new_build_rps/results/objective_function_value.txt
+++ b/examples/2periods_new_build_rps/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 972819423.62
+Objective function: 972692908.13

--- a/examples/2periods_new_build_rps_variable_reserves/inputs/projects.tab
+++ b/examples/2periods_new_build_rps_variable_reserves/inputs/projects.tab
@@ -1,9 +1,9 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	rps_zone
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	.
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	RPSZone1
-Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.
-Gas_CT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
-Wind_New	Zone1	new_build_generator	0	variable	Zone1	Zone1	Zone1	Zone1	.	.	.	.	RPSZone1
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	rps_zone	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	.	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.	.
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	RPSZone1	.
+Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.	6
+Gas_CT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	.	6
+Wind_New	Zone1	new_build_generator	0	variable	Zone1	Zone1	Zone1	Zone1	.	.	.	.	RPSZone1	.

--- a/examples/2periods_new_build_rps_variable_reserves/results/objective_function_value.txt
+++ b/examples/2periods_new_build_rps_variable_reserves/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 845688188.89
+Objective function: 844029554.49

--- a/examples/2periods_new_build_rps_variable_reserves/results/summary_results.txt
+++ b/examples/2periods_new_build_rps_variable_reserves/results/summary_results.txt
@@ -19,5 +19,5 @@ Zone1     2020   unspecified                   80            100
 ### RPS RESULTS ###
                  rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed       dual  rps_marginal_cost_per_mwh
 rps_zone period                                                                                                                             
-RPSZone1 2020                50                        50                        -0                 -0  7,128,255                    712,826
-         2030                50                        50                        23                 31 18,199,650                  1,819,965
+RPSZone1 2020                50                        50                         0                  0  7,128,256                    712,826
+         2030                50                        50                        23                 31 18,595,563                  1,859,556

--- a/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/inputs/projects.tab
+++ b/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/inputs/projects.tab
@@ -1,9 +1,9 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	rps_zone
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	.
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	RPSZone1
-Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.
-Gas_CT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.
-Wind_New	Zone1	new_build_generator	0	variable	Zone1	Zone1	Zone1	Zone1	.	.	.	.	RPSZone1
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	rps_zone	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	.	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	.	.
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	RPSZone1	.
+Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	.	6
+Gas_CT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	.	6
+Wind_New	Zone1	new_build_generator	0	variable	Zone1	Zone1	Zone1	Zone1	.	.	.	.	RPSZone1	.

--- a/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/results/objective_function_value.txt
+++ b/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 846576209.42
+Objective function: 845462123.96

--- a/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/results/summary_results.txt
+++ b/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/results/summary_results.txt
@@ -20,4 +20,4 @@ Zone1     2020   unspecified                   80            100
                  rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed       dual  rps_marginal_cost_per_mwh
 rps_zone period                                                                                                                             
 RPSZone1 2020                50                        50                         0                  0  7,199,750                    719,975
-         2030                50                        50                        23                 31 18,199,650                  1,819,965
+         2030                50                        50                        23                 31 18,595,563                  1,859,556

--- a/examples/2periods_new_build_simple_prm/inputs/projects.tab
+++ b/examples/2periods_new_build_simple_prm/inputs/projects.tab
@@ -1,8 +1,8 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	prm_zone	elcc_simple_fraction	prm_type
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	Zone1	0.8	fully_deliverable
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Zone1	0.8	fully_deliverable
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	Zone1	0.8	fully_deliverable
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	Zone1	0.8	fully_deliverable
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	Zone1	0.8	fully_deliverable
-Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Zone1	0.8	fully_deliverable
-Gas_CT_New	Zone1	new_build_generator	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	Zone1	0.8	fully_deliverable
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	prm_zone	elcc_simple_fraction	prm_type	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	Zone1	0.8	fully_deliverable	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Zone1	0.8	fully_deliverable	.
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	Zone1	0.8	fully_deliverable	.
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	Zone1	0.8	fully_deliverable	.
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	Zone1	0.8	fully_deliverable	.
+Gas_CCGT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	Zone1	0.8	fully_deliverable	6
+Gas_CT_New	Zone1	new_build_generator	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	Zone1	0.8	fully_deliverable	6

--- a/examples/2periods_new_build_simple_prm/results/objective_function_value.txt
+++ b/examples/2periods_new_build_simple_prm/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 197097539.09
+Objective function: 198677529.6

--- a/examples/2periods_new_build_simple_prm/results/summary_results.txt
+++ b/examples/2periods_new_build_simple_prm/results/summary_results.txt
@@ -6,7 +6,6 @@
                               New Capacity (MW)
 load_zone technology  period                   
 Zone1     unspecified 2020                   49
-                      2030                    0
 
 ### OPERATIONAL RESULTS ###
 

--- a/examples/multi_stage_prod_cost/1/da/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost/1/da/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	da	6
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost/1/da/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost/1/da/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/multi_stage_prod_cost/1/da/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/1/da/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/multi_stage_prod_cost/1/ha/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost/1/ha/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost/1/ha/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost/1/ha/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/multi_stage_prod_cost/1/ha/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/1/ha/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/multi_stage_prod_cost/1/rt/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost/1/rt/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost/1/rt/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost/1/rt/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/multi_stage_prod_cost/1/rt/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/1/rt/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/multi_stage_prod_cost/2/da/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost/2/da/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost/2/da/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost/2/da/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/multi_stage_prod_cost/2/da/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/2/da/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/multi_stage_prod_cost/2/ha/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost/2/ha/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost/2/ha/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost/2/ha/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/multi_stage_prod_cost/2/ha/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/2/ha/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/multi_stage_prod_cost/2/rt/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost/2/rt/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost/2/rt/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost/2/rt/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/multi_stage_prod_cost/2/rt/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/2/rt/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/multi_stage_prod_cost/3/da/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost/3/da/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost/3/da/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost/3/da/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/multi_stage_prod_cost/3/da/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/3/da/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/multi_stage_prod_cost/3/ha/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost/3/ha/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost/3/ha/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost/3/ha/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/multi_stage_prod_cost/3/ha/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/3/ha/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/multi_stage_prod_cost/3/rt/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost/3/rt/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost/3/rt/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost/3/rt/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/multi_stage_prod_cost/3/rt/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/3/rt/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/multi_stage_prod_cost_w_hydro/1/da/inputs/heat_rate_curves.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/1/da/inputs/heat_rate_curves.tab
@@ -1,0 +1,8 @@
+project	load_point_mw	average_heat_rate_mmbtu_per_mwh
+Coal	2.4	1250
+Coal	6	506
+Gas_CCGT	3	506
+Gas_CCGT	6	256
+Gas_CT	2.4	208.33333
+Gas_CT	6	88.13333
+Nuclear	6	1666.67

--- a/examples/multi_stage_prod_cost_w_hydro/1/da/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/1/da/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	da	6
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost_w_hydro/1/da/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/1/da/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 60564.52
+Objective function: 966735355.35

--- a/examples/multi_stage_prod_cost_w_hydro/1/da/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/1/da/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   32            100

--- a/examples/multi_stage_prod_cost_w_hydro/1/ha/inputs/heat_rate_curves.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/1/ha/inputs/heat_rate_curves.tab
@@ -1,0 +1,8 @@
+project	load_point_mw	average_heat_rate_mmbtu_per_mwh
+Coal	2.4	1250
+Coal	6	506
+Gas_CCGT	3	506
+Gas_CCGT	6	256
+Gas_CT	2.4	208.33333
+Gas_CT	6	88.13333
+Nuclear	6	1666.67

--- a/examples/multi_stage_prod_cost_w_hydro/1/ha/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/1/ha/inputs/projects.tab
@@ -1,7 +1,7 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
-Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost_w_hydro/1/ha/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/1/ha/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 60564.52
+Objective function: 966735355.35

--- a/examples/multi_stage_prod_cost_w_hydro/1/ha/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/1/ha/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   32            100

--- a/examples/multi_stage_prod_cost_w_hydro/1/rt/inputs/heat_rate_curves.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/1/rt/inputs/heat_rate_curves.tab
@@ -1,0 +1,8 @@
+project	load_point_mw	average_heat_rate_mmbtu_per_mwh
+Coal	2.4	1250
+Coal	6	506
+Gas_CCGT	3	506
+Gas_CCGT	6	256
+Gas_CT	2.4	208.33333
+Gas_CT	6	88.13333
+Nuclear	6	1666.67

--- a/examples/multi_stage_prod_cost_w_hydro/1/rt/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/1/rt/inputs/projects.tab
@@ -1,7 +1,7 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
-Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost_w_hydro/1/rt/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/1/rt/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 60564.52
+Objective function: 966735355.35

--- a/examples/multi_stage_prod_cost_w_hydro/1/rt/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/1/rt/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   32            100

--- a/examples/multi_stage_prod_cost_w_hydro/2/da/inputs/heat_rate_curves.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/2/da/inputs/heat_rate_curves.tab
@@ -1,0 +1,8 @@
+project	load_point_mw	average_heat_rate_mmbtu_per_mwh
+Coal	2.4	1250
+Coal	6	506
+Gas_CCGT	3	506
+Gas_CCGT	6	256
+Gas_CT	2.4	208.33333
+Gas_CT	6	88.13333
+Nuclear	6	1666.67

--- a/examples/multi_stage_prod_cost_w_hydro/2/da/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/2/da/inputs/projects.tab
@@ -1,7 +1,7 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
-Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost_w_hydro/2/da/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/2/da/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 60564.52
+Objective function: 966735355.35

--- a/examples/multi_stage_prod_cost_w_hydro/2/da/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/2/da/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   32            100

--- a/examples/multi_stage_prod_cost_w_hydro/2/ha/inputs/heat_rate_curves.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/2/ha/inputs/heat_rate_curves.tab
@@ -1,0 +1,8 @@
+project	load_point_mw	average_heat_rate_mmbtu_per_mwh
+Coal	2.4	1250
+Coal	6	506
+Gas_CCGT	3	506
+Gas_CCGT	6	256
+Gas_CT	2.4	208.33333
+Gas_CT	6	88.13333
+Nuclear	6	1666.67

--- a/examples/multi_stage_prod_cost_w_hydro/2/ha/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/2/ha/inputs/projects.tab
@@ -1,7 +1,7 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
-Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost_w_hydro/2/ha/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/2/ha/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 60564.52
+Objective function: 966735355.35

--- a/examples/multi_stage_prod_cost_w_hydro/2/ha/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/2/ha/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   32            100

--- a/examples/multi_stage_prod_cost_w_hydro/2/rt/inputs/heat_rate_curves.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/2/rt/inputs/heat_rate_curves.tab
@@ -1,0 +1,8 @@
+project	load_point_mw	average_heat_rate_mmbtu_per_mwh
+Coal	2.4	1250
+Coal	6	506
+Gas_CCGT	3	506
+Gas_CCGT	6	256
+Gas_CT	2.4	208.33333
+Gas_CT	6	88.13333
+Nuclear	6	1666.67

--- a/examples/multi_stage_prod_cost_w_hydro/2/rt/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/2/rt/inputs/projects.tab
@@ -1,7 +1,7 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
-Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost_w_hydro/2/rt/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/2/rt/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 60564.52
+Objective function: 966735355.35

--- a/examples/multi_stage_prod_cost_w_hydro/2/rt/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/2/rt/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   32            100

--- a/examples/multi_stage_prod_cost_w_hydro/3/da/inputs/heat_rate_curves.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/3/da/inputs/heat_rate_curves.tab
@@ -1,0 +1,8 @@
+project	load_point_mw	average_heat_rate_mmbtu_per_mwh
+Coal	2.4	1250
+Coal	6	506
+Gas_CCGT	3	506
+Gas_CCGT	6	256
+Gas_CT	2.4	208.33333
+Gas_CT	6	88.13333
+Nuclear	6	1666.67

--- a/examples/multi_stage_prod_cost_w_hydro/3/da/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/3/da/inputs/projects.tab
@@ -1,7 +1,7 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
-Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost_w_hydro/3/da/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/3/da/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 60564.52
+Objective function: 966735355.35

--- a/examples/multi_stage_prod_cost_w_hydro/3/da/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/3/da/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   32            100

--- a/examples/multi_stage_prod_cost_w_hydro/3/ha/inputs/heat_rate_curves.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/3/ha/inputs/heat_rate_curves.tab
@@ -1,0 +1,8 @@
+project	load_point_mw	average_heat_rate_mmbtu_per_mwh
+Coal	2.4	1250
+Coal	6	506
+Gas_CCGT	3	506
+Gas_CCGT	6	256
+Gas_CT	2.4	208.33333
+Gas_CT	6	88.13333
+Nuclear	6	1666.67

--- a/examples/multi_stage_prod_cost_w_hydro/3/ha/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/3/ha/inputs/projects.tab
@@ -1,7 +1,7 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
-Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost_w_hydro/3/ha/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/3/ha/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 60564.52
+Objective function: 966735355.35

--- a/examples/multi_stage_prod_cost_w_hydro/3/ha/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/3/ha/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   32            100

--- a/examples/multi_stage_prod_cost_w_hydro/3/rt/inputs/heat_rate_curves.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/3/rt/inputs/heat_rate_curves.tab
@@ -1,0 +1,8 @@
+project	load_point_mw	average_heat_rate_mmbtu_per_mwh
+Coal	2.4	1250
+Coal	6	506
+Gas_CCGT	3	506
+Gas_CCGT	6	256
+Gas_CT	2.4	208.33333
+Gas_CT	6	88.13333
+Nuclear	6	1666.67

--- a/examples/multi_stage_prod_cost_w_hydro/3/rt/inputs/projects.tab
+++ b/examples/multi_stage_prod_cost_w_hydro/3/rt/inputs/projects.tab
@@ -1,7 +1,7 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh	last_commitment_stage	unit_size_mw
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6	da	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10	ha	6
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	500	8	rt	6
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	.
-Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	last_commitment_stage	unit_size_mw
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	da	6
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	ha	6
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	rt	6
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+Hydro	Zone1	existing_gen_no_economic_retirement	0	hydro_noncurtailable	.	.	.	.	.	.	.	.	.	.

--- a/examples/multi_stage_prod_cost_w_hydro/3/rt/results/objective_function_value.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/3/rt/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 60564.52
+Objective function: 966735355.35

--- a/examples/multi_stage_prod_cost_w_hydro/3/rt/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/3/rt/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   32            100

--- a/examples/single_stage_prod_cost/1/inputs/projects.tab
+++ b/examples/single_stage_prod_cost/1/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.

--- a/examples/single_stage_prod_cost/1/results/objective_function_value.txt
+++ b/examples/single_stage_prod_cost/1/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/single_stage_prod_cost/1/results/summary_results.txt
+++ b/examples/single_stage_prod_cost/1/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/single_stage_prod_cost/2/inputs/projects.tab
+++ b/examples/single_stage_prod_cost/2/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	500	8
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.

--- a/examples/single_stage_prod_cost/2/results/objective_function_value.txt
+++ b/examples/single_stage_prod_cost/2/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/single_stage_prod_cost/2/results/summary_results.txt
+++ b/examples/single_stage_prod_cost/2/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/single_stage_prod_cost/3/inputs/projects.tab
+++ b/examples/single_stage_prod_cost/3/inputs/projects.tab
@@ -1,6 +1,6 @@
-project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	minimum_input_mmbtu_per_hr	inc_heat_rate_mmbtu_per_mwh
-Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	0	1666.67
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	1500	6
-Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	3000	10
-Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas	500	8
-Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.
+project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel
+Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas
+Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_continuous_commit	.	Zone1	.	Zone1	0.4	1	0	Coal
+Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_continuous_commit	.	.	.	.	0.4	0	1	Gas
+Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.

--- a/examples/single_stage_prod_cost/3/results/objective_function_value.txt
+++ b/examples/single_stage_prod_cost/3/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/single_stage_prod_cost/3/results/summary_results.txt
+++ b/examples/single_stage_prod_cost/3/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/test/inputs/projects.tab
+++ b/examples/test/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.

--- a/examples/test/results/objective_function_value.txt
+++ b/examples/test/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 65508.41
+Objective function: 866737242.35

--- a/examples/test/results/summary_results.txt
+++ b/examples/test/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/test_new_build_storage/inputs/projects.tab
+++ b/examples/test_new_build_storage/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw	charging_efficiency	discharging_efficiency	technology	minimum_duration_hours
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.	.	Nuclear	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6	.	.	Gas	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6	.	.	Gas	.
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6	.	.	Coal	.
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6	.	.	Gas	.
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	Wind	.

--- a/examples/test_new_build_storage_cumulative_min_max/inputs/projects.tab
+++ b/examples/test_new_build_storage_cumulative_min_max/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw	charging_efficiency	discharging_efficiency	technology	minimum_duration_hours
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.	.	Nuclear	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6	.	.	Gas	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6	.	.	Gas	.
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6	.	.	Coal	.
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6	.	.	Gas	.
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.	Wind	.

--- a/examples/test_new_build_storage_cumulative_min_max/results/objective_function_value.txt
+++ b/examples/test_new_build_storage_cumulative_min_max/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 104166.48
+Objective function: 104184.54

--- a/examples/test_new_build_storage_cumulative_min_max/results/summary_results.txt
+++ b/examples/test_new_build_storage_cumulative_min_max/results/summary_results.txt
@@ -5,7 +5,7 @@
 --> New Storage Capacity <--
                              New Storage Power Capacity (MW)  New Storage Energy Capacity (MWh)
 load_zone technology period                                                                    
-Zone1     Storage    2020                                  5                                  7
+Zone1     Storage    2020                                  4                                  7
                      2030                                 10                                 15
 
 ### OPERATIONAL RESULTS ###
@@ -13,10 +13,10 @@ Zone1     Storage    2020                                  5                    
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          0              0
-                 Gas                          16             53
+Zone1     2020   Coal                          1              2
+                 Gas                          15             49
                  Nuclear                      12             40
-                 Storage                      -1             -2
+                 Storage                      -0             -1
                  Wind                          3              9
           2030   Coal                          0              0
                  Gas                          17             55

--- a/examples/test_new_solar/inputs/projects.tab
+++ b/examples/test_new_solar/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.

--- a/examples/test_new_solar/results/objective_function_value.txt
+++ b/examples/test_new_solar/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 62139.69
+Objective function: 866736555.01

--- a/examples/test_new_solar/results/summary_results.txt
+++ b/examples/test_new_solar/results/summary_results.txt
@@ -12,4 +12,4 @@ Zone1     unspecified 2020                    2
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/test_new_solar_carbon_cap/inputs/projects.tab
+++ b/examples/test_new_solar_carbon_cap/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw	carbon_cap_zone
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6	Zone1
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6	Zone1
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6	Zone1
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6	Zone1
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/test_new_solar_carbon_cap/results/objective_function_value.txt
+++ b/examples/test_new_solar_carbon_cap/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 271066535.59
+Objective function: 3286733066.41

--- a/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/inputs/projects.tab
+++ b/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw	carbon_cap_zone
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6	Zone1
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6	Zone1
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6	Zone1
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6	Zone1
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/results/objective_function_value.txt
+++ b/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 142694322.44
+Objective function: 3164472610.84

--- a/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/results/summary_results.txt
+++ b/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/results/summary_results.txt
@@ -12,5 +12,5 @@ Zone1     unspecified 2020                    2
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   28            100
-Zone2     2020   unspecified                   22            100
+Zone1     2020   unspecified                   30            100
+Zone2     2020   unspecified                   20            100

--- a/examples/test_new_solar_carbon_cap_2zones_tx/inputs/projects.tab
+++ b/examples/test_new_solar_carbon_cap_2zones_tx/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw	carbon_cap_zone
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6	Zone1
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6	Zone1
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6	Zone1
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6	Zone1
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/test_new_solar_carbon_cap_2zones_tx/results/objective_function_value.txt
+++ b/examples/test_new_solar_carbon_cap_2zones_tx/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 159168642.35
+Objective function: 3180162433.13

--- a/examples/test_new_solar_carbon_cap_2zones_tx/results/summary_results.txt
+++ b/examples/test_new_solar_carbon_cap_2zones_tx/results/summary_results.txt
@@ -12,5 +12,5 @@ Zone1     unspecified 2020                    2
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   28            100
-Zone2     2020   unspecified                   22            100
+Zone1     2020   unspecified                   30            100
+Zone2     2020   unspecified                   20            100

--- a/examples/test_no_reserves/inputs/projects.tab
+++ b/examples/test_no_reserves/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	Uranium	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	0	1	2	Gas	6
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	0.4	1	2	Gas	6
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	0.4	1	0	Coal	6
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	0.4	0	1	Gas	6
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.

--- a/examples/test_ramp_up_and_down_constraints/inputs/projects.tab
+++ b/examples/test_ramp_up_and_down_constraints/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw	startup_plus_ramp_up_rate	shutdown_plus_ramp_down_rate
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6	0.005	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6	0.005	.
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6	.	0.015
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6	.	.
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.

--- a/examples/test_ramp_up_and_down_constraints/results/objective_function_value.txt
+++ b/examples/test_ramp_up_and_down_constraints/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 68909.08
+Objective function: 1080081236.68

--- a/examples/test_ramp_up_and_down_constraints/results/summary_results.txt
+++ b/examples/test_ramp_up_and_down_constraints/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   33            100

--- a/examples/test_ramp_up_constraints/inputs/projects.tab
+++ b/examples/test_ramp_up_constraints/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw	startup_plus_ramp_up_rate
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6	0.005
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6	0.005
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6	.
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6	.
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.

--- a/examples/test_ramp_up_constraints/results/objective_function_value.txt
+++ b/examples/test_ramp_up_constraints/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 67414.48
+Objective function: 866737242.35

--- a/examples/test_ramp_up_constraints/results/summary_results.txt
+++ b/examples/test_ramp_up_constraints/results/summary_results.txt
@@ -7,4 +7,4 @@
 --> Energy Production <--
                               Annual Energy (MWh)  % Total Power
 load_zone period technology                                     
-Zone1     2020   unspecified                   30            100
+Zone1     2020   unspecified                   31            100

--- a/examples/test_variable_gen_reserves/inputs/projects.tab
+++ b/examples/test_variable_gen_reserves/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw	lf_reserves_up_derate	regulation_up_derate	lf_reserves_down_derate	regulation_down_derate
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.	.	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6	.	.	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6	.	.	.	.
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6	.	.	.	.
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6	.	.	.	.
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	Zone1	Zone1	Zone1	Zone1	.	.	.	.	.	0.5	0.5	0.5	0.5

--- a/examples/test_variable_gen_reserves/results/objective_function_value.txt
+++ b/examples/test_variable_gen_reserves/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 64754.81
+Objective function: 306735066.21

--- a/examples/test_w_hydro/inputs/projects.tab
+++ b/examples/test_w_hydro/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.

--- a/examples/test_w_storage/inputs/projects.tab
+++ b/examples/test_w_storage/inputs/projects.tab
@@ -1,6 +1,6 @@
 project	load_zone	capacity_type	variable_om_cost_per_mwh	operational_type	lf_reserves_up_ba	regulation_up_ba	lf_reserves_down_ba	regulation_down_ba	min_stable_level_fraction	startup_cost_per_mw	shutdown_cost_per_mw	fuel	unit_size_mw	charging_efficiency	discharging_efficiency
 Nuclear	Zone1	existing_gen_no_economic_retirement	1	must_run	.	.	.	.	.	.	.	Uranium	.	.	.
-Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0	1	2	Gas	6	.	.
+Gas_CCGT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	Zone1	Zone1	Zone1	Zone1	0.4	1	2	Gas	6	.	.
 Coal	Zone1	existing_gen_no_economic_retirement	1	dispatchable_capacity_commit	.	Zone1	.	Zone1	0.4	1	0	Coal	6	.	.
 Gas_CT	Zone1	existing_gen_no_economic_retirement	2	dispatchable_capacity_commit	.	.	.	.	0.4	0	1	Gas	6	.	.
 Wind	Zone1	existing_gen_no_economic_retirement	0	variable	.	.	.	.	.	.	.	.	.	.	.

--- a/examples/test_w_storage/results/objective_function_value.txt
+++ b/examples/test_w_storage/results/objective_function_value.txt
@@ -1,1 +1,1 @@
-Objective function: 53987.7
+Objective function: 54334.55

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -25,7 +25,7 @@ class TestExamples(unittest.TestCase):
                                "--scenario_location", "examples",
                                "--quiet", "--mute_solver_output", "--testing"])
 
-        expected_objective = 65508.41333333334
+        expected_objective = 866737242.3466034
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -40,7 +40,7 @@ class TestExamples(unittest.TestCase):
                                "--scenario_location", "examples",
                                "--quiet", "--mute_solver_output", "--testing"])
 
-        expected_objective = 102420.064
+        expected_objective = 102420.06359999996
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -57,7 +57,7 @@ class TestExamples(unittest.TestCase):
                                "--scenario_location", "examples",
                                "--quiet", "--mute_solver_output", "--testing"])
 
-        expected_objective = 104166.4775
+        expected_objective = 104184.53965
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -72,7 +72,7 @@ class TestExamples(unittest.TestCase):
                                "--scenario_location", "examples",
                                "--mute_solver_output", "--testing"])
 
-        expected_objective = 53381.74666666667
+        expected_objective = 53381.74655000001
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -87,7 +87,7 @@ class TestExamples(unittest.TestCase):
                                "--scenario_location", "examples",
                                "--mute_solver_output", "--testing"])
 
-        expected_objective = 49067.08
+        expected_objective = 49067.079900000004
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -102,7 +102,7 @@ class TestExamples(unittest.TestCase):
                                "--scenario_location", "examples",
                                "--mute_solver_output", "--testing"])
 
-        expected_objective = 53987.69666666667
+        expected_objective = 54334.546550000014
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -117,7 +117,7 @@ class TestExamples(unittest.TestCase):
                                "--scenario_location", "examples",
                                "--mute_solver_output", "--testing"])
 
-        expected_objective = 131016.826635704
+        expected_objective = 1733474484.6932068
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -132,41 +132,36 @@ class TestExamples(unittest.TestCase):
                                "--scenario_location", "examples",
                                "--mute_solver_output", "--testing"])
 
-        expected_objective = 1310168.26635704
+        expected_objective = 17334744846.932064
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
 
     def test_example_2periods_new_build(self):
         """
-        Check objective function value of "2periods_new_build" example;
-        this example requires a non-linear solver
-        :return:
+        Check objective function value of "2periods_new_build" example
         """
         actual_objective = \
             run_scenario.main(["--scenario", "2periods_new_build",
                                "--scenario_location", "examples",
-                               "--solver", "ipopt", "--quiet",
-                               "--mute_solver_output", "--testing"])
+                               "--quiet", "--mute_solver_output", "--testing"])
 
-        expected_objective = 110457853.08850166
+        expected_objective = 111439176.928
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
 
     def test_example_2periods_new_build_2zones(self):
         """
-        Check objective function value of "2periods_new_build_2zones" example;
-        this example requires a non-linear solver
+        Check objective function value of "2periods_new_build_2zones" example
         :return:
         """
         actual_objective = \
             run_scenario.main(["--scenario", "2periods_new_build_2zones",
                                "--scenario_location", "examples",
-                               "--solver", "ipopt", "--quiet",
-                               "--mute_solver_output", "--testing"])
+                               "--quiet", "--mute_solver_output", "--testing"])
 
-        expected_objective = 220915706.17696014
+        expected_objective = 222878353.856
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -194,7 +189,7 @@ class TestExamples(unittest.TestCase):
     def test_example_2periods_new_build_2zones_singleBA(self):
         """
         Check objective function value of "2periods_new_build_2zones_singleBA"
-        example; this example requires a non-linear solver
+        example
         :return:
         """
         actual_objective = \
@@ -202,11 +197,10 @@ class TestExamples(unittest.TestCase):
                 ["--scenario",
                  "2periods_new_build_2zones_singleBA",
                  "--scenario_location", "examples",
-                 "--solver", "ipopt", "--quiet",
-                 "--mute_solver_output", "--testing"]
+                 "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 220874494.66702762
+        expected_objective = 222878353.857
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -232,8 +226,7 @@ class TestExamples(unittest.TestCase):
 
     def test_example_2periods_new_build_rps(self):
         """
-        Check objective function value of "2periods_new_build_rps" example;
-        this example requires a non-linear solver
+        Check objective function value of "2periods_new_build_rps" example
         :return:
         """
         actual_objective = \
@@ -241,11 +234,10 @@ class TestExamples(unittest.TestCase):
                 ["--scenario",
                  "2periods_new_build_rps",
                  "--scenario_location", "examples",
-                 "--solver", "ipopt", "--quiet",
-                 "--mute_solver_output", "--testing"]
+                 "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 972819424.030913
+        expected_objective = 972692908.1319999
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -253,18 +245,16 @@ class TestExamples(unittest.TestCase):
     def test_example_2periods_new_build_cumulative_min_max(self):
         """
         Check objective function value of
-        "2periods_new_build_cumulative_min_max" example;
-        this example requires a non-linear solver
+        "2periods_new_build_cumulative_min_max" example
         :return:
         """
         actual_objective = \
             run_scenario.main(["--scenario",
                                "2periods_new_build_cumulative_min_max",
                                "--scenario_location", "examples",
-                               "--solver", "ipopt", "--quiet",
-                               "--mute_solver_output", "--testing"])
+                               "--quiet", "--mute_solver_output", "--testing"])
 
-        expected_objective = 6295830632.2028
+        expected_objective = 6296548240.926001
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -280,9 +270,9 @@ class TestExamples(unittest.TestCase):
                                "--quiet", "--mute_solver_output", "--testing"])
 
         expected_objectives = {
-            1: 65508.413317852006,
-            2: 65508.413317852006,
-            3: 65508.413317852006
+            1: 866737242.3466034,
+            2: 866737242.3466034,
+            3: 866737242.3466034
         }
 
         for horizon in [1, 2, 3]:
@@ -303,15 +293,15 @@ class TestExamples(unittest.TestCase):
                                "--quiet", "--mute_solver_output", "--testing"])
 
         expected_objectives = {
-            1: {"da": 65508.41333333334,
-                "ha": 65508.41333333334,
-                "rt": 65508.41333333334},
-            2: {"da": 65508.41333333334,
-                "ha": 65508.41333333334,
-                "rt": 65508.41333333334},
-            3: {"da": 65508.41333333334,
-                "ha": 65508.41333333334,
-                "rt": 65508.41333333334}
+            1: {"da": 866737242.3466433,
+                "ha": 866737242.3466433,
+                "rt": 866737242.3466433},
+            2: {"da": 866737242.3466433,
+                "ha": 866737242.3466433,
+                "rt": 866737242.3466433},
+            3: {"da": 866737242.3466433,
+                "ha": 866737242.3466433,
+                "rt": 866737242.3466433}
         }
 
         for horizon in [1, 2, 3]:
@@ -334,15 +324,15 @@ class TestExamples(unittest.TestCase):
                                "--quiet", "--mute_solver_output", "--testing"])
 
         expected_objectives = {
-            1: {"da": 60564.524391700004,
-                "ha": 60564.524391700004,
-                "rt": 60564.524391700004},
-            2: {"da": 60564.524391700004,
-                "ha": 60564.524391700004,
-                "rt": 60564.524391700004},
-            3: {"da": 60564.524391700004,
-                "ha": 60564.524391700004,
-                "rt": 60564.524391700004}
+            1: {"da": 966735355.3466533,
+                "ha": 966735355.3466533,
+                "rt": 966735355.3466533},
+            2: {"da": 966735355.3466533,
+                "ha": 966735355.3466533,
+                "rt": 966735355.3466533},
+            3: {"da": 966735355.3466533,
+                "ha": 966735355.3466533,
+                "rt": 966735355.3466533}
         }
 
         for horizon in [1, 2, 3]:
@@ -364,11 +354,10 @@ class TestExamples(unittest.TestCase):
                 ["--scenario",
                  "2periods_gen_lin_econ_retirement",
                  "--scenario_location", "examples",
-                 "--quiet",
-                 "--mute_solver_output", "--testing"]
+                 "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 1276508.2612077533
+        expected_objective = 17334744846.932064
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -384,11 +373,10 @@ class TestExamples(unittest.TestCase):
                 ["--scenario",
                  "2periods_gen_bin_econ_retirement",
                  "--scenario_location", "examples",
-                 "--quiet",
-                 "--mute_solver_output", "--testing"]
+                 "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 1310168.26635704
+        expected_objective = 17334744846.932064
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -404,11 +392,10 @@ class TestExamples(unittest.TestCase):
                 ["--scenario",
                  "test_variable_gen_reserves",
                  "--scenario_location", "examples",
-                 "--solver", "ipopt", "--quiet",
-                 "--mute_solver_output", "--testing"]
+                 "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 64754.81343815058
+        expected_objective = 306735066.21341676
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -416,8 +403,7 @@ class TestExamples(unittest.TestCase):
     def test_example_2periods_new_build_rps_variable_reserves(self):
         """
         Check objective function value of
-        "2periods_new_build_rps_variable_reserves" example; this example
-        requires a non-linear solver
+        "2periods_new_build_rps_variable_reserves" example
         :return:
         """
         actual_objective = \
@@ -425,11 +411,10 @@ class TestExamples(unittest.TestCase):
                 ["--scenario",
                  "2periods_new_build_rps_variable_reserves",
                  "--scenario_location", "examples",
-                 "--solver", "ipopt", "--quiet",
-                 "--mute_solver_output", "--testing"]
+                 "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 845688188.8876854
+        expected_objective = 844029554.4855622
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -438,8 +423,7 @@ class TestExamples(unittest.TestCase):
             self):
         """
         Check objective function value of
-        "2periods_new_build_rps_variable_reserves_subhourly_adj" example;
-        this example requires a non-linear solver
+        "2periods_new_build_rps_variable_reserves_subhourly_adj" example
         :return:
         """
         actual_objective = \
@@ -447,11 +431,10 @@ class TestExamples(unittest.TestCase):
                 ["--scenario",
                  "2periods_new_build_rps_variable_reserves_subhourly_adj",
                  "--scenario_location", "examples",
-                 "--solver", "ipopt", "--quiet",
-                 "--mute_solver_output", "--testing"]
+                 "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 846576209.4197431
+        expected_objective = 845462123.9605286
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -466,11 +449,10 @@ class TestExamples(unittest.TestCase):
                 ["--scenario",
                  "test_ramp_up_constraints",
                  "--scenario_location", "examples",
-                 "--quiet",
-                 "--mute_solver_output", "--testing"]
+                 "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 67414.48
+        expected_objective = 866737242.3466034
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -486,11 +468,10 @@ class TestExamples(unittest.TestCase):
                 ["--scenario",
                  "test_ramp_up_and_down_constraints",
                  "--scenario_location", "examples",
-                 "--quiet",
-                 "--mute_solver_output", "--testing"]
+                 "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 68909.08
+        expected_objective = 1080081236.67995
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -509,7 +490,7 @@ class TestExamples(unittest.TestCase):
                  "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 940358688.2807122
+        expected_objective = 940358688.2807117
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -528,7 +509,7 @@ class TestExamples(unittest.TestCase):
                  "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 944988974.7999973
+        expected_objective = 944988974.7999967
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -546,7 +527,7 @@ class TestExamples(unittest.TestCase):
                  "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 62139.69105836666
+        expected_objective = 866736555.0133034
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -564,7 +545,7 @@ class TestExamples(unittest.TestCase):
                  "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 271066535.5942914
+        expected_objective = 3286733066.412322
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -583,7 +564,7 @@ class TestExamples(unittest.TestCase):
                  "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 159168642.34751052
+        expected_objective = 3180162433.1252494
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -602,7 +583,7 @@ class TestExamples(unittest.TestCase):
                  "--quiet", "--mute_solver_output", "--testing"]
             )
 
-        expected_objective = 142694322.44447643
+        expected_objective = 3164472610.8364196
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=1)
@@ -610,16 +591,15 @@ class TestExamples(unittest.TestCase):
     def test_example_2periods_new_build_simple_prm(self):
         """
         Check objective function value of "2periods_new_build_simple_prm" 
-        example; this example requires a non-linear solver
+        example
         :return:
         """
         actual_objective = \
             run_scenario.main(["--scenario", "2periods_new_build_simple_prm",
                                "--scenario_location", "examples",
-                               "--solver", "ipopt", "--quiet",
-                               "--mute_solver_output", "--testing"])
+                               "--quiet", "--mute_solver_output", "--testing"])
 
-        expected_objective = 197097539.08647087
+        expected_objective = 198677529.596
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)
@@ -627,17 +607,16 @@ class TestExamples(unittest.TestCase):
     def test_example_2periods_new_build_local_capacity(self):
         """
         Check objective function value of "2periods_new_build_local_capacity"
-        example; this example requires a non-linear solver
+        example
         :return:
         """
         actual_objective = \
             run_scenario.main(["--scenario",
                                "2periods_new_build_local_capacity",
                                "--scenario_location", "examples",
-                               "--solver", "ipopt", "--quiet",
-                               "--mute_solver_output", "--testing"])
+                               "--quiet", "--mute_solver_output", "--testing"])
 
-        expected_objective = 113881853.08932793
+        expected_objective = 114863176.928
 
         self.assertAlmostEqual(expected_objective, actual_objective,
                                places=0)


### PR DESCRIPTION
The current test examples have a few problems:
- Some of the test cases combined continuous commit operational types with new build capacity types, which is not an intended use case, and creates a non-linear problem. 
- Some operational types are not covered in any of the test examples. 
- The production cost test examples include capacity_commit types which aren't intended to be used in production cost modeling 
- The ramping test cases only test startup ramps

This PR will:
- change the operational type of any new build thermal generator to the capacity_commit type
- modify one example test such that it includes an always_on operational type
- modify one example test such that it includes a binary_commit operational type
- modify one example test such that it includes a no_commit operational type
- remove capacity_commit operational type from the production cost examples.  
- add "ramp_when_on" inputs to the ramp example tests

Note that this PR will linearize all example problem and remove the ipopt solver dependency of the test examples. 