### PR TITLE
UI plots accept default values for stage/subproblem

### DIFF
--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -3530,6 +3530,7 @@ rps_zone_form_control INTEGER,
 carbon_cap_zone_form_control INTEGER,
 period_form_control INTEGER,
 horizon_form_control INTEGER,
+subproblem_form_control INTEGER,
 stage_form_control INTEGER,
 project_form_control INTEGER
 );

--- a/ui/server/create_api.py
+++ b/ui/server/create_api.py
@@ -113,7 +113,8 @@ def add_scenario_results_resources(api, db_path):
     api.add_resource(
         ScenarioResultsPlot,
         '/scenarios/<scenario_id>/results/<plot>/<load_zone>/<rps_zone>'
-        '/<carbon_cap_zone>/<period>/<horizon>/<stage>/<project>/<ymax>',
+        '/<carbon_cap_zone>/<period>/<horizon>/<subproblem>/<stage>/<project'
+        '>/<ymax>',
         resource_class_kwargs={'db_path': db_path}
     )
 

--- a/ui/src/app/scenario-results/scenario-results.component.html
+++ b/ui/src/app/scenario-results/scenario-results.component.html
@@ -73,6 +73,13 @@
                     <option>{{opt}}</option>
                   </ng-container>
                 </select>
+                <select class="custom-select" formControlName="subproblem"
+                        *ngIf="formGroup.value['subproblem'] !== 'default'">
+                  <ng-container
+                    *ngFor="let opt of formOptions.subproblemOptions">
+                    <option>{{opt}}</option>
+                  </ng-container>
+                </select>
                 <select class="custom-select" formControlName="stage"
                         *ngIf="formGroup.value['stage'] !== 'default'">
                   <ng-container

--- a/ui/src/app/scenario-results/scenario-results.component.ts
+++ b/ui/src/app/scenario-results/scenario-results.component.ts
@@ -132,6 +132,7 @@ export class ScenarioResultsComponent implements OnInit {
             carbonCapZone: plot.carbonCapZone,
             period: plot.period,
             horizon: plot.horizon,
+            subproblem: plot.subproblem,
             stage: plot.stage,
             project: plot.project,
             yMax: null
@@ -141,6 +142,9 @@ export class ScenarioResultsComponent implements OnInit {
       });
   }
 
+  // This function is called when a user requests a plot; this will change
+  // some values, namely the plotHTMLTarget and then call ngOnInit, which
+  // in turn calls getResultPlot
   showPlot(formGroup): void {
     // We need to set the plotFormValue and plotHTMLTarget before
     // calling ngOnInit to be able to embed the plot
@@ -152,14 +156,25 @@ export class ScenarioResultsComponent implements OnInit {
     const rpsZone = formGroup.value.rpsZone;
     const period = formGroup.value.period;
     const horizon = formGroup.value.horizon;
-    const stage = formGroup.value.stage;
+    // Set subproblem to 'default' if it is null or 'Select Subproblem' (either
+    // because the user didn't select a subproblem, selected the prompt, or
+    // because we didn't give the subproblem option
+    const subproblem = (formGroup.value.subproblem == null) ? 'default'
+      : (formGroup.value.subproblem === 'Select Subproblem') ? 'default'
+        : formGroup.value.subproblem;
+    // Set stage to 'default' if it is null or 'Select Stage' (either
+    // because the user didn't select a stage, selected the prompt, or
+    // because we didn't give the stage option
+    const stage = (formGroup.value.stage == null) ? 'default'
+      : (formGroup.value.stage === 'Select Stage') ? 'default'
+        : formGroup.value.stage;
     const project = formGroup.value.project;
     let yMax = formGroup.value.yMax;
     if (yMax === null) { yMax = 'default'; }
 
     this.scenarioResultsService.getResultsPlot(
       this.scenarioID, plotType, loadZone, rpsZone, carbonCapZone,
-      period, horizon, stage, project, yMax
+      period, horizon, subproblem, stage, project, yMax
     ).subscribe(resultsPlot => {
         this.plotHTMLTarget = resultsPlot.plotJSON.target_id;
         this.resultsToShow = resultsPlot.plotJSON.target_id;
@@ -167,6 +182,7 @@ export class ScenarioResultsComponent implements OnInit {
       });
   }
 
+  // This function is called in ngOnInit
   getResultsPlot(scenarioID, formGroup): void {
     const plotType = formGroup.value.plotType;
     const loadZone = formGroup.value.loadZone;
@@ -174,14 +190,25 @@ export class ScenarioResultsComponent implements OnInit {
     const rpsZone = formGroup.value.rpsZone;
     const period = formGroup.value.period;
     const horizon = formGroup.value.horizon;
-    const stage = formGroup.value.stage;
+    // Set subproblem to 'default' if it is null or 'Select Subproblem' (either
+    // because the user didn't select a subproblem, selected the prompt, or
+    // because we didn't give the subproblem option
+    const subproblem = (formGroup.value.subproblem == null) ? 'default'
+      : (formGroup.value.subproblem === 'Select Subproblem') ? 'default'
+        : formGroup.value.subproblem;
+    // Set stage to 'default' if it is null or 'Select Stage' (either
+    // because the user didn't select a stage, selected the prompt, or
+    // because we didn't give the stage option
+    const stage = (formGroup.value.stage == null) ? 'default'
+      : (formGroup.value.stage === 'Select Stage') ? 'default'
+        : formGroup.value.stage;
     const project = formGroup.value.project;
     let yMax = formGroup.value.yMax;
     if (yMax === null) { yMax = 'default'; }
 
     this.scenarioResultsService.getResultsPlot(
       scenarioID, plotType, loadZone, rpsZone, carbonCapZone,
-      period, horizon, stage, project, yMax
+      period, horizon, subproblem, stage, project, yMax
     ).subscribe(resultsPlot => {
         this.resultsPlot = resultsPlot.plotJSON;
         Bokeh.embed.embed_item(this.resultsPlot);

--- a/ui/src/app/scenario-results/scenario-results.service.ts
+++ b/ui/src/app/scenario-results/scenario-results.service.ts
@@ -34,11 +34,12 @@ export class ScenarioResultsService {
     carbonCapZone: string,
     period: number,
     horizon: number,
+    subproblem: number,
     stage: number,
     project: string,
     yMax: number
   ): Observable<ScenarioResultsPlot> {
-    return this.http.get<ScenarioResultsPlot>(`${this.scenariosBaseURL}${scenarioID}/results/${plotType}/${loadZone}/${rpsZone}/${carbonCapZone}/${period}/${horizon}/${stage}/${project}/${yMax}`
+    return this.http.get<ScenarioResultsPlot>(`${this.scenariosBaseURL}${scenarioID}/results/${plotType}/${loadZone}/${rpsZone}/${carbonCapZone}/${period}/${horizon}/${subproblem}/${stage}/${project}/${yMax}`
     );
   }
 

--- a/ui/src/app/scenario-results/scenario-results.ts
+++ b/ui/src/app/scenario-results/scenario-results.ts
@@ -18,6 +18,7 @@ export class ResultsOptions {
   carbonCapZoneOptions: [];
   periodOptions: [];
   horizonOptions: [];
+  subproblemOptions: [];
   stageOptions: [];
   projectOptions: [];
 }
@@ -30,6 +31,7 @@ export class IncludedPlotFormBuilderAPI {
   'rpsZone': [] | string;
   'period': [] | string;
   'horizon': [] | string;
+  'subproblem': [] | string;
   'stage': [] | string;
   'project': [] | string;
 }


### PR DESCRIPTION
This adds subproblem as a dropdown for the UI plots. If the user does
not specify a subproblem and/or stage, the default values, as specified
in the plot script arguments, are used as respective flag is not
passed. This also makes it possible to omit the dropdowns when we only
have a single subproblem and/or a single stage, as in that case the
script defaults are also used.

Closes #185.