### PR TITLE
Restructure and refactor viz suite

### DIFF
--- a/gridpath/auxiliary/auxiliary.py
+++ b/gridpath/auxiliary/auxiliary.py
@@ -260,15 +260,19 @@ class Logging(object):
         self.log_file.flush()
 
 
+# TODO: handle non-existing scenarios/scenario_ids
 def get_scenario_id_and_name(scenario_id_arg, scenario_name_arg, c, script):
     """
-    huh
+    Get the scenario_id and the scenario_ name. Usually only one is given (the
+    other one will be 'None'), so this functions determine the missing one from
+    the one that is provided. If both are provided, this function checks whether
+    they match.
 
     :param scenario_id_arg: 
     :param scenario_name_arg: 
     :param c: 
     :param script: 
-    :return: 
+    :return: (scenario_id, scenario_name)
     """
     if scenario_id_arg is None and scenario_name_arg is None:
         raise TypeError(

--- a/viz/capacity_factor_plot.py
+++ b/viz/capacity_factor_plot.py
@@ -18,8 +18,8 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
-from viz.common_functions import show_hide_legend, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
+from viz.common_functions import show_hide_legend, show_plot, get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -231,9 +231,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="capacity_factor_plot"
     )
 
     plot_title = "Capacity Factors by Period - {} - Stage {}".format(

--- a/viz/capacity_new_plot.py
+++ b/viz/capacity_new_plot.py
@@ -20,8 +20,9 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
 from viz.common_functions import create_stacked_bar_plot, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+    get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -97,9 +98,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="capacity_new_plot"
     )
 
     plot_title = "New Capacity by Period - {} - Subproblem {} - Stage {}"\

--- a/viz/capacity_retired_plot.py
+++ b/viz/capacity_retired_plot.py
@@ -21,8 +21,9 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
 from viz.common_functions import create_stacked_bar_plot, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+    get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -98,9 +99,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="capacity_retired_plot"
     )
 
     plot_title = \

--- a/viz/capacity_total_loadzone_comparison_plot.py
+++ b/viz/capacity_total_loadzone_comparison_plot.py
@@ -15,8 +15,9 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
 from viz.common_functions import create_stacked_bar_plot, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+    get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -85,9 +86,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="capacity_total_loadzone_comparison_plot"
     )
 
     plot_title = "Total Capacity by Load Zone - {} - Subproblem {} - Stage {}"\

--- a/viz/capacity_total_plot.py
+++ b/viz/capacity_total_plot.py
@@ -14,8 +14,9 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
 from viz.common_functions import create_stacked_bar_plot, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+    get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -84,9 +85,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="capacity_total_plot"
     )
 
     plot_title = \

--- a/viz/capacity_total_scenario_comparison_plot.py
+++ b/viz/capacity_total_scenario_comparison_plot.py
@@ -16,7 +16,7 @@ import sys
 # GridPath modules
 from db.common_functions import connect_to_database
 from viz.common_functions import create_stacked_bar_plot, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+    get_parent_parser
 
 
 def parse_arguments(arguments):

--- a/viz/carbon_plot.py
+++ b/viz/carbon_plot.py
@@ -21,8 +21,8 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
-from viz.common_functions import show_hide_legend, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
+from viz.common_functions import show_hide_legend, show_plot, get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -233,9 +233,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="carbon_plot"
     )
 
     plot_title = "Carbon Emissions by Period - {} - Subproblem {} - Stage {}"\

--- a/viz/common_functions.py
+++ b/viz/common_functions.py
@@ -64,44 +64,6 @@ def show_plot(plot, plot_name, plot_write_directory, scenario=None):
     show(plot)
 
 
-# TODO: handle non-existing scenarios/scenario_ids
-def get_scenario_and_scenario_id(parsed_arguments, c):
-    """
-    Get the scenario and the scenario_id from the parsed arguments.
-
-    Usually only one is given, so we determine the missing one from the one
-    that is provided.
-
-    :param parsed_arguments:
-    :param c:
-    :return:
-    """
-
-    if parsed_arguments.scenario_id is None \
-            and parsed_arguments.scenario is None:
-        raise IOError("Missing scenario input arguments. Please provide at "
-                      "least one of the following arguments to the script:"
-                      " '--scenario' or '--scenario_id'")
-    elif parsed_arguments.scenario_id is None:
-        scenario = parsed_arguments.scenario
-        # Get the scenario ID
-        scenario_id = c.execute(
-            """SELECT scenario_id
-            FROM scenarios
-            WHERE scenario_name = '{}';""".format(scenario)
-        ).fetchone()[0]
-    else:
-        scenario_id = parsed_arguments.scenario_id
-        # Get the scenario name
-        scenario = c.execute(
-            """SELECT scenario_name
-            FROM scenarios
-            WHERE scenario_id = {};""".format(scenario_id)
-        ).fetchone()[0]
-
-    return scenario, scenario_id
-
-
 def get_parent_parser():
     """
     Create "parent" ArgumentParser object which has the common set of arguments

--- a/viz/cost_plot.py
+++ b/viz/cost_plot.py
@@ -13,8 +13,9 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
 from viz.common_functions import create_stacked_bar_plot, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+    get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -175,9 +176,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="cost_plot"
     )
 
     plot_title = "Total Cost by Period - {} - Stage {}".format(

--- a/viz/curtailment_hydro_heatmap_plot.py
+++ b/viz/curtailment_hydro_heatmap_plot.py
@@ -28,7 +28,8 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
-from viz.common_functions import show_plot, get_scenario_and_scenario_id, get_parent_parser
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
+from viz.common_functions import show_plot, get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -197,9 +198,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="curtailment_hydro_heatmap_plot"
     )
 
     plot_title = "Hydro Curtailment by Month-Hour - {} - {} - {}".format(

--- a/viz/curtailment_variable_heatmap_plot.py
+++ b/viz/curtailment_variable_heatmap_plot.py
@@ -28,8 +28,8 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
-from viz.common_functions import show_plot, get_scenario_and_scenario_id, \
-    get_parent_parser
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
+from viz.common_functions import show_plot, get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -198,9 +198,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="curtailment_variable_heatmap_plot"
     )
 
     plot_title = "VER Curtailment by Month-Hour - {} - {} - {}".format(

--- a/viz/dispatch_plot.py
+++ b/viz/dispatch_plot.py
@@ -24,8 +24,8 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
-from viz.common_functions import show_hide_legend, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
+from viz.common_functions import show_hide_legend, show_plot, get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -613,9 +613,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="dispatch_plot"
     )
 
     plot_title = "Dispatch Plot - {} - Stage {} - Horizon {}".format(

--- a/viz/energy_plot.py
+++ b/viz/energy_plot.py
@@ -13,8 +13,9 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
 from viz.common_functions import create_stacked_bar_plot, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+    get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -94,11 +95,12 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="energy_plot"
     )
-
     plot_title = "Energy by Period - {} - Stage {}".format(
         parsed_args.load_zone, parsed_args.stage)
     plot_name = "EnergyPlot-{}-{}".format(

--- a/viz/project_operations_plot.py
+++ b/viz/project_operations_plot.py
@@ -22,8 +22,8 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
-from viz.common_functions import show_hide_legend, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
+from viz.common_functions import show_hide_legend, show_plot, get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -353,9 +353,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="project_operations_plot"
     )
 
     plot_title = "Operations Plot - {} - {} - Stage {}".format(

--- a/viz/rps_plot.py
+++ b/viz/rps_plot.py
@@ -25,8 +25,8 @@ import sys
 
 # GridPath modules
 from db.common_functions import connect_to_database
-from viz.common_functions import show_hide_legend, show_plot, \
-    get_scenario_and_scenario_id, get_parent_parser
+from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
+from viz.common_functions import show_hide_legend, show_plot, get_parent_parser
 
 
 def parse_arguments(arguments):
@@ -225,9 +225,11 @@ def main(args=None):
     conn = connect_to_database(db_path=parsed_args.database)
     c = conn.cursor()
 
-    scenario, scenario_id = get_scenario_and_scenario_id(
-        parsed_arguments=parsed_args,
-        c=c
+    scenario_id, scenario = get_scenario_id_and_name(
+        scenario_id_arg=parsed_args.scenario_id,
+        scenario_name_arg=parsed_args.scenario,
+        c=c,
+        script="rps_plot"
     )
 
     plot_title = "RPS Result by Period - {} - Subproblem {} - Stage {}".format(


### PR DESCRIPTION
Changes:
 - use parent parser for common arguments to be parsed for all the plots
 - change parse_known_args to parse_args so we throw an error when we
   try and pass unknown arguments
 - add required flags and types to parser to give clearer error messages
 - factor out the stacked bar chart creation for all charts that use it
   (costs, capacity, energy). Note that this will make creating any new
   stacked bar plot very easy.
 - add new stacked bar charts for scenario comparison for capacity and
   load zone comparison for capacity
 - simplify process of sql to dataframe using pd.read_sql rather than
   a 2-step process
 - standardize naming of the plotting data functions
 - rename database connection param from 'db'  to 'conn' for clarity
   and consistency

Note: this is a first step in generalizing the viz suite and should make
creating new plots easier, especially if it is a stacked bar chart.
There could be further generalizations but a lot of these would require
major re-structuring and would possibly make future plots less flexible.