### PR TITLE
Add validation for must_run and variable_no_curt

### DIFF
--- a/gridpath/auxiliary/auxiliary.py
+++ b/gridpath/auxiliary/auxiliary.py
@@ -481,3 +481,65 @@ def check_constant_heat_rate(df, op_type):
         )
 
     return results
+
+
+def check_projects_for_reserves(projects, operational_type, subscenarios, conn):
+    """
+    Check that a list of projects of a given operational_type does not show up
+    in any of the inputs_project_reserve_bas tables since the operational type
+    can't provide any reserves (e.g. must_run).
+    :param operational_type:
+    :param projects:
+    :param subscenarios:
+    :param conn:
+    :return:
+    """
+    validation_results = []
+
+    reserves = ["frequency_response", "spinning_reserves",
+                "lf_reserves_down", "lf_reserves_up",
+                "regulation_up", "regulation_down"]
+    for reserve in reserves:
+        # Get set of projects with a reserve BA specified and set of must_run
+        table = "inputs_project_" + reserve + "_bas"
+        ba_column = reserve + "_ba"
+        ba_id = reserve + "_ba_scenario_id"
+        project_ba_id = "project_" + reserve + "_ba_scenario_id"
+
+        # If the subscenario_ids are specified, do the input validation
+        if getattr(subscenarios, ba_id.upper()) and \
+                getattr(subscenarios, project_ba_id.upper()):
+            c = conn.cursor()
+            prjs_w_ba = c.execute(
+                """SELECT project
+                FROM {}
+                WHERE {} IS NOT NULL
+                AND {} = {}
+                AND {} = {}
+                """.format(
+                    table,
+                    ba_column,
+                    ba_id, getattr(subscenarios, ba_id.upper()),
+                    project_ba_id, getattr(subscenarios, project_ba_id.upper())
+                )
+            )
+            prjs_w_ba = set([p[0] for p in prjs_w_ba.fetchall()])
+            must_run_projects = set(projects)
+
+            # If there are any projects with a reserve BA specified,
+            # create a validation error
+            bad_projects = prjs_w_ba & must_run_projects  # intersection of sets
+            if bad_projects:
+                print_bad_projects = ", ".join(bad_projects)
+                validation_results.append(
+                    (subscenarios.SCENARIO_ID,
+                     __name__,
+                     project_ba_id.upper(),
+                     table,
+                     "Invalid {} BA inputs".format(reserve),
+                     "Project(s) '{}'; {} cannot provide {}".format(
+                         print_bad_projects, operational_type, reserve)
+                     )
+                )
+
+    return validation_results


### PR DESCRIPTION
Make sure that there are no reserve BAs specified for these resources
since they cannot provide reserves.

Note: this validation is skipped for reserves for which
there is no reserve scenario ID specified.