### PR TITLE
Select Python environment directory in UI

### DIFF
--- a/ui/src/app/settings/settings.component.html
+++ b/ui/src/app/settings/settings.component.html
@@ -73,8 +73,8 @@
                    placeholder="GridPath Python environment directory"
                    type="text"
                    [(ngModel)]="requestedPythonDirectory">
-            <button id="browsePythonBinary" class="button-primary"
-                    (click)="browsePythonBinary()">Browse</button>
+            <button id="browsePythonEnvironment" class="button-primary"
+                    (click)="browsePythonEnvironment()">Browse</button>
           </td>
           <td  [ngClass]="{
               'orange' : pythonStatus == 'restart required',

--- a/ui/src/app/settings/settings.component.ts
+++ b/ui/src/app/settings/settings.component.ts
@@ -62,13 +62,13 @@ export class SettingsComponent implements OnInit {
     this.zone.run(() => {
       this.currentScenariosDirectory = data.currentScenariosDirectory.value;
       this.currentGridPathDB = data.currentGridPathDatabase.value;
-      this.currentPythonDirectory = data.currentPythonBinary.value;
+      this.currentPythonDirectory = data.currentPythonEnvironment.value;
       this.currentCbcExecutable = data.currentCbcExecutable.value;
       this.currentCPLEXExecutable = data.currentCPLEXExecutable.value;
       this.currentGurobiExecutable = data.currentGurobiExecutable.value;
       this.requestedScenariosDirectory = data.requestedScenariosDirectory.value;
       this.requestedGridPathDB = data.requestedGridPathDatabase.value;
-      this.requestedPythonDirectory = data.requestedPythonBinary.value;
+      this.requestedPythonDirectory = data.requestedPythonEnvironment.value;
       this.requestedCbcExecutable = data.requestedCbcExecutable.value;
       this.requestedCPLEXExecutable = data.requestedCPLEXExecutable.value;
       this.requestedGurobiExecutable = data.requestedGurobiExecutable.value;
@@ -135,7 +135,7 @@ export class SettingsComponent implements OnInit {
     });
   }
 
-  browsePythonBinary() {
+  browsePythonEnvironment() {
     // Open an Electron dialog to select the folder
     electron.remote.dialog.showOpenDialog(
       {title: 'Select a the Python environment directory',
@@ -146,7 +146,7 @@ export class SettingsComponent implements OnInit {
           return;
       } else {
         // Send Electron the selected folder
-        electron.ipcRenderer.send('setPythonBinarySetting', folderPath[0]);
+        electron.ipcRenderer.send('setPythonEnvironmentSetting', folderPath[0]);
         // Update the Angular component
         this.zone.run( () => {
           this.requestedPythonDirectory = folderPath[0];

--- a/ui/src/electron-main.js
+++ b/ui/src/electron-main.js
@@ -25,10 +25,10 @@ function createMainWindow () {
         const requiredKeys = [
           'currentGridPathDatabase',
           'currentScenariosDirectory',
-          'currentPythonBinary',
+          'currentPythonEnvironment',
           'requestedGridPathDatabase',
           'requestedScenariosDirectory',
-          'requestedPythonBinary',
+          'requestedPythonEnvironment',
         ];
 
         // TODO: should a solver be required; currently not (user can
@@ -196,15 +196,15 @@ ipcMain.on('setGridPathDatabaseSetting', (event, gpDB) => {
   );
 });
 
-// Set the Python binary setting based on Angular input
+// Set the Python environment setting based on Angular input
 // Get setting from renderer and store it
-ipcMain.on('setPythonBinarySetting', (event, pythonbinary) => {
-	console.log(`Python binary directory set to ${pythonbinary}`);
+ipcMain.on('setPythonEnvironmentSetting', (event, pythonenvironment) => {
+	console.log(`Python environment directory set to ${pythonenvironment}`);
 	// TODO: do we need to keep in storage?
-  // Set the Python binary path in Electron JSON storage
+  // Set the Python environment path in Electron JSON storage
   storage.set(
-      'requestedPythonBinary',
-      { 'value': pythonbinary },
+      'requestedPythonEnvironment',
+      { 'value': pythonenvironment },
       (error) => {if (error) throw error;}
   );
 });
@@ -257,13 +257,13 @@ function startServer () {
     [
       'currentGridPathDatabase',
       'currentScenariosDirectory',
-      'currentPythonBinary',
+      'currentPythonEnvironment',
       'currentCbcExecutable',
       'currentCPLEXExecutable',
       'currentGurobiExecutable',
       'requestedGridPathDatabase',
       'requestedScenariosDirectory',
-      'requestedPythonBinary',
+      'requestedPythonEnvironment',
       'requestedCbcExecutable',
       'requestedCPLEXExecutable',
       'requestedGurobiExecutable'
@@ -298,13 +298,13 @@ function startServer () {
           (error) => {if (error) throw error;}
         );
       }
-      if (data['currentPythonBinary']['value']
-        === data['requestedPythonBinary']['value']) {
+      if (data['currentPythonEnvironment']['value']
+        === data['requestedPythonEnvironment']['value']) {
         console.log("Current and requested Python directories match.")
       } else {
         storage.set(
-          'currentPythonBinary',
-          { 'value': data['requestedPythonBinary']['value'] },
+          'currentPythonEnvironment',
+          { 'value': data['requestedPythonEnvironment']['value'] },
           (error) => {
             if (error) throw error;
           }
@@ -350,7 +350,7 @@ function startServer () {
 
       const dbPath = data['requestedGridPathDatabase']['value'];
       const scenariosDir = data['requestedScenariosDirectory']['value'];
-      const pyDir = data['requestedPythonBinary']['value'];
+      const pyDir = data['requestedPythonEnvironment']['value'];
       const cbcExec = data['requestedCbcExecutable']['value'];
       const cplexExec = data['requestedCPLEXExecutable']['value'];
       const gurobiExec = data['requestedGurobiExecutable']['value'];
@@ -447,7 +447,7 @@ ipcMain.on('requestStoredSettings', (event) => {
     storage.getMany(
       ['currentScenariosDirectory', 'requestedScenariosDirectory',
         'currentGridPathDatabase', 'requestedGridPathDatabase',
-        'currentPythonBinary', 'requestedPythonBinary',
+        'currentPythonEnvironment', 'requestedPythonEnvironment',
         'currentCbcExecutable', 'requestedCbcExecutable',
         'currentCPLEXExecutable', 'requestedCPLEXExecutable',
         'currentGurobiExecutable', 'requestedGurobiExecutable'


### PR DESCRIPTION
Select the main Python environment directory instead of the binary directory within the environment. This should reduce confusion. On Windows, we then look for the 'Scripts' directory to find the server entry point; on Mac/Linux the executables are in the 'bin' directory. This should reduce confusion and I hope addresses the issue in #162 (which I haven't been able to reproduce).