### PR TITLE
Add cost by period plot

### DIFF
--- a/viz/cost_plot.py
+++ b/viz/cost_plot.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python
+# Copyright 2017 Blue Marble Analytics LLC. All rights reserved.
+
+"""
+Make plot of costs
+"""
+
+from argparse import ArgumentParser
+from bokeh.models import ColumnDataSource, Legend, NumeralTickFormatter
+from bokeh.plotting import figure, output_file, show
+from bokeh.models.tools import HoverTool
+from bokeh.embed import json_item
+from bokeh.palettes import cividis
+
+import pandas as pd
+import os
+import sys
+
+# GridPath modules
+from viz.common_functions import connect_to_database, show_hide_legend
+
+
+def parse_arguments(arguments):
+    """
+
+    :return:
+    """
+    parser = ArgumentParser(add_help=True)
+
+    # Scenario name and location options
+    parser.add_argument("--database",
+                        help="The database file path. Defaults to ../db/io.db "
+                             "if not specified")
+    parser.add_argument("--scenario_id", help="The scenario ID. Required if "
+                                              "no --scenario is specified.")
+    parser.add_argument("--scenario", help="The scenario name. Required if "
+                                           "no --scenario_id is specified.")
+    parser.add_argument("--load_zone", help="The name of the load zone.")
+    parser.add_argument("--stage", default=1,
+                        help="The stage ID. Defaults to 1 if not specified.")
+    parser.add_argument("--show",
+                        default=False, action="store_true",
+                        help="Show and save figure to "
+                             "results/figures directory "
+                             "under scenario directory.")
+    parser.add_argument("--return_json",
+                        default=False, action="store_true",
+                        help="Return plot as a json file."
+                        )
+    # Parse arguments
+    parsed_arguments = parser.parse_known_args(args=arguments)[0]
+
+    return parsed_arguments
+
+
+def create_data_df(c, scenario_id, load_zone, stage):
+    """
+    Get costs results and put them into a df
+    :param c:
+    :param scenario_id:
+    :param load_zone:
+    :param stage:
+    :return:
+    """
+
+    # TODO: move this into a view that keeps all scenarios and periods
+    #   and then select from it? (but full table takes 19s to load, whereas
+    #   a slice is much faster!) Perhaps we can move each cost by scen/period
+    #   into a view, but that won't make things faster, just shorter queries?
+    # TODO: will this work when there are no capacity cost (left join would
+    #   start with empty capacity table
+    # TODO: what hurdle rates should we include? load_zone_to, load_zone_from
+    #   or both?
+
+    # System costs by scenario and period -- by source and total
+    sql = """SELECT period,
+        capacity_cost/1000000 as Capacity_Additions,
+        fuel_cost/1000000 as Fuel,
+        variable_om_cost/1000000 as Variable_OM,
+        startup_cost/1000000 as Startups,
+        shutdown_cost/1000000 as Shutdowns,
+        hurdle_cost/1000000 as Hurdle_Rates
+        
+        FROM
+        
+        (SELECT scenario_id, period, sum(annualized_capacity_cost) 
+        AS capacity_cost
+        FROM  results_project_costs_capacity
+        WHERE scenario_id = ?
+        AND stage_id = ?
+        AND load_zone = ?
+        GROUP BY scenario_id, period) AS cap_costs
+        
+        LEFT JOIN
+        
+        (SELECT scenario_id, period, 
+        sum(fuel_cost * horizon_weight * number_of_hours_in_timepoint) 
+        AS fuel_cost
+        FROM results_project_costs_operations_fuel
+        WHERE scenario_id = ?
+        AND stage_id = ?
+        AND load_zone = ?
+        GROUP BY scenario_id, period) AS fuel_costs
+        USING (scenario_id, period)
+        
+        LEFT JOIN
+        
+        (SELECT scenario_id, period, 
+        sum(variable_om_cost * horizon_weight * number_of_hours_in_timepoint) 
+        AS variable_om_cost
+        FROM results_project_costs_operations_variable_om
+        WHERE scenario_id = ?
+        AND stage_id = ?
+        AND load_zone = ?
+        GROUP BY scenario_id, period) AS variable_om_costs
+        USING (scenario_id, period)
+        
+        LEFT JOIN
+        
+        (SELECT scenario_id, period, 
+        sum(startup_cost * horizon_weight) AS startup_cost
+        FROM results_project_costs_operations_startup
+        WHERE scenario_id = ?
+        AND stage_id = ?
+        AND load_zone = ?
+        GROUP BY scenario_id, period) AS startup_costs
+        USING (scenario_id, period)
+        
+        LEFT JOIN
+        
+        (SELECT scenario_id, period, 
+        sum(shutdown_cost * horizon_weight) AS shutdown_cost
+        FROM results_project_costs_operations_shutdown
+        WHERE scenario_id = ?
+        AND stage_id = ?
+        AND load_zone = ?
+        GROUP BY scenario_id, period) AS shutdown_costs
+        USING (scenario_id, period)
+        
+        LEFT JOIN
+        
+        (SELECT scenario_id, period, 
+        sum((hurdle_cost_positive_direction + hurdle_cost_negative_direction) * 
+        horizon_weight * number_of_hours_in_timepoint) AS hurdle_cost
+        FROM
+        results_transmission_hurdle_costs
+        WHERE scenario_id = ?
+        AND stage_id = ?
+        AND load_zone_to = ?
+        GROUP BY scenario_id, period) AS hurdle_costs
+        USING (scenario_id, period)
+        ;"""
+
+    costs = c.execute(sql, (scenario_id, stage, load_zone,
+                            scenario_id, stage, load_zone,
+                            scenario_id, stage, load_zone,
+                            scenario_id, stage, load_zone,
+                            scenario_id, stage, load_zone,
+                            scenario_id, stage, load_zone)
+                      )
+
+    df = pd.DataFrame(
+        data=costs.fetchall(),
+        columns=[n[0] for n in costs.description]
+    )
+
+    # Set index to period and change index type from int to string
+    # (required for categorical bar chart)
+    df.set_index("period", inplace=True)
+    df.index = df.index.map(str)
+
+    return df
+
+
+def create_plot(df, load_zone, stage):
+    """
+
+    :param df:
+    :param load_zone:
+    :param stage:
+    :return:
+    """
+    # TODO: handle empty dataframe (will give bokeh warning)
+
+    # For Testing:
+    # df = pd.DataFrame(
+    #     index=["2018", "2020"],
+    #     data=[[0, 3000, 500, 1500],
+    #           [0, 6000, 4500, 2300]],
+    #     columns=["Biomass", "Hydro", "Solar", "Wind"]
+    # )
+    # df.index.name = "period"
+
+    # Set up data source
+    source = ColumnDataSource(data=df)
+
+    # Determine column types for plotting, legend and colors
+    # Order of stacked_cols will define order of stacked areas in chart
+    stacked_cols = list(df.columns)
+
+    # Stacked Area Colors
+    colors = cividis(len(stacked_cols))
+
+    # Set title
+    title = "Total Cost by Period - {} - stage {}".format(load_zone, stage)
+    
+    # Set up the figure
+    plot = figure(
+        plot_width=800, plot_height=500,
+        tools=["pan", "reset", "zoom_in", "zoom_out", "save", "help"],
+        title=title,
+        x_range=df.index.values
+        # sizing_mode="scale_both"
+    )
+
+    # Add stacked area chart to plot
+    area_renderers = plot.vbar_stack(
+        stackers=stacked_cols,
+        x="period",
+        source=source,
+        color=colors,
+        width=0.5,
+    )
+
+    # Keep track of legend items
+    legend_items = [(y, [area_renderers[i]]) for i, y in enumerate(stacked_cols)
+                    if df[y].mean() > 0]
+
+    # Add Legend
+    legend = Legend(items=legend_items)
+    plot.add_layout(legend, 'right')
+    plot.legend[0].items.reverse()  # Reverse legend to match stacked order
+    plot.legend.click_policy = 'hide'  # Add interactivity to the legend
+    # Note: Doesn't rescale the graph down, simply hides the area
+    # Note2: There's currently no way to auto-size legend based on graph size(?)
+    # except for maybe changing font size automatically?
+
+    # Add axis labels
+    plot.xaxis.axis_label = "Period"
+    plot.yaxis.axis_label = "Cost ($MM)"
+
+    # Format y- axis numbers
+    plot.yaxis.formatter = NumeralTickFormatter(format="$0,0")
+
+    # Add HoverTools for stacked bars/areas
+    for r in area_renderers:
+        category = r.name
+        hover = HoverTool(
+            tooltips=[
+                ("Period", "@period"),
+                ("Cost Category", category),
+                ("Cost", "@%s{$0,0} MM" % category)
+            ],
+            renderers=[r],
+            toggleable=False)
+        plot.add_tools(hover)
+
+    return plot
+
+
+def draw_cost_plot(c, scenario_id, load_zone, stage):
+    """
+
+    :param c:
+    :param scenario_id:
+    :param load_zone:
+    :param stage:
+    :return:
+    """
+    df = create_data_df(c, scenario_id, load_zone, stage)
+    plot = create_plot(df, load_zone, stage)
+
+    # Extras
+    show_hide_legend(plot=plot)
+
+    return plot
+
+
+def main(args=None):
+    """
+    :return: if requested, return the plot as JSON object
+
+    Parse the arguments and create the dispatch plot
+    """
+    if args is None:
+        args = sys.argv[1:]
+    parsed_args = parse_arguments(arguments=args)
+
+    db = connect_to_database(parsed_arguments=parsed_args)
+    c = db.cursor()
+
+    load_zone = parsed_args.load_zone
+    stage = parsed_args.stage
+    if parsed_args.scenario_id is None:
+        scenario = parsed_args.scenario
+        # Get the scenario ID
+        scenario_id = c.execute(
+            """SELECT scenario_id
+            FROM scenarios
+            WHERE scenario_name = '{}';""".format(parsed_args.scenario)
+        ).fetchone()[0]
+    else:
+        scenario_id = parsed_args.scenario_id
+        # Get the scenario name
+        scenario = c.execute(
+            """SELECT scenario_name
+            FROM scenarios
+            WHERE scenario_id = {};""".format(parsed_args.scenario_id)
+        ).fetchone()[0]
+
+    plot = draw_cost_plot(
+        c=c,
+        scenario_id=scenario_id,
+        load_zone=load_zone,
+        stage=stage
+    )
+
+    plot_name = "CostPlot-{}-{}".format(load_zone, stage)
+
+    # Show plot in HTML browser file if requested
+    if parsed_args.show:
+        figures_directory = os.path.join(
+            os.getcwd(), "..", "scenarios", scenario, "results",
+            "figures"
+        )
+        if not os.path.exists(figures_directory):
+            os.makedirs(figures_directory)
+        filename = plot_name + ".html"
+        output_file(os.path.join(figures_directory, filename))
+        show(plot)
+
+    # Return plot in json format if requested
+    if parsed_args.return_json:
+        return json_item(
+            plot,
+            plot_name
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add cost by period plot
    
This plots the cost by period for a select scenario/zone/stage, broken
out by the different cost categories.
    
The stage defaults to 1 which should be the default if you're not
modeling multiple stages.
    
Except for the capacity cost, the cost is calculated by multiplying each
projects's cost in each timepoint by that timepoint's
number_of_hours_in_timepoint and that timepoint's corresponding
horizon's horizon_weight, and aggregating it by technology and period.
This is done for each cost category. For startup and shutdown costs, we
don't weigh by the timepoint duration since the costs do not scale with
the duration.
    
We assume that the timepoints within each period have horizon_weights
and timepoint durations that sum up to a logical number that is the
same for each period (generally 8760 if periods are 1 year). The input
validation should warn the user if that is not the case.
    
Notes:
 - We need to figure out how to allocate hurdle rate costs to zones
 - We need to think about how to deal with performance issues
    if we were to compare multiple scenarios as well (not slicing for
    scenario results in queries taking ~20s).
 - More generally, we need to think about how to deal with the other
    dimensions. Sometimes we might want to compare costs/energy/capacity
    across scenarios for a given period/zone, or across zones for a given
    period/scenario. There might be a way to generalize this so we don't
    have to write 3 different plot functions for that. The general case
    is that you have a result that is indexed by 3 things, so you want
    to keep 2 things fixed while varying the last one.

