### PR TITLE
change tolerance of infeasibility warnings

### DIFF
--- a/run_scenario.py
+++ b/run_scenario.py
@@ -529,7 +529,7 @@ def solve(instance, parsed_arguments):
         symbolic_solver_labels=parsed_arguments.symbolic
     )
 
-    log_infeasible_constraints(instance)
+    log_infeasible_constraints(instance, tol=1E-3)
 
 
 def create_logs_directory_if_not_exists(scenario_directory, subproblem, stage):


### PR DESCRIPTION
The default setting to warn users for infeasible constraints is 1E-6
which resulted in a lot of false-positive warnings about infeasible
constraints for the test examples. The difference between the
constraint's body and its bound would be e.g. 1.999E-6, which is not
an actual infeasibility but a rounding issue.

This commit changes the feasibility tolerance to 1E-3, which removes the
false positive warnings from the test examples.