### PR TITLE
fix errors and code style in run_start_to_end.py

### DIFF
--- a/run_start_to_end.py
+++ b/run_start_to_end.py
@@ -114,16 +114,16 @@ def main(args):
         get_scenario_inputs.main(args=args)
     except Exception:
         update_run_status(parsed_args.scenario, 3)
-        print('Error encountered when getting inputs from the database for '
-              'scenario {}.'.format(args.scenario))
+        print("Error encountered when getting inputs from the database for "
+              "scenario {}.".format(parsed_args.scenario))
         traceback.print_exc()
         sys.exit(1)
     try:
         run_scenario.main(args=args)
     except Exception:
         update_run_status(parsed_args.scenario, 3)
-        print('Error encountered when running scenario {}.'.format(
-            args.scenario))
+        print("Error encountered when running scenario {}.".format(
+            parsed_args.scenario))
         traceback.print_exc()
         sys.exit(1)
 
@@ -131,8 +131,8 @@ def main(args):
         import_scenario_results.main(args=args)
     except Exception:
         update_run_status(args.scenario, 3)
-        print('Error encountered when importing results for '
-              'scenario {}.'.format(parsed_args.scenario))
+        print("Error encountered when importing results for "
+              "scenario {}.".format(parsed_args.scenario))
         traceback.print_exc()
         sys.exit(1)
 


### PR DESCRIPTION
Fixing a a small error and a styling inconsistency in run_start_to_end.py:
 - use parsed_args ArgumentParser object rather than the raw user input args
 - use double quotes (") rather than single quotes (') for printed strings