### PR TITLE
Read DataFrame and columns into one step

### DIFF
--- a/gridpath/project/__init__.py
+++ b/gridpath/project/__init__.py
@@ -237,10 +237,14 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     c = conn.cursor()
     validation_results = []
 
-    # Read in the project input data into a dataframe
+    # Get the project inputs
     projects = get_inputs_from_database(subscenarios, subproblem, stage, conn)
-    df = pd.DataFrame(projects.fetchall())
-    df.columns = [s[0] for s in projects.description]
+
+    # Convert input data into pandas DataFrame
+    df = pd.DataFrame(
+        data=projects.fetchall(),
+        columns=[s[0] for s in projects.description]
+    )
 
     # Check data types:
     expected_dtypes = {

--- a/gridpath/project/fuels.py
+++ b/gridpath/project/fuels.py
@@ -140,12 +140,18 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     ).fetchall()
 
     # Convert input data into pandas DataFrame
-    fuels_df = pd.DataFrame(fuels.fetchall())
-    fuels_df.columns = [s[0] for s in fuels.description]
-    fuel_prices_df = pd.DataFrame(fuel_prices.fetchall())
-    fuel_prices_df.columns = [s[0] for s in fuel_prices.description]
-    prj_df = pd.DataFrame(projects.fetchall())
-    prj_df.columns = [s[0] for s in projects.description]
+    fuels_df = pd.DataFrame(
+        data=fuels.fetchall(),
+        columns=[s[0] for s in fuels.description]
+    )
+    fuel_prices_df = pd.DataFrame(
+        data=fuel_prices.fetchall(),
+        columns = [s[0] for s in fuel_prices.description]
+    )
+    prj_df = pd.DataFrame(
+        data=projects.fetchall(),
+        columns=[s[0] for s in projects.description]
+    )
 
     # Check data types fuels:
     expected_dtypes = {


### PR DESCRIPTION
Context: we read in inputs into dataframes by first executing a cursor
query and then converting the query results into a DataFrame in 2 steps:
1. create the DataFrame from the raw query results (fetchall)
2. set the columns to the query result column values (description)

This 2 step approach would throw an error when trying to set columns
to an empty dataframe. With this update, an empty query will still
create a dataframe with the proper columns, but it will simply have no
entries. This makes validating the inputs much easier (no need to check
with a bunch of if statements).

This update also fixes how to deal when there's no availability
subscenario specified.