### PR TITLE
Add subproblem/stage to input validation tables

### DIFF
--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -81,6 +81,8 @@ FOREIGN KEY (status) REFERENCES mod_run_status_types (run_status_id)
 DROP TABLE IF EXISTS mod_input_validation;
 CREATE TABLE mod_input_validation (
 scenario_id INTEGER,
+subproblem_id INTEGER,
+stage_id INTEGER,
 gridpath_module VARCHAR(64),
 related_subscenario VARCHAR(64),
 related_database_table VARCHAR(64),

--- a/gridpath/auxiliary/auxiliary.py
+++ b/gridpath/auxiliary/auxiliary.py
@@ -316,8 +316,9 @@ def write_validation_to_database(validation_results, conn):
     c = conn.cursor()
     for row in validation_results:
         query = """INSERT into mod_input_validation
-                (scenario_id, gridpath_module, related_subscenario, 
-                related_database_table, issue_type, issue_description)
+                (scenario_id, subproblem_id, stage_id, 
+                gridpath_module, related_subscenario, related_database_table, 
+                issue_type, issue_description)
                 VALUES ({});""".format(','.join(['?' for item in row]))
 
         c.execute(query, row)
@@ -483,7 +484,8 @@ def check_constant_heat_rate(df, op_type):
     return results
 
 
-def check_projects_for_reserves(projects, operational_type, subscenarios, conn):
+def check_projects_for_reserves(projects, operational_type, subscenarios,
+                                subproblem, stage, conn):
     """
     Check that a list of projects of a given operational_type does not show up
     in any of the inputs_project_reserve_bas tables since the operational type
@@ -491,6 +493,8 @@ def check_projects_for_reserves(projects, operational_type, subscenarios, conn):
     :param operational_type:
     :param projects:
     :param subscenarios:
+    :param subproblem:
+    :param stage:
     :param conn:
     :return:
     """
@@ -533,6 +537,8 @@ def check_projects_for_reserves(projects, operational_type, subscenarios, conn):
                 print_bad_projects = ", ".join(bad_projects)
                 validation_results.append(
                     (subscenarios.SCENARIO_ID,
+                     subproblem,
+                     stage,
                      __name__,
                      project_ba_id.upper(),
                      table,

--- a/gridpath/project/__init__.py
+++ b/gridpath/project/__init__.py
@@ -275,6 +275,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in dtype_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS, PROJECT_PORTFOLIO",
              "inputs_project_operational_chars, inputs_project_portfolios",
@@ -290,6 +292,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in sign_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",
@@ -304,6 +308,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
         for error in validation_errors:
             validation_results.append(
                 (subscenarios.SCENARIO_ID,
+                 subproblem,
+                 stage,
                  __name__,
                  "PROJECT_OPERATIONAL_CHARS",
                  "inputs_project_operational_chars",
@@ -337,6 +343,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS, PROJECT_PORTFOLIO",
              "inputs_project_operational_chars, inputs_project_portfolios",
@@ -355,6 +363,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_PORTFOLIO",
              "inputs_project_portfolios",
@@ -373,6 +383,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",

--- a/gridpath/project/fuels.py
+++ b/gridpath/project/fuels.py
@@ -162,6 +162,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in dtype_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_FUELS",
              "inputs_project_fuels",
@@ -181,6 +183,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in dtype_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_FUEL_PRICES",
              "inputs_project_fuel_prices",
@@ -194,6 +198,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",
@@ -207,6 +213,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_FUEL_PRICES",
              "inputs_project_fuel_prices",

--- a/gridpath/project/operations/__init__.py
+++ b/gridpath/project/operations/__init__.py
@@ -395,6 +395,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in dtype_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_AVAILABILITY",
              "inputs_project_availability",
@@ -408,6 +410,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
         for error in validation_errors:
             validation_results.append(
                 (subscenarios.SCENARIO_ID,
+                 subproblem,
+                 stage,
                  __name__,
                  "PROJECT_AVAILABILITY",
                  "inputs_project_availability",
@@ -430,6 +434,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in dtype_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_HEAT_RATE_CURVES",
              "inputs_project_heat_rate_curves",
@@ -446,6 +452,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in sign_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_HEAT_RATE_CURVES",
              "inputs_project_heat_rate_curves",
@@ -461,6 +469,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",
@@ -475,6 +485,8 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_HEAT_RATE_CURVES",
              "inputs_project_heat_rate_curves",

--- a/gridpath/project/operations/operational_types/always_on.py
+++ b/gridpath/project/operations/operational_types/always_on.py
@@ -543,6 +543,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",
@@ -566,6 +568,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",

--- a/gridpath/project/operations/operational_types/dispatchable_capacity_commit.py
+++ b/gridpath/project/operations/operational_types/dispatchable_capacity_commit.py
@@ -1209,6 +1209,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",
@@ -1227,6 +1229,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",

--- a/gridpath/project/operations/operational_types/dispatchable_no_commit.py
+++ b/gridpath/project/operations/operational_types/dispatchable_no_commit.py
@@ -305,6 +305,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",
@@ -319,6 +321,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_HEAT_RATE_CURVES",
              "inputs_project_heat_rate_curves",

--- a/gridpath/project/operations/operational_types/must_run.py
+++ b/gridpath/project/operations/operational_types/must_run.py
@@ -295,6 +295,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_OPERATIONAL_CHARS",
              "inputs_project_operational_chars",
@@ -308,6 +310,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
+             subproblem,
+             stage,
              __name__,
              "PROJECT_HEAT_RATE_CURVES",
              "inputs_project_heat_rate_curves",
@@ -323,6 +327,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
         projects=df["project"],
         operational_type="must_run",
         subscenarios=subscenarios,
+        subproblem=subproblem,
+        stage=stage,
         conn=conn
     )
 

--- a/gridpath/project/operations/operational_types/variable_no_curtailment.py
+++ b/gridpath/project/operations/operational_types/variable_no_curtailment.py
@@ -426,6 +426,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
         projects=var_projects,
         operational_type="variable_no_curtailment",
         subscenarios=subscenarios,
+        subproblem=subproblem,
+        stage=stage,
         conn=conn
     )
 

--- a/gridpath/validate_inputs.py
+++ b/gridpath/validate_inputs.py
@@ -117,6 +117,8 @@ def validate_feature_subscenario_ids(subscenarios, optional_features, conn):
                     validation_results.append(
                         (subscenarios.SCENARIO_ID,
                          "N/A",
+                         "N/A",
+                         "N/A",
                          sc_id,
                          "scenarios",
                          "Missing subscenario ID",
@@ -130,6 +132,8 @@ def validate_feature_subscenario_ids(subscenarios, optional_features, conn):
                         getattr(subscenarios, sc_id) is not None:
                     validation_results.append(
                         (subscenarios.SCENARIO_ID,
+                         "N/A",
+                         "N/A",
                          "N/A",
                          sc_id,
                          "scenarios",
@@ -161,6 +165,8 @@ def validate_required_subscenario_ids(subscenarios, conn):
         if getattr(subscenarios, sc_id) is None:
             validation_results.append(
                 (subscenarios.SCENARIO_ID,
+                 "N/A",
+                 "N/A",
                  "N/A",
                  sc_id,
                  "scenarios",
@@ -224,6 +230,8 @@ def validate_data_dependent_subscenario_ids(subscenarios, conn):
         if getattr(subscenarios, sc_id) is None:
             validation_results.append(
                 (subscenarios.SCENARIO_ID,
+                 "N/A",
+                 "N/A",
                  "N/A",
                  sc_id,
                  "scenarios",


### PR DESCRIPTION
When running a multi-subproblem and/or multi-stage scenario, the input validation will be run for each subproblem/stage, so we need to add a subproblem/stage identifier to the input validation results table.

Closes #123 
