### PR TITLE
Add timestamp to input validation table

### DIFF
--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -114,6 +114,7 @@ related_subscenario VARCHAR(64),
 related_database_table VARCHAR(64),
 issue_type VARCHAR(32),
 issue_description VARCHAR(64),
+timestamp TEXT  -- ISO8601 String
 FOREIGN KEY (scenario_id) REFERENCES scenarios (scenario_id)
 );
 

--- a/gridpath/auxiliary/auxiliary.py
+++ b/gridpath/auxiliary/auxiliary.py
@@ -313,12 +313,15 @@ def write_validation_to_database(validation_results, conn):
     :param conn: database connection
     :return:
     """
+    # add timestamp (ISO8601 strings, so truncate to ms)
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    validation_results = [row + (timestamp,) for row in validation_results]
     c = conn.cursor()
     for row in validation_results:
         query = """INSERT into mod_input_validation
                 (scenario_id, subproblem_id, stage_id, 
                 gridpath_module, related_subscenario, related_database_table, 
-                issue_type, issue_description)
+                issue_type, issue_description, timestamp)
                 VALUES ({});""".format(','.join(['?' for item in row]))
 
         c.execute(query, row)


### PR DESCRIPTION
This helps the user determine when the validation was run.

Note: this requires a change in the mod_input_validation database table
structure (additional column).

Closes #170