### PR TITLE
Separate scripts for capacity and curtailment plots

### DIFF
--- a/db/data/ui_scenario_results_plot_metadata.csv
+++ b/db/data/ui_scenario_results_plot_metadata.csv
@@ -1,9 +1,13 @@
 ﻿results_plot,include,caption,load_zone_form_control,rps_zone_form_control,carbon_cap_zone_form_control,period_form_control,horizon_form_control,stage_form_control,project_form_control
-capacity_factor_plot,1,Capacity Factors,1,0,0,0,0,1,0
-capacity_plot,1,New Capacity,1,0,0,0,0,0,0
-carbon_plot,1,Carbon Emissions,0,0,1,0,0,1,0
+﻿capacity_factor_plot,1,Capacity Factors,1,0,0,0,0,1,0
+capacity_new_plot,1,New Capacity,1,0,0,0,0,0,0
+capacity_retired_plot,1,Retired Capacity,1,0,0,0,0,0,0
+capacity_total_plot,1,Total Capacity,1,0,0,0,0,0,0
+carbon_plot,1,Carbon Emissions,0,0,1,0,0,0,0
 cost_plot,1,System Costs,1,0,0,0,0,1,0
-curtailment_heatmap_plot,1,Curtailment,1,0,0,1,0,1,0
+curtailment_variable_heatmap_plot,1,VER Curtailment,1,0,0,1,0,1,0
+curtailment_hydro_heatmap_plot,1,Hydro Curtailment,1,0,0,1,0,1,0
 dispatch_plot,1,System Dispatch,1,0,0,0,1,1,0
 energy_plot,1,Energy Mix,1,0,0,0,0,1,0
 rps_plot,1,RPS,0,1,0,0,0,1,0
+project_operations_plot,1,Project Operations,0,0,0,1,0,1,1

--- a/viz/capacity_new_plot.py
+++ b/viz/capacity_new_plot.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+# Copyright 2017 Blue Marble Analytics LLC. All rights reserved.
+
+"""
+Make plot of capacity by period and technology for a certain zone/stage
+"""
+
+from argparse import ArgumentParser
+from bokeh.models import ColumnDataSource, Legend, NumeralTickFormatter
+from bokeh.plotting import figure
+from bokeh.models.tools import HoverTool
+from bokeh.embed import json_item
+from bokeh.palettes import cividis
+
+import pandas as pd
+import sys
+
+# GridPath modules
+from viz.common_functions import connect_to_database, show_hide_legend, \
+    show_plot, get_scenario_and_scenario_id
+
+
+def parse_arguments(arguments):
+    """
+
+    :return:
+    """
+    parser = ArgumentParser(add_help=True)
+
+    # Scenario name and location options
+    parser.add_argument("--database",
+                        help="The database file path. Defaults to ../db/io.db "
+                             "if not specified")
+    parser.add_argument("--scenario_id", help="The scenario ID. Required if "
+                                              "no --scenario is specified.")
+    parser.add_argument("--scenario", help="The scenario name. Required if "
+                                           "no --scenario_id is specified.")
+    parser.add_argument("--scenario_location",
+                        help="The path to the directory in which to create "
+                             "the scenario directory. Defaults to "
+                             "'../scenarios' if not specified.")
+    parser.add_argument("--load_zone",
+                        help="The name of the load zone. Required.")
+    parser.add_argument("--ylimit", help="Set y-axis limit.", type=float)
+    parser.add_argument("--show",
+                        default=False, action="store_true",
+                        help="Show and save figure to "
+                             "results/figures directory "
+                             "under scenario directory.")
+    parser.add_argument("--return_json",
+                        default=False, action="store_true",
+                        help="Return plot as a json file."
+                        )
+    # Parse arguments
+    parsed_arguments = parser.parse_known_args(args=arguments)[0]
+
+    return parsed_arguments
+
+
+def get_capacity(c, scenario_id, load_zone):
+    """
+    Get capacity results.
+    :param c:
+    :param scenario_id:
+    :param load_zone:
+    :param capacity_type:
+    :return:
+    """
+    # New capacity by period and technology
+    sql = """SELECT period, technology, sum(new_build_mw) as capacity_mw
+        FROM results_project_capacity_new_build_generator
+        WHERE scenario_id = ?
+        AND load_zone = ?
+        GROUP BY period, technology
+        UNION
+        SELECT period, technology, sum(new_build_mw) as mw
+        FROM results_project_capacity_new_build_generator
+        WHERE scenario_id = ?
+        AND load_zone = ?
+        GROUP BY period, technology;"""
+    capacity = c.execute(sql, (scenario_id, load_zone,
+                               scenario_id, load_zone))
+
+    return capacity
+
+
+def create_data_df(c, scenario_id, load_zone):
+    """
+    Get capacity results and pivot into data df
+    :param c:
+    :param scenario_id:
+    :param load_zone:
+    :return:
+    """
+
+    capacity = get_capacity(c, scenario_id, load_zone)
+
+    df = pd.DataFrame(
+        data=capacity.fetchall(),
+        columns=[n[0] for n in capacity.description]
+    )
+
+    df = df.pivot(
+        index='period',
+        columns='technology',
+        values='capacity_mw'
+    )
+
+    # Change index type from int to string (required for categorical bar chart)
+    df.index = df.index.map(str)
+
+    # For Testing:
+    # df = pd.DataFrame(
+    #     index=["2018", "2020"],
+    #     data=[[0, 3000, 500, 1500],
+    #           [0, 6000, 4500, 2300]],
+    #     columns=["Biomass", "Hydro", "Solar", "Wind"]
+    # )
+    # df.index.name = "period"
+
+    return df
+
+
+def create_plot(df, title, ylimit=None):
+    """
+
+    :param df:
+    :param title: string, plot title
+    :param ylimit: float/int, upper limit of y-axis; optional
+    :return:
+    """
+
+    # TODO: handle empty dataframe (will give bokeh warning)
+
+    # Set up data source
+    source = ColumnDataSource(data=df)
+
+    # Determine column types for plotting, legend and colors
+    # Order of stacked_cols will define order of stacked areas in chart
+    stacked_cols = list(df.columns)
+
+    # Stacked Area Colors
+    colors = cividis(len(stacked_cols))
+
+    # Set up the figure
+    plot = figure(
+        plot_width=800, plot_height=500,
+        tools=["pan", "reset", "zoom_in", "zoom_out", "save", "help"],
+        title=title,
+        x_range=df.index.values
+        # sizing_mode="scale_both"
+    )
+
+    # Add stacked area chart to plot
+    area_renderers = plot.vbar_stack(
+        stackers=stacked_cols,
+        x="period",
+        source=source,
+        color=colors,
+        width=0.5,
+    )
+
+    # Keep track of legend items
+    legend_items = [(y, [area_renderers[i]]) for i, y in enumerate(stacked_cols)
+                    if df[y].mean() > 0]
+
+    # Add Legend
+    legend = Legend(items=legend_items)
+    plot.add_layout(legend, 'right')
+    plot.legend[0].items.reverse()  # Reverse legend to match stacked order
+    plot.legend.click_policy = 'hide'  # Add interactivity to the legend
+    # Note: Doesn't rescale the graph down, simply hides the area
+    # Note2: There's currently no way to auto-size legend based on graph size(?)
+    # except for maybe changing font size automatically?
+    show_hide_legend(plot=plot)  # Hide legend on double click
+
+    # Format Axes (labels, number formatting, range, etc.)
+    plot.xaxis.axis_label = "Period"
+    plot.yaxis.axis_label = "Capacity (MW)"
+    plot.yaxis.formatter = NumeralTickFormatter(format="0,0")
+    plot.y_range.end = ylimit  # will be ignored if ylimit is None
+
+    # Add HoverTools for stacked bars/areas
+    for r in area_renderers:
+        technology = r.name
+        hover = HoverTool(
+            tooltips=[
+                ("Period", "@period"),
+                ("Technology", technology),
+                ("Capacity", "@%s{0,0} MW" % technology)
+            ],
+            renderers=[r],
+            toggleable=False)
+        plot.add_tools(hover)
+
+    return plot
+
+
+def main(args=None):
+    """
+    Parse the arguments, get the data in a df, and create the plot
+
+    :return: if requested, return the plot as JSON object
+    """
+    if args is None:
+        args = sys.argv[1:]
+    parsed_args = parse_arguments(arguments=args)
+
+    db = connect_to_database(parsed_arguments=parsed_args)
+    c = db.cursor()
+
+    scenario_location = parsed_args.scenario_location
+    scenario, scenario_id = get_scenario_and_scenario_id(
+        parsed_arguments=parsed_args,
+        c=c
+    )
+
+    plot_title = "New Capacity by Period - {}".format(parsed_args.load_zone)
+    # TODO: add capacity type to title?
+    plot_name = "NewCapacityPlot-{}".format(parsed_args.load_zone)
+
+    df = create_data_df(
+        c=c,
+        scenario_id=scenario_id,
+        load_zone=parsed_args.load_zone,
+    )
+
+    plot = create_plot(
+        df=df,
+        title=plot_title,
+        ylimit=parsed_args.ylimit
+    )
+
+    # Show plot in HTML browser file if requested
+    if parsed_args.show:
+        show_plot(scenario_directory=scenario_location,
+                  scenario=scenario,
+                  plot=plot,
+                  plot_name=plot_name)
+
+    # Return plot in json format if requested
+    if parsed_args.return_json:
+        return json_item(plot, plot_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/viz/capacity_retired_plot.py
+++ b/viz/capacity_retired_plot.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+# Copyright 2017 Blue Marble Analytics LLC. All rights reserved.
+
+"""
+Make plot of capacity by period and technology for a certain zone/stage
+"""
+
+from argparse import ArgumentParser
+from bokeh.models import ColumnDataSource, Legend, NumeralTickFormatter
+from bokeh.plotting import figure
+from bokeh.models.tools import HoverTool
+from bokeh.embed import json_item
+from bokeh.palettes import cividis
+
+import pandas as pd
+import sys
+
+# GridPath modules
+from viz.common_functions import connect_to_database, show_hide_legend, \
+    show_plot, get_scenario_and_scenario_id
+
+
+def parse_arguments(arguments):
+    """
+
+    :return:
+    """
+    parser = ArgumentParser(add_help=True)
+
+    # Scenario name and location options
+    parser.add_argument("--database",
+                        help="The database file path. Defaults to ../db/io.db "
+                             "if not specified")
+    parser.add_argument("--scenario_id", help="The scenario ID. Required if "
+                                              "no --scenario is specified.")
+    parser.add_argument("--scenario", help="The scenario name. Required if "
+                                           "no --scenario_id is specified.")
+    parser.add_argument("--scenario_location",
+                        help="The path to the directory in which to create "
+                             "the scenario directory. Defaults to "
+                             "'../scenarios' if not specified.")
+    parser.add_argument("--load_zone",
+                        help="The name of the load zone. Required.")
+    parser.add_argument("--ylimit", help="Set y-axis limit.", type=float)
+    parser.add_argument("--show",
+                        default=False, action="store_true",
+                        help="Show and save figure to "
+                             "results/figures directory "
+                             "under scenario directory.")
+    parser.add_argument("--return_json",
+                        default=False, action="store_true",
+                        help="Return plot as a json file."
+                        )
+    # Parse arguments
+    parsed_arguments = parser.parse_known_args(args=arguments)[0]
+
+    return parsed_arguments
+
+
+def get_capacity(c, scenario_id, load_zone):
+    """
+    Get capacity results.
+    :param c:
+    :param scenario_id:
+    :param load_zone:
+    :param capacity_type:
+    :return:
+    """
+    # Retired apacity by period and technology
+    sql = """SELECT period, technology, sum(retired_mw) as capacity_mw
+        FROM (SELECT scenario_id, load_zone, project, period, technology, 
+              retired_mw 
+              FROM results_project_capacity_linear_economic_retirement
+              UNION 
+              SELECT scenario_id, load_zone, project, period, technology, 
+              retired_mw 
+              FROM results_project_capacity_binary_economic_retirement
+             ) as tbl
+        WHERE scenario_id = ?
+        AND load_zone = ?
+        GROUP BY period, technology;"""
+    capacity = c.execute(sql, (scenario_id, load_zone))
+
+    return capacity
+
+
+def create_data_df(c, scenario_id, load_zone):
+    """
+    Get capacity results and pivot into data df
+    :param c:
+    :param scenario_id:
+    :param load_zone:
+    :return:
+    """
+
+    capacity = get_capacity(c, scenario_id, load_zone)
+
+    df = pd.DataFrame(
+        data=capacity.fetchall(),
+        columns=[n[0] for n in capacity.description]
+    )
+
+    df = df.pivot(
+        index='period',
+        columns='technology',
+        values='capacity_mw'
+    )
+
+    # Change index type from int to string (required for categorical bar chart)
+    df.index = df.index.map(str)
+
+    # For Testing:
+    # df = pd.DataFrame(
+    #     index=["2018", "2020"],
+    #     data=[[0, 3000, 500, 1500],
+    #           [0, 6000, 4500, 2300]],
+    #     columns=["Biomass", "Hydro", "Solar", "Wind"]
+    # )
+    # df.index.name = "period"
+
+    return df
+
+
+def create_plot(df, title, ylimit=None):
+    """
+
+    :param df:
+    :param title: string, plot title
+    :param ylimit: float/int, upper limit of y-axis; optional
+    :return:
+    """
+
+    # TODO: handle empty dataframe (will give bokeh warning)
+
+    # Set up data source
+    source = ColumnDataSource(data=df)
+
+    # Determine column types for plotting, legend and colors
+    # Order of stacked_cols will define order of stacked areas in chart
+    stacked_cols = list(df.columns)
+
+    # Stacked Area Colors
+    colors = cividis(len(stacked_cols))
+
+    # Set up the figure
+    plot = figure(
+        plot_width=800, plot_height=500,
+        tools=["pan", "reset", "zoom_in", "zoom_out", "save", "help"],
+        title=title,
+        x_range=df.index.values
+        # sizing_mode="scale_both"
+    )
+
+    # Add stacked area chart to plot
+    area_renderers = plot.vbar_stack(
+        stackers=stacked_cols,
+        x="period",
+        source=source,
+        color=colors,
+        width=0.5,
+    )
+
+    # Keep track of legend items
+    legend_items = [(y, [area_renderers[i]]) for i, y in enumerate(stacked_cols)
+                    if df[y].mean() > 0]
+
+    # Add Legend
+    legend = Legend(items=legend_items)
+    plot.add_layout(legend, 'right')
+    plot.legend[0].items.reverse()  # Reverse legend to match stacked order
+    plot.legend.click_policy = 'hide'  # Add interactivity to the legend
+    # Note: Doesn't rescale the graph down, simply hides the area
+    # Note2: There's currently no way to auto-size legend based on graph size(?)
+    # except for maybe changing font size automatically?
+    show_hide_legend(plot=plot)  # Hide legend on double click
+
+    # Format Axes (labels, number formatting, range, etc.)
+    plot.xaxis.axis_label = "Period"
+    plot.yaxis.axis_label = "Capacity (MW)"
+    plot.yaxis.formatter = NumeralTickFormatter(format="0,0")
+    plot.y_range.end = ylimit  # will be ignored if ylimit is None
+
+    # Add HoverTools for stacked bars/areas
+    for r in area_renderers:
+        technology = r.name
+        hover = HoverTool(
+            tooltips=[
+                ("Period", "@period"),
+                ("Technology", technology),
+                ("Capacity", "@%s{0,0} MW" % technology)
+            ],
+            renderers=[r],
+            toggleable=False)
+        plot.add_tools(hover)
+
+    return plot
+
+
+def main(args=None):
+    """
+    Parse the arguments, get the data in a df, and create the plot
+
+    :return: if requested, return the plot as JSON object
+    """
+    if args is None:
+        args = sys.argv[1:]
+    parsed_args = parse_arguments(arguments=args)
+
+    db = connect_to_database(parsed_arguments=parsed_args)
+    c = db.cursor()
+
+    scenario_location = parsed_args.scenario_location
+    scenario, scenario_id = get_scenario_and_scenario_id(
+        parsed_arguments=parsed_args,
+        c=c
+    )
+
+    plot_title = "Retired Capacity by Period - {}".format(parsed_args.load_zone)
+    # TODO: add capacity type to title?
+    plot_name = "RetiredCapacityPlot-{}".format(parsed_args.load_zone)
+
+    df = create_data_df(
+        c=c,
+        scenario_id=scenario_id,
+        load_zone=parsed_args.load_zone,
+    )
+
+    plot = create_plot(
+        df=df,
+        title=plot_title,
+        ylimit=parsed_args.ylimit
+    )
+
+    # Show plot in HTML browser file if requested
+    if parsed_args.show:
+        show_plot(scenario_directory=scenario_location,
+                  scenario=scenario,
+                  plot=plot,
+                  plot_name=plot_name)
+
+    # Return plot in json format if requested
+    if parsed_args.return_json:
+        return json_item(plot, plot_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/viz/curtailment_hydro_heatmap_plot.py
+++ b/viz/curtailment_hydro_heatmap_plot.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+# Copyright 2017 Blue Marble Analytics LLC. All rights reserved.
+
+"""
+Make plot of scheduled curtailment heatmap (by month and hour)
+"""
+
+# TODO: Find a color palette that is more continuous? E.g. like 'grey' but then
+#   for red. Right now the number of ticks will not always match the 9 colors
+#   in the color bar since the tickmarks are made such that each tick is a round
+#   number but the max value is not always close to 9 * that round number so
+#   sometimes there are less than 9 ticks (or more).
+#   If the palette is continuous, where ticks fall doesn't matter.
+#   Alternatively we can make sure that the maximum value is divisable by the
+#   number of colors/ticks, but that often results in sub-optimal resolution.
+
+
+from argparse import ArgumentParser
+from bokeh.models import NumeralTickFormatter, LinearColorMapper, ColorBar, \
+    BasicTicker
+from bokeh.plotting import figure
+from bokeh.models.tools import HoverTool
+from bokeh.embed import json_item
+from bokeh.palettes import Reds
+
+import pandas as pd
+import sys
+
+# GridPath modules
+from viz.common_functions import connect_to_database, show_plot, \
+    get_scenario_and_scenario_id
+
+
+def parse_arguments(arguments):
+    """
+
+    :return:
+    """
+    parser = ArgumentParser(add_help=True)
+
+    # Scenario name and location options
+    parser.add_argument("--database",
+                        help="The database file path. Defaults to ../db/io.db "
+                             "if not specified")
+    parser.add_argument("--scenario_id", help="The scenario ID. Required if "
+                                              "no --scenario is specified.")
+    parser.add_argument("--scenario", help="The scenario name. Required if "
+                                           "no --scenario_id is specified.")
+    parser.add_argument("--scenario_location",
+                        help="The path to the directory in which to create "
+                             "the scenario directory. Defaults to "
+                             "'../scenarios' if not specified.")
+    parser.add_argument("--load_zone",
+                        help="The name of the load zone. Required.")
+    parser.add_argument("--period",
+                        help="The desired modeling period to plot. Required.")
+    parser.add_argument("--stage", default=1,
+                        help="The stage ID. Defaults to 1.")
+    parser.add_argument("--show",
+                        default=False, action="store_true",
+                        help="Show and save figure to "
+                             "results/figures directory "
+                             "under scenario directory.")
+    parser.add_argument("--return_json",
+                        default=False, action="store_true",
+                        help="Return plot as a json file."
+                        )
+    # Parse arguments
+    parsed_arguments = parser.parse_known_args(args=arguments)[0]
+
+    return parsed_arguments
+
+
+def get_curtailment(c, scenario_id, load_zone, period, stage):
+    """
+    Get curtailment results by month-hour
+    :param c:
+    :param scenario_id:
+    :param load_zone:
+    :param period:
+    :param stage:
+    :return:
+    """
+
+    # Curtailment by period and timepoint
+    sql = """SELECT month, hour_on_horizon, 
+        SUM(scheduled_curtailment_mwh) AS scheduled_curtailment_mwh
+        FROM (
+            SELECT scenario_id, horizon, period, timepoint, 
+            (scheduled_curtailment_mw * horizon_weight * 
+            number_of_hours_in_timepoint) as scheduled_curtailment_mwh, 
+            month, SUM(number_of_hours_in_timepoint) OVER (
+            PARTITION BY horizon ORDER BY timepoint) AS hour_on_horizon
+            FROM results_project_curtailment_hydro
+
+            INNER JOIN
+
+            (SELECT scenario_id, temporal_scenario_id 
+            FROM scenarios)
+            USING (scenario_id)
+
+            INNER JOIN
+
+            (SELECT temporal_scenario_id, period, horizon, month 
+            FROM inputs_temporal_horizons)
+            USING (temporal_scenario_id, period, horizon)
+
+            WHERE scenario_id = ?
+            AND load_zone = ?
+            AND period = ?
+            AND stage_id = ?
+        )
+        GROUP BY month, hour_on_horizon
+        ORDER BY month, hour_on_horizon
+        ;"""
+
+    curtailment = c.execute(sql, (scenario_id, load_zone, period, stage))
+
+    return curtailment
+
+
+def create_data_df(c, scenario_id, load_zone, period, stage):
+    """
+    Get curtailment results into df
+    :param c:
+    :param scenario_id:
+    :param load_zone:
+    :param period:
+    :param stage:
+    :return:
+    """
+
+    # Get curtailment from db
+    curtailment = get_curtailment(c, scenario_id, load_zone, period, stage)
+
+    # Convert SQL query results into DataFrame
+    df = pd.DataFrame(
+        data=curtailment.fetchall(),
+        columns=[n[0] for n in curtailment.description]
+    )
+
+    # Convert month numbers to strings
+    mapper = {
+        1: "Jan",
+        2: "Feb",
+        3: "Mar",
+        4: "Apr",
+        5: "May",
+        6: "Jun",
+        7: "Jul",
+        8: "Aug",
+        9: "Sep",
+        10: "Oct",
+        11: "Nov",
+        12: "Dec"
+    }
+    df.replace({"month": mapper}, inplace=True)
+
+    # Round df (lots of rounding errors it where it should be 0)
+    df = df.round(decimals=5)
+
+    return df
+
+
+def create_plot(df, title):
+    """
+
+    :param df:
+    :param title: string, plot title
+    :return:
+    """
+
+    if df.empty:
+        return figure()
+
+    # Round hours and convert to string (required for x-axis)
+    # TODO: figure out a way to handle subhourly data properly!
+    df["hour_on_horizon"] = df["hour_on_horizon"].map(int).map(str)
+
+    # Get list of hours and months (used in xrange/yrange)
+    hours = list(df["hour_on_horizon"].unique())
+    months = list(reversed(df["month"].unique()))
+
+    # Set up color mapper
+    # colors = ["#75968f", "#a5bab7", "#c9d9d3", "#e2e2e2", "#dfccce",
+    #           "#ddb7b1", "#cc7878", "#933b41", "#550b1d"]
+    colors = list(reversed(Reds[9]))
+
+    mapper = LinearColorMapper(
+        palette=colors,
+        low=df.scheduled_curtailment_mwh.min(),
+        high=df.scheduled_curtailment_mwh.max())
+
+    # Set up the figure
+    plot = figure(
+        plot_width=800, plot_height=500,
+        tools=["pan", "reset", "zoom_in", "zoom_out", "save", "help"],
+        toolbar_location="below",
+        x_axis_location="above",
+        title=title,
+        x_range=hours,
+        y_range=months,
+    )
+
+    # Plot heatmap rectangles
+    hm = plot.rect(
+        x="hour_on_horizon",
+        y="month",
+        width=1, height=1,
+        source=df,
+        fill_color={'field': 'scheduled_curtailment_mwh', 'transform': mapper},
+        line_color="white"
+    )
+
+    # Add color bar legend
+    color_bar = ColorBar(
+        color_mapper=mapper,
+        major_label_text_font_size="7pt",
+        ticker=BasicTicker(desired_num_ticks=len(colors)),
+        formatter=NumeralTickFormatter(format="0,0"),
+        label_standoff=12,
+        border_line_color=None,
+        location=(0, 0)
+    )
+    plot.add_layout(color_bar, 'right')
+
+    # Format Axes (labels, number formatting, range, etc.)
+    plot.xaxis.axis_label = "Hour Ending"
+    plot.yaxis.axis_label = "Month"
+    plot.grid.grid_line_color = None
+    plot.axis.axis_line_color = None
+    plot.axis.major_tick_line_color = None
+    plot.axis.major_label_standoff = 0
+
+    # Add HoverTool
+    hover = HoverTool(
+        tooltips=[
+            ("Month", "@month"),
+            ("Hour", "@hour_on_horizon"),
+            ("Curtailment", "@scheduled_curtailment_mwh{0,0} MWh")
+        ],
+        renderers=[hm],
+        toggleable=True)
+    plot.add_tools(hover)
+
+    return plot
+
+
+def main(args=None):
+    """
+    Parse the arguments, get the data in a df, and create the plot
+
+    :return: if requested, return the plot as JSON object
+    """
+    if args is None:
+        args = sys.argv[1:]
+    parsed_args = parse_arguments(arguments=args)
+
+    db = connect_to_database(parsed_arguments=parsed_args)
+    c = db.cursor()
+
+    scenario_location = parsed_args.scenario_location
+    scenario, scenario_id = get_scenario_and_scenario_id(
+        parsed_arguments=parsed_args,
+        c=c
+    )
+
+    plot_title = "Hydro Curtailment by Month-Hour - {} - {} - {}".format(
+        parsed_args.load_zone, parsed_args.period, parsed_args.stage
+    )
+    plot_name = "HydroCurtailmentPlot-{}-{}-{}".format(
+        parsed_args.load_zone, parsed_args.period, parsed_args.stage)
+
+    df = create_data_df(
+        c=c,
+        scenario_id=scenario_id,
+        load_zone=parsed_args.load_zone,
+        period=parsed_args.period,
+        stage=parsed_args.stage
+    )
+
+    plot = create_plot(
+        df=df,
+        title=plot_title
+    )
+
+    # Show plot in HTML browser file if requested
+    if parsed_args.show:
+        show_plot(scenario_directory=scenario_location,
+                  scenario=scenario,
+                  plot=plot,
+                  plot_name=plot_name)
+
+    # Return plot in json format if requested
+    if parsed_args.return_json:
+        return json_item(plot, plot_name)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Split up the capacity and curtailment scripts into separate scripts for each type of capacity/curtailment (which was previously determined with a script argument). Further refactoring to avoid duplicated code is needed.

Closes #165.