### PR TITLE
Add newline="" when opening CSV/TAB files for writing

### DIFF
--- a/gridpath/geography/carbon_cap_zones.py
+++ b/gridpath/geography/carbon_cap_zones.py
@@ -82,7 +82,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "carbon_cap_zones.tab"), "w") as \
+                           "carbon_cap_zones.tab"), "w", newline="") as \
             carbon_cap_zones_file:
         writer = csv.writer(carbon_cap_zones_file, delimiter="\t")
 

--- a/gridpath/geography/frequency_response_balancing_areas.py
+++ b/gridpath/geography/frequency_response_balancing_areas.py
@@ -88,7 +88,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "frequency_response_balancing_areas.tab"), "w") as \
+                           "frequency_response_balancing_areas.tab"), "w", newline="") as \
             freq_resp_bas_tab_file:
         writer = csv.writer(freq_resp_bas_tab_file, delimiter="\t")
 

--- a/gridpath/geography/load_following_down_balancing_areas.py
+++ b/gridpath/geography/load_following_down_balancing_areas.py
@@ -88,7 +88,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "load_following_down_balancing_areas.tab"), "w") as \
+                           "load_following_down_balancing_areas.tab"), "w", newline="") as \
             lf_down_bas_tab_file:
         writer = csv.writer(lf_down_bas_tab_file, delimiter="\t")
 

--- a/gridpath/geography/load_following_up_balancing_areas.py
+++ b/gridpath/geography/load_following_up_balancing_areas.py
@@ -88,7 +88,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "load_following_up_balancing_areas.tab"), "w") as \
+                           "load_following_up_balancing_areas.tab"), "w", newline="") as \
             lf_up_bas_tab_file:
         writer = csv.writer(lf_up_bas_tab_file, delimiter="\t")
 

--- a/gridpath/geography/load_zones.py
+++ b/gridpath/geography/load_zones.py
@@ -95,7 +95,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory, "load_zones.tab"),
-              "w") as \
+              "w", newline="") as \
             load_zones_tab_file:
         writer = csv.writer(load_zones_tab_file, delimiter="\t")
 

--- a/gridpath/geography/local_capacity_zones.py
+++ b/gridpath/geography/local_capacity_zones.py
@@ -95,7 +95,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory, "local_capacity_zones.tab"),
-              "w") as \
+              "w", newline="") as \
             local_capacity_zones_file:
         writer = csv.writer(local_capacity_zones_file, delimiter="\t")
 

--- a/gridpath/geography/prm_zones.py
+++ b/gridpath/geography/prm_zones.py
@@ -91,7 +91,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory, "prm_zones.tab"),
-              "w") as \
+              "w", newline="") as \
             prm_zones_tab_file:
         writer = csv.writer(prm_zones_tab_file, delimiter="\t")
 

--- a/gridpath/geography/regulation_down_balancing_areas.py
+++ b/gridpath/geography/regulation_down_balancing_areas.py
@@ -88,7 +88,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "regulation_down_balancing_areas.tab"), "w") as \
+                           "regulation_down_balancing_areas.tab"), "w", newline="") as \
             reg_down_bas_tab_file:
         writer = csv.writer(reg_down_bas_tab_file, delimiter="\t")
 

--- a/gridpath/geography/regulation_up_balancing_areas.py
+++ b/gridpath/geography/regulation_up_balancing_areas.py
@@ -87,7 +87,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "regulation_up_balancing_areas.tab"), "w") as \
+                           "regulation_up_balancing_areas.tab"), "w", newline="") as \
             reg_up_bas_tab_file:
         writer = csv.writer(reg_up_bas_tab_file, delimiter="\t")
 

--- a/gridpath/geography/rps_zones.py
+++ b/gridpath/geography/rps_zones.py
@@ -81,7 +81,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory, "rps_zones.tab"),
-              "w") as \
+              "w", newline="") as \
             rps_zones_tab_file:
         writer = csv.writer(rps_zones_tab_file, delimiter="\t")
 

--- a/gridpath/geography/spinning_reserves_balancing_areas.py
+++ b/gridpath/geography/spinning_reserves_balancing_areas.py
@@ -88,7 +88,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "spinning_reserves_balancing_areas.tab"), "w") as \
+                           "spinning_reserves_balancing_areas.tab"), "w", newline="") as \
             spinning_reserve_bas_tab_file:
         writer = csv.writer(spinning_reserve_bas_tab_file, delimiter="\t")
 

--- a/gridpath/get_scenario_inputs.py
+++ b/gridpath/get_scenario_inputs.py
@@ -139,7 +139,7 @@ def write_subproblems_csv(scenario_directory, subproblems):
 
     if not os.path.exists(scenario_directory):
         os.makedirs(scenario_directory)
-    with open(os.path.join(scenario_directory, "subproblems.csv"), "w") as \
+    with open(os.path.join(scenario_directory, "subproblems.csv"), "w", newline="") as \
             subproblems_csv_file:
         writer = csv.writer(subproblems_csv_file, delimiter=",")
 
@@ -156,7 +156,7 @@ def write_features_csv(scenario_directory, feature_list):
     GridPath modules to include
     :return:
     """
-    with open(os.path.join(scenario_directory, "features.csv"), "w") as \
+    with open(os.path.join(scenario_directory, "features.csv"), "w", newline="") as \
             features_csv_file:
         writer = csv.writer(features_csv_file, delimiter=",")
 
@@ -174,7 +174,7 @@ def save_scenario_id(scenario_directory, scenario_id):
     :param scenario_id:
     :return:
     """
-    with open(os.path.join(scenario_directory, "scenario_id.txt"), "w") as \
+    with open(os.path.join(scenario_directory, "scenario_id.txt"), "w", newline="") as \
             scenario_id_file:
         scenario_id_file.write(str(scenario_id))
 
@@ -193,7 +193,7 @@ def write_scenario_description(
     :return:
     """
     with open(os.path.join(scenario_directory, "scenario_description.csv"),
-              "w") as \
+              "w", newline="") as \
             scenario_description_file:
         writer = csv.writer(scenario_description_file, delimiter=",")
 

--- a/gridpath/objective/system/prm/dynamic_elcc_tuning_penalties.py
+++ b/gridpath/objective/system/prm/dynamic_elcc_tuning_penalties.py
@@ -138,14 +138,14 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             new_rows.append(param_value)
 
         with open(os.path.join(inputs_directory, "tuning_params.tab"),
-                  "w") as \
+                  "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t")
             writer.writerows(new_rows)
 
     else:
         with open(os.path.join(inputs_directory, "tuning_params.tab"),
-                  "w") as \
+                  "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t")
             writer.writerows(["dynamic_elcc_tuning_cost"])

--- a/gridpath/objective/transmission/carbon_imports_tuning_costs.py
+++ b/gridpath/objective/transmission/carbon_imports_tuning_costs.py
@@ -149,14 +149,14 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             new_rows.append(param_value)
 
         with open(os.path.join(inputs_directory, "tuning_params.tab"),
-                  "w") as \
+                  "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t")
             writer.writerows(new_rows)
 
     else:
         with open(os.path.join(inputs_directory, "tuning_params.tab"),
-                  "w") as \
+                  "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t")
             writer.writerows(["import_carbon_tuning_cost"])

--- a/gridpath/project/__init__.py
+++ b/gridpath/project/__init__.py
@@ -455,9 +455,9 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     #   columns and tab file column names are the same everywhere
     #   projects.fillna(".", inplace=True)
     #   filename = os.path.join(inputs_directory, "projects.tab")
-    #   projects.to_csv(filename, sep="\t", mode="w")
+    #   projects.to_csv(filename, sep="\t", mode="w", newline="")
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_tab_file:
         writer = csv.writer(projects_tab_file, delimiter="\t")
 

--- a/gridpath/project/capacity/capacity.py
+++ b/gridpath/project/capacity/capacity.py
@@ -234,7 +234,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
 
     # Total capacity for all projects
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "capacity_all.csv"), "w") as f:
+                           "capacity_all.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "technology", "load_zone",
                          "capacity_mw", "capacity_mwh"])

--- a/gridpath/project/capacity/capacity_types/existing_gen_binary_economic_retirement.py
+++ b/gridpath/project/capacity/capacity_types/existing_gen_binary_economic_retirement.py
@@ -277,7 +277,7 @@ def export_module_specific_results(scenario_directory, subproblem, stage, m, d):
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
                            "capacity_existing_gen_binary_economic_retirement"
-                           ".csv"), "w") as f:
+                           ".csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "technology", "load_zone",
                          "retire_mw"])
@@ -433,7 +433,7 @@ def write_module_specific_model_inputs(
     # write header first, then add input data
     else:
         with open(os.path.join(inputs_directory,
-                               "existing_generation_period_params.tab"), "w") \
+                               "existing_generation_period_params.tab"), "w", newline="") \
                 as existing_project_capacity_tab_file:
             writer = csv.writer(existing_project_capacity_tab_file,
                                 delimiter="\t")

--- a/gridpath/project/capacity/capacity_types/existing_gen_linear_economic_retirement.py
+++ b/gridpath/project/capacity/capacity_types/existing_gen_linear_economic_retirement.py
@@ -301,7 +301,7 @@ def export_module_specific_results(scenario_directory, subproblem, stage, m, d):
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
                            "capacity_existing_gen_linear_economic_retirement"
-                           ".csv"), "w") as f:
+                           ".csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "technology", "load_zone",
                          "retire_mw"])
@@ -459,7 +459,7 @@ def write_module_specific_model_inputs(
     # write header first, then add input data
     else:
         with open(os.path.join(inputs_directory,
-                               "existing_generation_period_params.tab"), "w") \
+                               "existing_generation_period_params.tab"), "w", newline="") \
                 as existing_project_capacity_tab_file:
             writer = csv.writer(existing_project_capacity_tab_file,
                                 delimiter="\t")

--- a/gridpath/project/capacity/capacity_types/existing_gen_no_economic_retirement.py
+++ b/gridpath/project/capacity/capacity_types/existing_gen_no_economic_retirement.py
@@ -280,7 +280,7 @@ def write_module_specific_model_inputs(
     # write header first, then add input data
     else:
         with open(os.path.join(inputs_directory,
-                               "existing_generation_period_params.tab"), "w") \
+                               "existing_generation_period_params.tab"), "w", newline="") \
                 as existing_project_capacity_tab_file:
             writer = csv.writer(existing_project_capacity_tab_file,
                                 delimiter="\t")

--- a/gridpath/project/capacity/capacity_types/new_build_generator.py
+++ b/gridpath/project/capacity/capacity_types/new_build_generator.py
@@ -349,7 +349,7 @@ def export_module_specific_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "capacity_new_build_generator.csv"), "w") as f:
+                           "capacity_new_build_generator.csv"), "w", newline="") as f:
 
         writer = csv.writer(f)
         writer.writerow(["project", "period", "technology", "load_zone",
@@ -524,7 +524,7 @@ def write_module_specific_model_inputs(
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "new_build_generator_vintage_costs.tab"), "w") as \
+                           "new_build_generator_vintage_costs.tab"), "w", newline="") as \
             new_gen_costs_tab_file:
         writer = csv.writer(new_gen_costs_tab_file, delimiter="\t")
 

--- a/gridpath/project/capacity/capacity_types/new_build_storage.py
+++ b/gridpath/project/capacity/capacity_types/new_build_storage.py
@@ -552,7 +552,7 @@ def export_module_specific_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "capacity_new_build_storage.csv"), "w") as f:
+                           "capacity_new_build_storage.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "technology", "load_zone",
                          "new_build_mw", "new_build_mwh"])
@@ -729,7 +729,7 @@ def write_module_specific_model_inputs(
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "new_build_storage_vintage_costs.tab"), "w") as \
+                           "new_build_storage_vintage_costs.tab"), "w", newline="") as \
             new_storage_costs_tab_file:
         writer = csv.writer(new_storage_costs_tab_file, delimiter="\t")
 

--- a/gridpath/project/capacity/capacity_types/new_shiftable_load_supply_curve.py
+++ b/gridpath/project/capacity/capacity_types/new_shiftable_load_supply_curve.py
@@ -377,7 +377,7 @@ def write_module_specific_model_inputs(
     with open(os.path.join(
             inputs_directory,
             "new_shiftable_load_supply_curve_potential.tab"
-    ), "w") as potentials_tab_file:
+    ), "w", newline="") as potentials_tab_file:
         writer = csv.writer(potentials_tab_file, delimiter="\t")
 
         writer.writerow([
@@ -395,7 +395,7 @@ def write_module_specific_model_inputs(
     with open(os.path.join(
             inputs_directory,
             "new_shiftable_load_supply_curve.tab"
-    ), "w") as supply_curve_tab_file:
+    ), "w", newline="") as supply_curve_tab_file:
         writer = csv.writer(supply_curve_tab_file, delimiter="\t")
 
         writer.writerow([

--- a/gridpath/project/capacity/capacity_types/storage_specified_no_economic_retirement.py
+++ b/gridpath/project/capacity/capacity_types/storage_specified_no_economic_retirement.py
@@ -228,7 +228,7 @@ def write_module_specific_model_inputs(
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "storage_specified_capacities.tab"), "w") as \
+                           "storage_specified_capacities.tab"), "w", newline="") as \
             storage_specified_capacities_tab_file:
         writer = csv.writer(storage_specified_capacities_tab_file,
                             delimiter="\t")

--- a/gridpath/project/capacity/costs.py
+++ b/gridpath/project/capacity/costs.py
@@ -66,7 +66,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "costs_capacity_all_projects.csv"), "w") as f:
+                           "costs_capacity_all_projects.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
             ["project", "period", "technology", "load_zone",

--- a/gridpath/project/fuels.py
+++ b/gridpath/project/fuels.py
@@ -280,7 +280,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "fuels.tab"), "w") as \
+                           "fuels.tab"), "w", newline="") as \
             fuels_tab_file:
         writer = csv.writer(fuels_tab_file, delimiter="\t")
 
@@ -293,7 +293,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             writer.writerow(row)
 
     with open(os.path.join(inputs_directory,
-                           "fuel_prices.tab"), "w") as \
+                           "fuel_prices.tab"), "w", newline="") as \
             fuel_prices_tab_file:
         writer = csv.writer(fuel_prices_tab_file, delimiter="\t")
 

--- a/gridpath/project/operations/__init__.py
+++ b/gridpath/project/operations/__init__.py
@@ -636,7 +636,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
     if availabilities:
         with open(os.path.join(inputs_directory, "project_availability.tab"),
-                  "w") as \
+                  "w", newline="") as \
                 availability_tab_file:
             writer = csv.writer(availability_tab_file, delimiter="\t")
 
@@ -646,7 +646,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 writer.writerow(row)
 
     with open(os.path.join(inputs_directory, "heat_rate_curves.tab"),
-              "w") as \
+              "w", newline="") as \
             heat_rate_tab_file:
         writer = csv.writer(heat_rate_tab_file, delimiter="\t")
 

--- a/gridpath/project/operations/carbon_emissions.py
+++ b/gridpath/project/operations/carbon_emissions.py
@@ -93,7 +93,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "carbon_emissions_by_project.csv"), "w") as \
+                           "carbon_emissions_by_project.csv"), "w", newline="") as \
             carbon_emissions_results_file:
         writer = csv.writer(carbon_emissions_results_file)
         writer.writerow(["project", "period", "horizon", "timepoint",
@@ -192,7 +192,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/costs.py
+++ b/gridpath/project/operations/costs.py
@@ -196,7 +196,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     Nothing
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "costs_operations_variable_om.csv"), "w") as f:
+                           "costs_operations_variable_om.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
             ["project", "period", "horizon", "timepoint", "horizon_weight",
@@ -217,7 +217,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
             ])
 
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "costs_operations_fuel.csv"), "w") as f:
+                           "costs_operations_fuel.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
             ["project", "period", "horizon", "timepoint", "horizon_weight",
@@ -238,7 +238,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
             ])
 
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "costs_operations_startup.csv"), "w") as f:
+                           "costs_operations_startup.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
             ["project", "period", "horizon", "timepoint", "horizon_weight",
@@ -259,7 +259,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
             ])
 
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "costs_operations_shutdown.csv"), "w") as f:
+                           "costs_operations_shutdown.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
             ["project", "period", "horizon", "timepoint", "horizon_weight",

--- a/gridpath/project/operations/fuel_burn.py
+++ b/gridpath/project/operations/fuel_burn.py
@@ -135,7 +135,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     Nothing
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-              "fuel_burn.csv"), "w") as f:
+              "fuel_burn.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
             ["project", "period", "horizon", "timepoint", "horizon_weight",

--- a/gridpath/project/operations/operational_types/dispatchable_binary_commit.py
+++ b/gridpath/project/operations/operational_types/dispatchable_binary_commit.py
@@ -1100,7 +1100,7 @@ def export_module_specific_results(mod, d,
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_binary_commit.csv"), "w") as f:
+                           "dispatch_binary_commit.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
                          "horizon_weight", "number_of_hours_in_timepoint",

--- a/gridpath/project/operations/operational_types/dispatchable_capacity_commit.py
+++ b/gridpath/project/operations/operational_types/dispatchable_capacity_commit.py
@@ -1013,7 +1013,7 @@ def export_module_specific_results(mod, d, scenario_directory, subproblem, stage
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_capacity_commit.csv"), "w") as f:
+                           "dispatch_capacity_commit.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
                          "horizon_weight", "number_of_hours_in_timepoint",

--- a/gridpath/project/operations/operational_types/dispatchable_continuous_commit.py
+++ b/gridpath/project/operations/operational_types/dispatchable_continuous_commit.py
@@ -1105,7 +1105,7 @@ def export_module_specific_results(mod, d,
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_continuous_commit.csv"), "w") as f:
+                           "dispatch_continuous_commit.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
                          "horizon_weight", "number_of_hours_in_timepoint",

--- a/gridpath/project/operations/operational_types/hydro_curtailable.py
+++ b/gridpath/project/operations/operational_types/hydro_curtailable.py
@@ -483,7 +483,7 @@ def export_module_specific_results(mod, d,
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
                            "dispatch_hydro_curtailable.csv"),
-              "w") as f:
+              "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
                          "horizon_weight", "number_of_hours_in_timepoint",
@@ -629,7 +629,7 @@ def write_module_specific_model_inputs(
     else:
         with open(os.path.join(inputs_directory,
                                "hydro_conventional_horizon_params.tab"),
-                  "w") as \
+                  "w", newline="") as \
                 hydro_chars_tab_file:
             writer = csv.writer(hydro_chars_tab_file, delimiter="\t")
 

--- a/gridpath/project/operations/operational_types/hydro_noncurtailable.py
+++ b/gridpath/project/operations/operational_types/hydro_noncurtailable.py
@@ -634,7 +634,7 @@ def write_module_specific_model_inputs(
     else:
         with open(os.path.join(inputs_directory,
                                "hydro_conventional_horizon_params.tab"),
-                  "w") as \
+                  "w", newline="") as \
                 hydro_chars_tab_file:
             writer = csv.writer(hydro_chars_tab_file, delimiter="\t")
 

--- a/gridpath/project/operations/operational_types/storage_generic.py
+++ b/gridpath/project/operations/operational_types/storage_generic.py
@@ -510,7 +510,7 @@ def export_module_specific_results(mod, d,
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_storage_generic.csv"), "w") as f:
+                           "dispatch_storage_generic.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
                          "horizon_weight", "number_of_hours_in_timepoint",

--- a/gridpath/project/operations/operational_types/variable.py
+++ b/gridpath/project/operations/operational_types/variable.py
@@ -421,7 +421,7 @@ def export_module_specific_results(mod, d,
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_variable.csv"), "w") as f:
+                           "dispatch_variable.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
                          "horizon_weight", "number_of_hours_in_timepoint",
@@ -575,7 +575,7 @@ def write_module_specific_model_inputs(
     # then add profiles data
     else:
         with open(os.path.join(inputs_directory,
-                               "variable_generator_profiles.tab"), "w") as \
+                               "variable_generator_profiles.tab"), "w", newline="") as \
                 variable_profiles_tab_file:
             writer = csv.writer(variable_profiles_tab_file, delimiter="\t")
 

--- a/gridpath/project/operations/operational_types/variable_no_curtailment.py
+++ b/gridpath/project/operations/operational_types/variable_no_curtailment.py
@@ -463,7 +463,7 @@ def write_module_specific_model_inputs(
     # then add profiles data
     else:
         with open(os.path.join(inputs_directory,
-                               "variable_generator_profiles.tab"), "w") as \
+                               "variable_generator_profiles.tab"), "w", newline="") as \
                 variable_profiles_tab_file:
             writer = csv.writer(variable_profiles_tab_file, delimiter="\t")
 

--- a/gridpath/project/operations/power.py
+++ b/gridpath/project/operations/power.py
@@ -74,7 +74,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
 
     # First power
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_all.csv"), "w") as f:
+                           "dispatch_all.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
                          "horizon_weight", "number_of_hours_in_timepoint",

--- a/gridpath/project/operations/recs.py
+++ b/gridpath/project/operations/recs.py
@@ -155,7 +155,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "rps_by_project.csv"), "w") as rps_results_file:
+                           "rps_by_project.csv"), "w", newline="") as rps_results_file:
         writer = csv.writer(rps_results_file)
         writer.writerow(["project", "load_zone", "rps_zone",
                          "timepoint", "period", "horizon", "horizon_weight",
@@ -183,7 +183,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
 
     # Export list of RPS projects and their zones for later use
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "rps_project_zones.csv"), "w") as \
+                           "rps_project_zones.csv"), "w", newline="") as \
             rps_project_zones_file:
         writer = csv.writer(rps_project_zones_file)
         writer.writerow(["project", "rps_zone"])
@@ -271,7 +271,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/frequency_response.py
+++ b/gridpath/project/operations/reserves/frequency_response.py
@@ -177,7 +177,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
 
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
                            "reserves_provision_frequency_response.csv"),
-              "w") as f:
+              "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
                          "horizon_weight", "number_of_hours_in_timepoint",
@@ -310,7 +310,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/lf_reserves_down.py
+++ b/gridpath/project/operations/reserves/lf_reserves_down.py
@@ -249,7 +249,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/lf_reserves_up.py
+++ b/gridpath/project/operations/reserves/lf_reserves_up.py
@@ -250,7 +250,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/frequency_response.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/frequency_response.py
@@ -159,7 +159,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/lf_reserves_down.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/lf_reserves_down.py
@@ -158,7 +158,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/lf_reserves_up.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/lf_reserves_up.py
@@ -158,7 +158,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/regulation_down.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/regulation_down.py
@@ -158,7 +158,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/regulation_up.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/regulation_up.py
@@ -158,7 +158,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/spinning_reserves.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/spinning_reserves.py
@@ -158,7 +158,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/regulation_down.py
+++ b/gridpath/project/operations/reserves/regulation_down.py
@@ -249,7 +249,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/regulation_up.py
+++ b/gridpath/project/operations/reserves/regulation_up.py
@@ -253,7 +253,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/reserve_provision.py
+++ b/gridpath/project/operations/reserves/reserve_provision.py
@@ -335,7 +335,7 @@ def generic_export_module_specific_results(
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
                            "reserves_provision_" + module_name + ".csv"),
-              "w") as f:
+              "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
                          "horizon_weight", "number_of_hours_in_timepoint",

--- a/gridpath/project/operations/reserves/spinning_reserves.py
+++ b/gridpath/project/operations/reserves/spinning_reserves.py
@@ -250,7 +250,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/tuning_costs.py
+++ b/gridpath/project/operations/tuning_costs.py
@@ -203,14 +203,14 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             new_rows.append(param_value)
 
         with open(os.path.join(inputs_directory, "tuning_params.tab"),
-                  "w") as \
+                  "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t")
             writer.writerows(new_rows)
 
     else:
         with open(os.path.join(inputs_directory, "tuning_params.tab"),
-                  "w") as \
+                  "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t")
             writer.writerow(["ramp_tuning_cost"])

--- a/gridpath/project/reliability/local_capacity/__init__.py
+++ b/gridpath/project/reliability/local_capacity/__init__.py
@@ -138,7 +138,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/reliability/local_capacity/local_capacity_contribution.py
+++ b/gridpath/project/reliability/local_capacity/local_capacity_contribution.py
@@ -71,7 +71,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
                            "project_local_capacity_contribution.csv"),
-              "w") as \
+              "w", newline="") as \
             results_file:
         writer = csv.writer(results_file)
         writer.writerow(["project", "period", "local_capacity_zone", 
@@ -177,7 +177,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/reliability/prm/__init__.py
+++ b/gridpath/project/reliability/prm/__init__.py
@@ -159,7 +159,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                     row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/reliability/prm/elcc_surface.py
+++ b/gridpath/project/reliability/prm/elcc_surface.py
@@ -118,7 +118,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
                            "prm_project_elcc_surface_contribution.csv"),
-              "w") as \
+              "w", newline="") as \
             results_file:
         writer = csv.writer(results_file)
         writer.writerow(["project", "period", "prm_zone", "facet",
@@ -252,13 +252,13 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)
 
     with open(os.path.join(inputs_directory,
-                           "project_elcc_surface_coefficients.tab"), "w") as \
+                           "project_elcc_surface_coefficients.tab"), "w", newline="") as \
             coefficients_file:
         writer = csv.writer(coefficients_file, delimiter="\t")
 

--- a/gridpath/project/reliability/prm/prm_simple.py
+++ b/gridpath/project/reliability/prm/prm_simple.py
@@ -72,7 +72,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
                            "prm_project_elcc_simple_contribution.csv"),
-              "w") as \
+              "w", newline="") as \
             results_file:
         writer = csv.writer(results_file)
         writer.writerow(["project", "period", "prm_zone", "technology",
@@ -182,7 +182,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/project/reliability/prm/prm_types/energy_only_allowed.py
+++ b/gridpath/project/reliability/prm/prm_types/energy_only_allowed.py
@@ -304,7 +304,7 @@ def export_module_specific_results(m, d, scenario_directory, subproblem, stage,)
     with open(os.path.join(
             scenario_directory, subproblem, stage, "results",
             "project_prm_energy_only_and_deliverable_capacity.csv"
-    ), "w") as f:
+    ), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow([
             "project", "period", "prm_zone",
@@ -323,7 +323,7 @@ def export_module_specific_results(m, d, scenario_directory, subproblem, stage,)
 
     # Total capacity for all projects in group
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "deliverability_group_capacity_and_costs.csv"), "w") as f:
+                           "deliverability_group_capacity_and_costs.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow([
             "deliverability_group", "period",
@@ -442,7 +442,7 @@ def write_module_specific_model_inputs(
     if group_threshold_costs:
         with open(os.path.join(
                 inputs_directory,
-                "deliverability_group_params.tab"), "w") as \
+                "deliverability_group_params.tab"), "w", newline="") as \
                 elcc_eligibility_thresholds_file:
             writer = csv.writer(elcc_eligibility_thresholds_file,
                                 delimiter="\t")

--- a/gridpath/project/reliability/prm/prm_types/fully_deliverable_energy_limited.py
+++ b/gridpath/project/reliability/prm/prm_types/fully_deliverable_energy_limited.py
@@ -212,7 +212,7 @@ def write_module_specific_model_inputs(
             else:
                 row.append(".")
                 new_rows.append(row)
-    with open(os.path.join(inputs_directory, "projects.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t")
         writer.writerows(new_rows)

--- a/gridpath/run_scenario.py
+++ b/gridpath/run_scenario.py
@@ -661,7 +661,7 @@ def save_objective_function_value(scenario_directory, subproblem, stage,
     with open(os.path.join(
             scenario_directory, subproblem, stage, "results",
             "objective_function_value.txt"),
-            "w") as objective_file:
+            "w", newline="") as objective_file:
         objective_file.write(
             "Objective function: " + str(objective_function_value)
         )
@@ -722,7 +722,7 @@ def summarize_results(scenario_directory, subproblem, stage, loaded_modules,
 
     # TODO: how to handle results from previous runs
     # Overwrite prior results
-    with open(summary_results_file, "w") as outfile:
+    with open(summary_results_file, "w", newline="") as outfile:
         outfile.write("##### SUMMARY RESULTS FOR SCENARIO *{}* #####\n".format(
             parsed_arguments.scenario)
         )

--- a/gridpath/system/load_balance/aggregate_transmission_power.py
+++ b/gridpath/system/load_balance/aggregate_transmission_power.py
@@ -62,7 +62,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     """
 
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "imports_exports.csv"), "w") as imp_exp_file:
+                           "imports_exports.csv"), "w", newline="") as imp_exp_file:
         writer = csv.writer(imp_exp_file)
         writer.writerow(
             ["load_zone", "timepoint", "period", "horizon", "horizon_weight",

--- a/gridpath/system/load_balance/load_balance.py
+++ b/gridpath/system/load_balance/load_balance.py
@@ -115,7 +115,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "load_balance.csv"), "w") as results_file:
+                           "load_balance.csv"), "w", newline="") as results_file:
         writer = csv.writer(results_file)
         writer.writerow(["zone", "period", "horizon", "timepoint",
                          "discount_factor", "number_years_represented",

--- a/gridpath/system/load_balance/static_load_requirement.py
+++ b/gridpath/system/load_balance/static_load_requirement.py
@@ -126,7 +126,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "load_mw.tab"), "w") as \
+                           "load_mw.tab"), "w", newline="") as \
             load_tab_file:
         writer = csv.writer(load_tab_file, delimiter="\t")
 

--- a/gridpath/system/policy/carbon_cap/aggregate_project_carbon_emissions.py
+++ b/gridpath/system/policy/carbon_cap/aggregate_project_carbon_emissions.py
@@ -65,7 +65,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "carbon_cap_total_project.csv"), "w") as \
+                           "carbon_cap_total_project.csv"), "w", newline="") as \
             rps_results_file:
         writer = csv.writer(rps_results_file)
         writer.writerow(["carbon_cap_zone", "period",

--- a/gridpath/system/policy/carbon_cap/aggregate_transmission_carbon_emissions.py
+++ b/gridpath/system/policy/carbon_cap/aggregate_transmission_carbon_emissions.py
@@ -90,7 +90,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "carbon_cap_total_transmission.csv"), "w") as \
+                           "carbon_cap_total_transmission.csv"), "w", newline="") as \
             rps_results_file:
         writer = csv.writer(rps_results_file)
         writer.writerow(["carbon_cap_zone", "period", "carbon_cap_target_mmt",

--- a/gridpath/system/policy/carbon_cap/carbon_balance.py
+++ b/gridpath/system/policy/carbon_cap/carbon_balance.py
@@ -61,7 +61,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "carbon_cap.csv"), "w") as carbon_cap_results_file:
+                           "carbon_cap.csv"), "w", newline="") as carbon_cap_results_file:
         writer = csv.writer(carbon_cap_results_file)
         writer.writerow(["carbon_cap_zone", "period",
                          "discount_factor", "number_years_represented",

--- a/gridpath/system/policy/carbon_cap/carbon_cap.py
+++ b/gridpath/system/policy/carbon_cap/carbon_cap.py
@@ -111,7 +111,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "carbon_cap.tab"), "w") as \
+                           "carbon_cap.tab"), "w", newline="") as \
             carbon_cap_file:
         writer = csv.writer(carbon_cap_file, delimiter="\t")
 

--- a/gridpath/system/policy/rps/rps_balance.py
+++ b/gridpath/system/policy/rps/rps_balance.py
@@ -51,7 +51,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "rps.csv"), "w") as rps_results_file:
+                           "rps.csv"), "w", newline="") as rps_results_file:
         writer = csv.writer(rps_results_file)
         writer.writerow(["rps_zone", "period",
                          "discount_factor", "number_years_represented",

--- a/gridpath/system/policy/rps/rps_requirement.py
+++ b/gridpath/system/policy/rps/rps_requirement.py
@@ -111,7 +111,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "rps_targets.tab"), "w") as \
+                           "rps_targets.tab"), "w", newline="") as \
             rps_targets_tab_file:
         writer = csv.writer(rps_targets_tab_file,
                             delimiter="\t")

--- a/gridpath/system/reliability/local_capacity/aggregate_local_capacity_contribution.py
+++ b/gridpath/system/reliability/local_capacity/aggregate_local_capacity_contribution.py
@@ -61,7 +61,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "local_capacity_contribution.csv"), "w") as \
+                           "local_capacity_contribution.csv"), "w", newline="") as \
             results_file:
         writer = csv.writer(results_file)
         writer.writerow(["local_capacity_zone", "period", "contribution_mw"])

--- a/gridpath/system/reliability/local_capacity/local_capacity_balance.py
+++ b/gridpath/system/reliability/local_capacity/local_capacity_balance.py
@@ -91,7 +91,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "local_capacity.csv"), "w") as rps_results_file:
+                           "local_capacity.csv"), "w", newline="") as rps_results_file:
         writer = csv.writer(rps_results_file)
         writer.writerow(["local_capacity_zone", "period",
                          "discount_factor", "number_years_represented",

--- a/gridpath/system/reliability/local_capacity/local_capacity_requirement.py
+++ b/gridpath/system/reliability/local_capacity/local_capacity_requirement.py
@@ -111,7 +111,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "local_capacity_requirement.tab"), "w") as \
+                           "local_capacity_requirement.tab"), "w", newline="") as \
             local_capacity_requirement_tab_file:
         writer = csv.writer(local_capacity_requirement_tab_file,
                             delimiter="\t")

--- a/gridpath/system/reliability/prm/aggregate_project_simple_prm_contribution.py
+++ b/gridpath/system/reliability/prm/aggregate_project_simple_prm_contribution.py
@@ -59,7 +59,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "prm_elcc_simple.csv"), "w") as \
+                           "prm_elcc_simple.csv"), "w", newline="") as \
             results_file:
         writer = csv.writer(results_file)
         writer.writerow(["prm_zone", "period", "elcc_mw"])

--- a/gridpath/system/reliability/prm/elcc_surface.py
+++ b/gridpath/system/reliability/prm/elcc_surface.py
@@ -106,7 +106,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "prm_elcc_surface.csv"), "w") as \
+                           "prm_elcc_surface.csv"), "w", newline="") as \
             results_file:
         writer = csv.writer(results_file)
         writer.writerow(["prm_zone", "period", "elcc_mw"])
@@ -182,7 +182,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
     with open(os.path.join(
             inputs_directory, "prm_zone_surface_facets_and_intercept.tab"
-    ), "w") as intercepts_file:
+    ), "w", newline="") as intercepts_file:
         writer = csv.writer(intercepts_file, delimiter="\t")
 
         # Writer header

--- a/gridpath/system/reliability/prm/prm_balance.py
+++ b/gridpath/system/reliability/prm/prm_balance.py
@@ -61,7 +61,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "prm.csv"), "w") as rps_results_file:
+                           "prm.csv"), "w", newline="") as rps_results_file:
         writer = csv.writer(rps_results_file)
         writer.writerow(["prm_zone", "period",
                          "discount_factor", "number_years_represented",

--- a/gridpath/system/reliability/prm/prm_requirement.py
+++ b/gridpath/system/reliability/prm/prm_requirement.py
@@ -110,7 +110,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "prm_requirement.tab"), "w") as \
+                           "prm_requirement.tab"), "w", newline="") as \
             prm_requirement_tab_file:
         writer = csv.writer(prm_requirement_tab_file,
                             delimiter="\t")

--- a/gridpath/system/reserves/balance/reserve_balance.py
+++ b/gridpath/system/reserves/balance/reserve_balance.py
@@ -66,7 +66,7 @@ def generic_export_results(scenario_directory, subproblem, stage, m, d,
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           filename), "w") \
+                           filename), "w", newline="") \
             as results_file:
         writer = csv.writer(results_file)
         writer.writerow(["ba", "period", "horizon", "timepoint",

--- a/gridpath/system/reserves/requirement/frequency_response.py
+++ b/gridpath/system/reserves/requirement/frequency_response.py
@@ -130,7 +130,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "frequency_response_requirement.tab"), "w") as \
+                           "frequency_response_requirement.tab"), "w", newline="") as \
             frequency_response_tab_file:
         writer = csv.writer(frequency_response_tab_file, delimiter="\t")
 

--- a/gridpath/system/reserves/requirement/lf_reserves_down.py
+++ b/gridpath/system/reserves/requirement/lf_reserves_down.py
@@ -106,7 +106,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "lf_reserves_down_requirement.tab"), "w") as \
+                           "lf_reserves_down_requirement.tab"), "w", newline="") as \
             lf_reserves_down_tab_file:
         writer = csv.writer(lf_reserves_down_tab_file, delimiter="\t")
 

--- a/gridpath/system/reserves/requirement/lf_reserves_up.py
+++ b/gridpath/system/reserves/requirement/lf_reserves_up.py
@@ -106,7 +106,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "lf_reserves_up_requirement.tab"), "w") as \
+                           "lf_reserves_up_requirement.tab"), "w", newline="") as \
             lf_reserves_up_tab_file:
         writer = csv.writer(lf_reserves_up_tab_file, delimiter="\t")
 

--- a/gridpath/system/reserves/requirement/regulation_down.py
+++ b/gridpath/system/reserves/requirement/regulation_down.py
@@ -106,7 +106,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "regulation_down_requirement.tab"), "w") as \
+                           "regulation_down_requirement.tab"), "w", newline="") as \
             regulation_down_tab_file:
         writer = csv.writer(regulation_down_tab_file, delimiter="\t")
 

--- a/gridpath/system/reserves/requirement/regulation_up.py
+++ b/gridpath/system/reserves/requirement/regulation_up.py
@@ -106,7 +106,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory,
-                           "regulation_up_requirement.tab"), "w") as \
+                           "regulation_up_requirement.tab"), "w", newline="") as \
             regulation_up_tab_file:
         writer = csv.writer(regulation_up_tab_file, delimiter="\t")
 

--- a/gridpath/system/reserves/requirement/spinning_reserves.py
+++ b/gridpath/system/reserves/requirement/spinning_reserves.py
@@ -107,7 +107,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
     # spinning_reserves_requirement.tab
     with open(os.path.join(inputs_directory,
-                           "spinning_reserves_requirement.tab"), "w") as \
+                           "spinning_reserves_requirement.tab"), "w", newline="") as \
             spinning_reserves_tab_file:
         writer = csv.writer(spinning_reserves_tab_file, delimiter="\t")
 

--- a/gridpath/temporal/investment/periods.py
+++ b/gridpath/temporal/investment/periods.py
@@ -153,7 +153,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     periods = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "periods.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "periods.tab"), "w", newline="") as \
             periods_tab_file:
         writer = csv.writer(periods_tab_file, delimiter="\t")
 

--- a/gridpath/temporal/operations/horizons.py
+++ b/gridpath/temporal/operations/horizons.py
@@ -259,7 +259,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     horizons = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "horizons.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "horizons.tab"), "w", newline="") as \
             horizons_tab_file:
         writer = csv.writer(horizons_tab_file, delimiter="\t")
 

--- a/gridpath/temporal/operations/timepoints.py
+++ b/gridpath/temporal/operations/timepoints.py
@@ -108,7 +108,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     timepoints = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "timepoints.tab"), "w") as \
+    with open(os.path.join(inputs_directory, "timepoints.tab"), "w", newline="") as \
             timepoints_tab_file:
         writer = csv.writer(timepoints_tab_file, delimiter="\t")
 

--- a/gridpath/transmission/__init__.py
+++ b/gridpath/transmission/__init__.py
@@ -145,7 +145,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(inputs_directory, "transmission_lines.tab"),
-              "w") as \
+              "w", newline="") as \
             transmission_lines_tab_file:
         writer = csv.writer(transmission_lines_tab_file, delimiter="\t")
 

--- a/gridpath/transmission/capacity/capacity.py
+++ b/gridpath/transmission/capacity/capacity.py
@@ -151,7 +151,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
 
     # Export transmission capacity
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "transmission_capacity.csv"), "w") as f:
+                           "transmission_capacity.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["tx_line", "period", "load_zone_from", "load_zone_to",
                          "transmission_min_capacity_mw",
@@ -168,7 +168,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
 
     # Export transmission capacity costs
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-              "costs_transmission_capacity.csv"), "w") as f:
+              "costs_transmission_capacity.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
             ["tx_line", "period", "load_zone_from",

--- a/gridpath/transmission/capacity/capacity_types/new_build_transmission.py
+++ b/gridpath/transmission/capacity/capacity_types/new_build_transmission.py
@@ -204,7 +204,7 @@ def write_module_specific_model_inputs(
 
     with open(os.path.join(inputs_directory,
                            "new_build_transmission_vintage_costs.tab"),
-              "w") as existing_tx_capacity_tab_file:
+              "w", newline="") as existing_tx_capacity_tab_file:
         writer = csv.writer(existing_tx_capacity_tab_file,
                             delimiter="\t")
 
@@ -232,7 +232,7 @@ def export_module_specific_results(m, d, scenario_directory, subproblem, stage):
 
     # Export transmission capacity
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "transmission_new_capacity.csv"), "w") as f:
+                           "transmission_new_capacity.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["transmission_line", "period",
                          "load_zone_from", "load_zone_to",

--- a/gridpath/transmission/capacity/capacity_types/specified_transmission.py
+++ b/gridpath/transmission/capacity/capacity_types/specified_transmission.py
@@ -121,7 +121,7 @@ def write_module_specific_model_inputs(
 
     with open(os.path.join(inputs_directory,
                            "specified_transmission_line_capacities.tab"),
-              "w") as existing_tx_capacity_tab_file:
+              "w", newline="") as existing_tx_capacity_tab_file:
         writer = csv.writer(existing_tx_capacity_tab_file,
                             delimiter="\t")
 

--- a/gridpath/transmission/operations/carbon_emissions.py
+++ b/gridpath/transmission/operations/carbon_emissions.py
@@ -151,7 +151,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "carbon_emission_imports_by_tx_line.csv"), "w") \
+                           "carbon_emission_imports_by_tx_line.csv"), "w", newline="") \
             as carbon_emission_imports__results_file:
         writer = csv.writer(carbon_emission_imports__results_file)
         writer.writerow(["tx_line", "period", "horizon", "timepoint",
@@ -261,7 +261,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 new_rows.append(row)
 
     with open(os.path.join(inputs_directory, "transmission_lines.tab"),
-              "w") as tx_file_out:
+              "w", newline="") as tx_file_out:
         writer = csv.writer(tx_file_out, delimiter="\t")
         writer.writerows(new_rows)
 

--- a/gridpath/transmission/operations/costs.py
+++ b/gridpath/transmission/operations/costs.py
@@ -168,7 +168,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
     with open(os.path.join(inputs_directory,
                            "transmission_hurdle_rates.tab"),
-              "w") as \
+              "w", newline="") as \
             sim_flows_file:
         writer = csv.writer(sim_flows_file, delimiter="\t")
 
@@ -197,7 +197,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     Nothing
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-              "costs_transmission_hurdle.csv"), "w") as f:
+              "costs_transmission_hurdle.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
             ["tx_line", "period", "horizon", "timepoint", "horizon_weight",

--- a/gridpath/transmission/operations/operations.py
+++ b/gridpath/transmission/operations/operations.py
@@ -93,7 +93,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "transmission_operations.csv"), "w") as \
+                           "transmission_operations.csv"), "w", newline="") as \
             tx_op_results_file:
         writer = csv.writer(tx_op_results_file)
         writer.writerow(["tx_line", "lz_from", "lz_to", "timepoint", "period",

--- a/gridpath/transmission/operations/simultaneous_flow_limits.py
+++ b/gridpath/transmission/operations/simultaneous_flow_limits.py
@@ -128,7 +128,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
                            "transmission_simultaneous_flow_limits.csv"),
-              "w") as \
+              "w", newline="") as \
             tx_op_results_file:
         writer = csv.writer(tx_op_results_file)
         writer.writerow(["simultaneous_flow_limit", "timepoint", "period",
@@ -236,7 +236,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     # transmission_simultaneous_flow_limits.tab
     with open(os.path.join(inputs_directory,
                            "transmission_simultaneous_flow_limits.tab"),
-              "w") as \
+              "w", newline="") as \
             sim_flows_file:
         writer = csv.writer(sim_flows_file, delimiter="\t")
 
@@ -251,7 +251,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     # transmission_simultaneous_flow_limit_lines.tab
     with open(os.path.join(inputs_directory,
                            "transmission_simultaneous_flow_limit_lines.tab"),
-              "w") as \
+              "w", newline="") as \
             sim_flow_limit_lines_file:
         writer = csv.writer(sim_flow_limit_lines_file,
                             delimiter="\t")


### PR DESCRIPTION
On Windows, CSV/TAB files were written with an extra blank line in between lines. This was not only annoying, but was actually breaking `get_inputs_from_database.py`, as modules needing to open and append to TAB files would find a blank line when iterating over rows and throw an index error.

Adding `newline=""` is the suggested solution on Python 3 per [StackOverflow](https://stackoverflow.com/questions/3348460/csv-file-written-with-python-has-blank-lines-between-each-row).