### PR TITLE
Rename status tables

### DIFF
--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -76,36 +76,28 @@ PRIMARY KEY (feature, subscenario_id),
 FOREIGN KEY (feature) REFERENCES mod_features (feature)
 );
 
--- Scenario validation status
+-- Scenario validation status types
 DROP TABLE IF EXISTS mod_validation_status_types;
 CREATE TABLE mod_validation_status_types (
 validation_status_id INTEGER PRIMARY KEY,
 validation_status_name VARCHAR(32) UNIQUE
 );
 
--- Run status
+-- Run status types
 DROP TABLE IF EXISTS mod_run_status_types;
 CREATE TABLE mod_run_status_types (
 run_status_id INTEGER PRIMARY KEY,
 run_status_name VARCHAR(32) UNIQUE
 );
 
--- TODO: figure out foreign keys for subproblems/stages when structure in place
--- TODO: what happens if user deletes scenario in scenarios table
-DROP TABLE IF EXISTS mod_run_status;
-CREATE TABLE mod_run_status (
-scenario_id INTEGER,
-scenario_name VARCHAR(64),
-subproblem_id INTEGER,
-stage_id INTEGER,
-status VARCHAR(32),
-FOREIGN KEY (scenario_id) REFERENCES scenarios (scenario_id),
-FOREIGN KEY (status) REFERENCES mod_run_status_types (run_status_id)
-);
+
+--------------------
+-- -- STATUS -- --
+--------------------
 
 -- Validation Results
-DROP TABLE IF EXISTS mod_input_validation;
-CREATE TABLE mod_input_validation (
+DROP TABLE IF EXISTS status_validation;
+CREATE TABLE status_validation (
 scenario_id INTEGER,
 subproblem_id INTEGER,
 stage_id INTEGER,
@@ -117,6 +109,11 @@ issue_description VARCHAR(64),
 timestamp TEXT,  -- ISO8601 String
 FOREIGN KEY (scenario_id) REFERENCES scenarios (scenario_id)
 );
+
+
+-------------------------------------------------------------------------------
+---- SUBSCENARIOS AND INPUTS -----
+-------------------------------------------------------------------------------
 
 --------------------
 -- -- TEMPORAL -- --

--- a/gridpath/auxiliary/auxiliary.py
+++ b/gridpath/auxiliary/auxiliary.py
@@ -318,7 +318,7 @@ def write_validation_to_database(validation_results, conn):
     validation_results = [row + (timestamp,) for row in validation_results]
     c = conn.cursor()
     for row in validation_results:
-        query = """INSERT into mod_input_validation
+        query = """INSERT INTO status_validation
                 (scenario_id, subproblem_id, stage_id, 
                 gridpath_module, related_subscenario, related_database_table, 
                 issue_type, issue_description, timestamp)

--- a/gridpath/validate_inputs.py
+++ b/gridpath/validate_inputs.py
@@ -259,7 +259,7 @@ def reset_input_validation(conn, scenario_id):
     """
     c = conn.cursor()
     c.execute(
-        """DELETE FROM mod_input_validation
+        """DELETE FROM status_validation
         WHERE scenario_id = {};""".format(str(scenario_id))
     )
 
@@ -282,7 +282,7 @@ def update_validation_status(conn, scenario_id):
     c = conn.cursor()
     validations = c.execute(
         """SELECT scenario_id 
-        FROM mod_input_validation
+        FROM status_validation
         WHERE scenario_id = {}""".format(str(scenario_id))
     ).fetchall()
 

--- a/ui/src/app/scenario-detail/scenario-detail.component.ts
+++ b/ui/src/app/scenario-detail/scenario-detail.component.ts
@@ -147,7 +147,7 @@ export class ScenarioDetailComponent implements OnInit {
 
   viewValidationErrors(): void {
     const navigationExtras: NavigationExtras = {
-      state: {table: 'mod_input_validation'}
+      state: {table: 'status_validation'}
     };
     this.router.navigate(['/view-data', this.scenarioID],
       navigationExtras);


### PR DESCRIPTION
Renamed the `mod_input_validation` table to `status_validation` and deleted the `mod_run_status` table since it's actually not used at this point.

Closes #159.