### PR TITLE
Fix issue 119 - subscenario ID validation cleanup

### DIFF
--- a/db/create_database.py
+++ b/db/create_database.py
@@ -83,7 +83,123 @@ def load_data(db, omit_data):
     if not omit_data:
         c = db.cursor()
 
+        # General Model Data
+
+        # mod_months
+        with open(os.path.join(os.getcwd(), "data",
+                               "mod_months.csv"),
+                  "r") as f:
+            reader = csv.reader(f, delimiter=",")
+            next(reader)
+            for row in reader:
+                c.execute(
+                    """INSERT INTO mod_months
+                    (month, description)
+                    VALUES ({}, '{}');""".format(row[0], row[1])
+                )
+            db.commit()
+
+        # mod_capacity_types
+        with open(os.path.join(os.getcwd(), "data",
+                               "mod_capacity_types.csv"),
+                  "r") as f:
+            reader = csv.reader(f, delimiter=",")
+            next(reader)
+            for row in reader:
+                c.execute(
+                    """INSERT INTO mod_capacity_types
+                    (capacity_type, description)
+                    VALUES ('{}', '{}');""".format(row[0], row[1])
+                )
+            db.commit()
+
+        # mod_operational_types
+        with open(os.path.join(os.getcwd(), "data",
+                               "mod_operational_types.csv"),
+                  "r") as f:
+            reader = csv.reader(f, delimiter=",")
+            next(reader)
+            for row in reader:
+                c.execute(
+                    """INSERT INTO mod_operational_types
+                    (operational_type, description)
+                    VALUES ('{}', '{}');""".format(row[0], row[1])
+                )
+            db.commit()
+
+        # mod_horizon_boundary_types
+        with open(os.path.join(os.getcwd(), "data",
+                               "mod_horizon_boundary_types.csv"),
+                  "r") as f:
+            reader = csv.reader(f, delimiter=",")
+            next(reader)
+            for row in reader:
+                c.execute(
+                    """INSERT INTO mod_horizon_boundary_types
+                    (horizon_boundary_type, description)
+                    VALUES ('{}', '{}');""".format(row[0], row[1])
+                )
+            db.commit()
+
+        # mod_run_status_types
+        with open(os.path.join(os.getcwd(), "data",
+                               "mod_run_status_types.csv"),
+                  "r") as f:
+            reader = csv.reader(f, delimiter=",")
+            next(reader)
+            for row in reader:
+                c.execute(
+                    """INSERT INTO mod_run_status_types
+                    (run_status_id, run_status_name)
+                    VALUES ({}, '{}');""".format(row[0], row[1])
+                )
+            db.commit()
+
+        # mod_validation_status_types
+        with open(os.path.join(os.getcwd(), "data",
+                               "mod_validation_status_types.csv"),
+                  "r") as f:
+            reader = csv.reader(f, delimiter=",")
+            next(reader)
+            for row in reader:
+                c.execute(
+                    """INSERT INTO mod_validation_status_types
+                    (validation_status_id, validation_status_name)
+                    VALUES ({}, '{}');""".format(row[0], row[1])
+                )
+            db.commit()
+
+        # mod_features
+        with open(os.path.join(os.getcwd(), "data",
+                               "mod_features.csv"),
+                  "r") as f:
+            reader = csv.reader(f, delimiter=",")
+            next(reader)
+            for row in reader:
+                c.execute(
+                    """INSERT INTO mod_features
+                    (feature, description)
+                    VALUES ('{}', '{}');""".format(row[0], row[1])
+                )
+            db.commit()
+
+        # mod_feature_subscenarios
+        with open(os.path.join(os.getcwd(), "data",
+                               "mod_feature_subscenarios.csv"),
+                  "r") as f:
+            reader = csv.reader(f, delimiter=",")
+            next(reader)
+            for row in reader:
+                c.execute(
+                    """INSERT INTO mod_feature_subscenarios
+                    (feature, subscenario_id)
+                    VALUES ('{}', '{}');""".format(row[0], row[1])
+                )
+            db.commit()
+
         # Data required for the UI
+
+        # ui_scenario_detail_table_metadata
         with open(os.path.join(os.getcwd(), "data",
                                "ui_scenario_detail_table_metadata.csv"),
                   "r") as f:
@@ -97,6 +213,7 @@ def load_data(db, omit_data):
                 )
             db.commit()
 
+        # ui_scenario_detail_table_row_metadata
         with open(os.path.join(os.getcwd(), "data",
                                "ui_scenario_detail_table_row_metadata.csv"),
                   "r") as f:

--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -13,28 +13,12 @@ horizon_boundary_type VARCHAR(16) PRIMARY KEY,
 description VARCHAR(128)
 );
 
--- TODO: add descriptions
-INSERT INTO mod_horizon_boundary_types (horizon_boundary_type, description)
-VALUES
-('circular',
-'Last horizon timepoint is previous timepoint for first horizon timepoint'),
-('linear',
-'No previous timepoint for first horizon timepoint');
-
 -- Implemented capacity types
 DROP TABLE IF EXISTS mod_capacity_types;
 CREATE TABLE mod_capacity_types (
 capacity_type VARCHAR(32) PRIMARY KEY,
 description VARCHAR(128)
 );
-
--- TODO: add descriptions
-INSERT INTO mod_capacity_types (capacity_type)
-VALUES ('existing_gen_linear_economic_retirement'),
-('existing_gen_binary_economic_retirement'),
-('existing_gen_no_economic_retirement'), ('new_build_generator'),
-('new_build_storage'), ('new_shiftable_load_supply_curve'),
-('storage_specified_no_economic_retirement');
 
 -- Implemented operational types
 DROP TABLE IF EXISTS mod_operational_types;
@@ -43,29 +27,12 @@ operational_type VARCHAR(32) PRIMARY KEY,
 description VARCHAR(128)
 );
 
-INSERT INTO mod_operational_types (operational_type)
-VALUES ('dispatchable_binary_commit'), ('dispatchable_capacity_commit'),
-('dispatchable_continuous_commit'), ('dispatchable_no_commit'),
-('hydro_curtailable'), ('hydro_noncurtailable'), ('must_run'),
-('storage_generic'), ('variable'), ('variable_no_curtailment'), ('always_on');
-
 -- Features
 DROP TABLE IF EXISTS mod_features;
 CREATE TABLE mod_features (
 feature VARCHAR(32) PRIMARY KEY,
 description VARCHAR(128)
 );
-
--- TODO: add descriptions
-INSERT INTO mod_features (feature)
-VALUES ('core'), ('data_dependent'), ('optional'),
-('fuels'),
-('transmission'), ('transmission_hurdle_rates'), ('simultaneous_flow_limits'),
-('lf_reserves_up'), ('lf_reserves_down'),
-('regulation_up'), ('regulation_down'),
-('frequency_response'), ('spinning_reserves'),
-('rps'), ('carbon_cap'), ('track_carbon_imports'),
-('prm'), ('elcc_surface'), ('local_capacity');
 
 -- Subscenarios by feature
 DROP TABLE IF EXISTS mod_feature_subscenarios;
@@ -76,65 +43,6 @@ PRIMARY KEY (feature, subscenario_id),
 FOREIGN KEY (feature) REFERENCES mod_features (feature)
 );
 
-INSERT INTO mod_feature_subscenarios (feature, subscenario_id)
-VALUES ('optional', 'PROJECT_AVAILABILITY_SCENARIO_ID'),
-('core', 'TEMPORAL_SCENARIO_ID'),
-('core','PROJECT_PORTFOLIO_SCENARIO_ID'),
-('core', 'PROJECT_OPERATIONAL_CHARS_SCENARIO_ID'),
-('core', 'LOAD_SCENARIO_ID'),
-('core', 'LOAD_ZONE_SCENARIO_ID'),
-('core', 'PROJECT_LOAD_ZONE_SCENARIO_ID'),
-('core', 'TUNING_SCENARIO_ID'),
-('data_dependent', 'PROJECT_EXISTING_CAPACITY_SCENARIO_ID'),
-('data_dependent', 'PROJECT_EXISTING_FIXED_COST_SCENARIO_ID'),
-('data_dependent', 'PROJECT_NEW_COST_SCENARIO_ID'),
-('data_dependent', 'PROJECT_NEW_POTENTIAL_SCENARIO_ID'),
-('fuels', 'FUEL_SCENARIO_ID'),
-('fuels', 'FUEL_PRICE_SCENARIO_ID'),
-('transmission', 'TRANSMISSION_PORTFOLIO_SCENARIO_ID'),
-('transmission', 'TRANSMISSION_LOAD_ZONE_SCENARIO_ID'),
-('transmission', 'TRANSMISSION_EXISTING_CAPACITY_SCENARIO_ID'),
-('transmission', 'TRANSMISSION_OPERATIONAL_CHARS_SCENARIO_ID'),
-('transmission_hurdle_rates', 'TRANSMISSION_HURDLE_RATE_SCENARIO_ID'),
-('simultaneous_flow_limits', 'TRANSMISSION_SIMULTANEOUS_FLOW_LIMIT_SCENARIO_ID'),
-('simultaneous_flow_limits', 'TRANSMISSION_SIMULTANEOUS_FLOW_LIMIT_LINE_SCENARIO_ID'),
-('lf_reserves_up', 'LF_RESERVES_UP_BA_SCENARIO_ID'),
-('lf_reserves_up', 'PROJECT_LF_RESERVES_UP_BA_SCENARIO_ID'),
-('lf_reserves_up', 'LF_RESERVES_UP_SCENARIO_ID'),
-('lf_reserves_down', 'LF_RESERVES_DOWN_BA_SCENARIO_ID'),
-('lf_reserves_down', 'PROJECT_LF_RESERVES_DOWN_BA_SCENARIO_ID'),
-('lf_reserves_down', 'LF_RESERVES_DOWN_SCENARIO_ID'),
-('regulation_up', 'REGULATION_UP_BA_SCENARIO_ID'),
-('regulation_up', 'PROJECT_REGULATION_UP_BA_SCENARIO_ID'),
-('regulation_up', 'REGULATION_UP_SCENARIO_ID'),
-('regulation_down', 'REGULATION_DOWN_BA_SCENARIO_ID'),
-('regulation_down', 'PROJECT_REGULATION_DOWN_BA_SCENARIO_ID'),
-('regulation_down', 'REGULATION_DOWN_SCENARIO_ID'),
-('frequency_response', 'FREQUENCY_RESPONSE_BA_SCENARIO_ID'),
-('frequency_response', 'PROJECT_FREQUENCY_RESPONSE_BA_SCENARIO_ID'),
-('frequency_response', 'FREQUENCY_RESPONSE_SCENARIO_ID'),
-('spinning_reserves', 'SPINNING_RESERVES_BA_SCENARIO_ID'),
-('spinning_reserves', 'PROJECT_SPINNING_RESERVES_BA_SCENARIO_ID'),
-('spinning_reserves', 'SPINNING_RESERVES_SCENARIO_ID'),
-('rps', 'RPS_ZONE_SCENARIO_ID'),
-('rps', 'PROJECT_RPS_ZONE_SCENARIO_ID'),
-('rps', 'RPS_TARGET_SCENARIO_ID'),
-('carbon_cap', 'CARBON_CAP_ZONE_SCENARIO_ID'),
-('carbon_cap', 'PROJECT_CARBON_CAP_ZONE_SCENARIO_ID'),
-('carbon_cap', 'CARBON_CAP_TARGET_SCENARIO_ID'),
-('track_carbon_imports', 'TRANSMISSION_CARBON_CAP_ZONE_SCENARIO_ID'),
-('prm', 'PRM_ZONE_SCENARIO_ID'),
-('prm', 'PROJECT_PRM_ZONE_SCENARIO_ID'),
-('prm', 'PRM_ENERGY_ONLY_SCENARIO_ID'),
-('prm', 'PRM_REQUIREMENT_SCENARIO_ID'),
-('elcc_surface', 'PROJECT_ELCC_CHARS_SCENARIO_ID'),
-('elcc_surface', 'ELCC_SURFACE_SCENARIO_ID'),
-('local_capacity', 'LOCAL_CAPACITY_ZONE_SCENARIO_ID'),
-('local_capacity', 'PROJECT_LOCAL_CAPACITY_ZONE_SCENARIO_ID'),
-('local_capacity', 'PROJECT_LOCAL_CAPACITY_CHARS_SCENARIO_ID'),
-('local_capacity', 'LOCAL_CAPACITY_REQUIREMENT_SCENARIO_ID');
-
-
 -- Scenario validation status
 DROP TABLE IF EXISTS mod_validation_status_types;
 CREATE TABLE mod_validation_status_types (
@@ -142,19 +50,12 @@ validation_status_id INTEGER PRIMARY KEY,
 validation_status_name VARCHAR(32) UNIQUE
 );
 
-INSERT INTO mod_validation_status_types
-    (validation_status_id, validation_status_name)
-VALUES (0, 'not_validated'), (1, 'valid'), (2, 'invalid');
-
 -- Run status
 DROP TABLE IF EXISTS mod_run_status_types;
 CREATE TABLE mod_run_status_types (
 run_status_id INTEGER PRIMARY KEY,
 run_status_name VARCHAR(32) UNIQUE
 );
-
-INSERT INTO mod_run_status_types (run_status_id, run_status_name)
-VALUES (0, 'not_run'), (1, 'running'), (2, 'complete'), (3, 'run_error');
 
 -- TODO: figure out foreign keys for subproblems/stages when structure in place
 -- TODO: what happens if user deletes scenario in scenarios table

--- a/gridpath/auxiliary/scenario_chars.py
+++ b/gridpath/auxiliary/scenario_chars.py
@@ -528,9 +528,9 @@ class SubScenarios(object):
         feature_sc_dict = {}
         for f, sc in feature_sc:
             if f in feature_sc_dict:
-                feature_sc_dict[f].append(sc)
+                feature_sc_dict[f].append(sc.upper())
             else:
-                feature_sc_dict[f] = [sc]
+                feature_sc_dict[f] = [sc.upper()]
         return feature_sc_dict
 
     # TODO: refactor this in capacity_types/__init__? (similar functions are


### PR DESCRIPTION
 - Move auxiliary data (features, subscenario by features, etc.) to
   'data' folder under 'db' rather than hard-coding it into the schema
   file. Add the loading of the data in create_database.py.
 - Change subscenario IDs in the mod_feature_subscenarios table to
   lower case and use .upper() in the code

Closes #119