### PR TITLE
Fix determine modules in import scenario results

### DIFF
--- a/import_scenario_results.py
+++ b/import_scenario_results.py
@@ -132,7 +132,7 @@ def main(args=None):
             raise AssertionError("ERROR: saved scenario_id does not match")
 
     # Go through modules
-    modules_to_use = determine_modules(scenario_directory)
+    modules_to_use = determine_modules(scenario_directory=scenario_directory)
     loaded_modules = load_modules(modules_to_use)
 
     # Import appropriate results into database


### PR DESCRIPTION
The determine module function changed and the first keyword argument
is now feature_list, not scenario_directory. So to determine the
module based on the scenario_directory, we need to specify the
scenario_directory keyword (feature_list will default to None).