### PR TITLE
Add subproblem/stage index/arg to relevant plots

### DIFF
--- a/viz/capacity_new_plot.py
+++ b/viz/capacity_new_plot.py
@@ -2,8 +2,15 @@
 # Copyright 2017 Blue Marble Analytics LLC. All rights reserved.
 
 """
-Make plot of capacity by period and technology for a certain zone/stage
+Create plot of new capacity by period and technology for a given
+zone/subproblem/stage.
+
+Note: Generally capacity expansion problems will have only one subproblem/stage
+If not specified, the plotting module assumes the subproblem/stage is equal to
+1, which is the default if there's only one subproblem/stage.
 """
+
+# TODO: should we calculate cumulative new capacity instead?
 
 from argparse import ArgumentParser
 from bokeh.models import ColumnDataSource, Legend, NumeralTickFormatter
@@ -41,6 +48,10 @@ def parse_arguments(arguments):
                              "'../scenarios' if not specified.")
     parser.add_argument("--load_zone",
                         help="The name of the load zone. Required.")
+    parser.add_argument("--subproblem", default=1,
+                        help="The subproblem ID. Defaults to 1.")
+    parser.add_argument("--stage", default=1,
+                        help="The stage ID. Defaults to 1.")
     parser.add_argument("--ylimit", help="Set y-axis limit.", type=float)
     parser.add_argument("--show",
                         default=False, action="store_true",
@@ -57,43 +68,63 @@ def parse_arguments(arguments):
     return parsed_arguments
 
 
-def get_capacity(c, scenario_id, load_zone):
+def get_capacity(c, scenario_id, load_zone, subproblem, stage):
     """
     Get capacity results.
     :param c:
     :param scenario_id:
     :param load_zone:
-    :param capacity_type:
+    :param subproblem:
+    :param stage:
     :return:
     """
     # New capacity by period and technology
+    # sql = """SELECT period, technology, sum(new_build_mw) as capacity_mw
+    #     FROM results_project_capacity_new_build_generator
+    #     WHERE scenario_id = ?
+    #     AND load_zone = ?
+    #     GROUP BY period, technology
+    #     UNION
+    #     SELECT period, technology, sum(new_build_mw) as mw
+    #     FROM results_project_capacity_new_build_storage
+    #     WHERE scenario_id = ?
+    #     AND load_zone = ?
+    #     AND subproblem_id = ?
+    #     AND stage_id = ?
+    #     GROUP BY period, technology;"""
+
     sql = """SELECT period, technology, sum(new_build_mw) as capacity_mw
-        FROM results_project_capacity_new_build_generator
+        FROM (SELECT scenario_id, load_zone, subproblem_id, stage_id,
+              project, period, technology, new_build_mw 
+              FROM results_project_capacity_new_build_generator
+              UNION 
+              SELECT scenario_id, load_zone, subproblem_id, stage_id, 
+              project, period, technology, new_build_mw 
+              FROM results_project_capacity_new_build_storage
+             ) as tbl
         WHERE scenario_id = ?
         AND load_zone = ?
-        GROUP BY period, technology
-        UNION
-        SELECT period, technology, sum(new_build_mw) as mw
-        FROM results_project_capacity_new_build_storage
-        WHERE scenario_id = ?
-        AND load_zone = ?
+        AND subproblem_id = ?
+        AND stage_id = ?
         GROUP BY period, technology;"""
-    capacity = c.execute(sql, (scenario_id, load_zone,
-                               scenario_id, load_zone))
+
+    capacity = c.execute(sql, (scenario_id, load_zone, subproblem, stage))
 
     return capacity
 
 
-def create_data_df(c, scenario_id, load_zone):
+def create_data_df(c, scenario_id, load_zone, subproblem, stage):
     """
     Get capacity results and pivot into data df
     :param c:
     :param scenario_id:
     :param load_zone:
+    :param subproblem:
+    :param stage:
     :return:
     """
 
-    capacity = get_capacity(c, scenario_id, load_zone)
+    capacity = get_capacity(c, scenario_id, load_zone, subproblem, stage)
 
     df = pd.DataFrame(
         data=capacity.fetchall(),
@@ -215,14 +246,25 @@ def main(args=None):
         c=c
     )
 
-    plot_title = "New Capacity by Period - {}".format(parsed_args.load_zone)
-    # TODO: add capacity type to title?
-    plot_name = "NewCapacityPlot-{}".format(parsed_args.load_zone)
+    plot_title = "New Capacity by Period - {} - Subproblem {} - Stage {}"\
+        .format(
+            parsed_args.load_zone,
+            parsed_args.subproblem,
+            parsed_args.stage
+        )
+    plot_name = "NewCapacityPlot-{}-{}-{}"\
+        .format(
+            parsed_args.load_zone,
+            parsed_args.subproblem,
+            parsed_args.stage
+        )
 
     df = create_data_df(
         c=c,
         scenario_id=scenario_id,
         load_zone=parsed_args.load_zone,
+        subproblem=parsed_args.subproblem,
+        stage=parsed_args.stage
     )
 
     plot = create_plot(


### PR DESCRIPTION
The capacity, carbon, and rps plots were all based on results that
are indexed by period, subproblem, and stage but they weren't slicing
out a particular subproblem/stage. This update adds a subproblem and
stage argument to each of these plots to slice out the appropriate
results.

When no subproblem/stage is provided, the default is set to 1 which is
assumed to be the default subproblem/stage when running the model in
capacity expansion mode.

Note: we might want to disallow users to combine RPS/carbon cap/new
build functionality with multi subproblem/stage functionality anyway
since usually this will be meaingless
(see issues #99, #173, and #175).

Closes #173