### PR TITLE
Clean up tuning costs modules

### DIFF
--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -1899,6 +1899,18 @@ local_capacity_zone)
 );
 
 -- Case tuning
+-- We can apply additional costs in the model to prevent degeneracy
+-- Currently this includes:
+-- 1) Carbon Imports (see objective.transmission.carbon_imports_tuning_costs
+-- module; prevents the carbon imports expression from being set above actual
+-- flow x intensity in situations when the carbon cap is non-binding)
+-- 2) Ramps (see project.operations.tuning_costs module; applies to
+-- hydro and storage operational types only and prevents erratic-looking
+-- dispatch for these zero-variable-cost resources in case of degeneracy)
+-- 3) Dynamic ELCC (see objective.reliability.prm
+-- .dynamic_elcc_tuning_penalties module; ensures that the dynamic ELCC is set
+-- to the maximum available in
+-- case the PRM constraint is non-binding.
 DROP TABLE IF EXISTS subscenarios_tuning;
 CREATE TABLE subscenarios_tuning (
 tuning_scenario_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1909,9 +1921,9 @@ description VARCHAR(128)
 DROP TABLE IF EXISTS inputs_tuning;
 CREATE TABLE inputs_tuning (
 tuning_scenario_id INTEGER PRIMARY KEY,
-import_carbon_tuning_cost DOUBLE,
-ramp_tuning_cost DOUBLE,
-dynamic_elcc_tuning_cost DOUBLE,
+import_carbon_tuning_cost_per_ton DOUBLE,
+ramp_tuning_cost_per_mw DOUBLE,  -- applies to hydro and storage only
+dynamic_elcc_tuning_cost_per_mw DOUBLE,
 FOREIGN KEY (tuning_scenario_id) REFERENCES subscenarios_tuning
 (tuning_scenario_id)
 );

--- a/gridpath/objective/transmission/carbon_imports_tuning_costs.py
+++ b/gridpath/objective/transmission/carbon_imports_tuning_costs.py
@@ -9,7 +9,7 @@ on the line times the emissions intensity. In the case, this constraint is
 non-binding -- and without a tuning cost, the optimization is allowed to
 set Import_Carbon_Emissions higher than the product of flow and emissions
 rate. Adding a tuning cost prevents that behavior as it pushes the emissions
-variable down to be equal
+variable down to be equal.
 """
 
 from builtins import next
@@ -28,7 +28,7 @@ def add_model_components(m, d):
     :return:
     """
 
-    m.import_carbon_tuning_cost = Param(default=0)
+    m.import_carbon_tuning_cost_per_ton = Param(default=0)
 
     def total_import_carbon_tuning_cost_rule(mod):
         """
@@ -38,7 +38,7 @@ def add_model_components(m, d):
         """
         return sum(
             mod.Import_Carbon_Emissions_Tons[tx, tmp]
-            * mod.import_carbon_tuning_cost
+            * mod.import_carbon_tuning_cost_per_ton
             * mod.number_of_hours_in_timepoint[tmp]
             * mod.timepoint_weight[tmp]
             * mod.number_years_represented[mod.period[tmp]]
@@ -72,8 +72,8 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
 
     if os.path.exists(tuning_param_file):
         data_portal.load(filename=tuning_param_file,
-                         select=("import_carbon_tuning_cost",),
-                         param=m.import_carbon_tuning_cost
+                         select=("import_carbon_tuning_cost_per_ton",),
+                         param=m.import_carbon_tuning_cost_per_ton
                          )
     else:
         pass
@@ -89,7 +89,7 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     """
     c = conn.cursor()
     import_carbon_tuning_cost = c.execute(
-        """SELECT import_carbon_tuning_cost
+        """SELECT import_carbon_tuning_cost_per_ton
         FROM inputs_tuning
         WHERE tuning_scenario_id = {}""".format(
             subscenarios.TUNING_SCENARIO_ID
@@ -140,7 +140,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
             # Append column header
             header = next(reader)
-            header.append("import_carbon_tuning_cost")
+            header.append("import_carbon_tuning_cost_per_ton")
             new_rows.append(header)
 
             # Append tuning param value
@@ -159,5 +159,5 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                   "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t")
-            writer.writerows(["import_carbon_tuning_cost"])
+            writer.writerows(["import_carbon_tuning_cost_per_ton"])
             writer.writerows([import_carbon_tuning_cost])

--- a/gridpath/project/operations/tuning_costs.py
+++ b/gridpath/project/operations/tuning_costs.py
@@ -26,7 +26,7 @@ def add_model_components(m, d):
     :return:
     """
 
-    m.ramp_tuning_cost = Param(default=0)
+    m.ramp_tuning_cost_per_mw = Param(default=0)
 
     # Import needed operational modules
     imported_operational_modules = \
@@ -67,7 +67,7 @@ def add_model_components(m, d):
         """
         gen_op_type = mod.operational_type[g]
         tuning_cost = \
-            mod.ramp_tuning_cost if gen_op_type in [
+            mod.ramp_tuning_cost_per_mw if gen_op_type in [
                 "hydro_curtailable", "hydro_noncurtailable", "storage_generic"
             ] else 0
         if tmp == mod.first_horizon_timepoint[
@@ -96,7 +96,7 @@ def add_model_components(m, d):
         """
         gen_op_type = mod.operational_type[g]
         tuning_cost = \
-            mod.ramp_tuning_cost \
+            mod.ramp_tuning_cost_per_mw \
             if gen_op_type in ["hydro_curtailable", "hydro_noncurtailable"] \
             else 0
         if tmp == mod.first_horizon_timepoint[
@@ -134,8 +134,8 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
 
     if os.path.exists(tuning_param_file):
         data_portal.load(filename=tuning_param_file,
-                         select=("ramp_tuning_cost",),
-                         param=m.ramp_tuning_cost
+                         select=("ramp_tuning_cost_per_mw",),
+                         param=m.ramp_tuning_cost_per_mw
                          )
     else:
         pass
@@ -151,7 +151,7 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     """
     c = conn.cursor()
     ramp_tuning_cost = c.execute(
-        """SELECT ramp_tuning_cost
+        """SELECT ramp_tuning_cost_per_mw
         FROM inputs_tuning
         WHERE tuning_scenario_id = {}""".format(
             subscenarios.TUNING_SCENARIO_ID
@@ -203,7 +203,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
             # Append column header
             header = next(reader)
-            header.append("import_carbon_tuning_cost")
+            header.append("ramp_tuning_cost_per_mw")
             new_rows.append(header)
 
             # Append tuning param value
@@ -222,5 +222,5 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                   "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t")
-            writer.writerow(["ramp_tuning_cost"])
+            writer.writerow(["ramp_tuning_cost_per_mw"])
             writer.writerow([ramp_tuning_cost])

--- a/tests/objective/system/reliability/prm/test_dynamic_elcc_tuning_penalties.py
+++ b/tests/objective/system/reliability/prm/test_dynamic_elcc_tuning_penalties.py
@@ -90,7 +90,7 @@ class TestDynamicELCCTuningPenalties(unittest.TestCase):
         instance = m.create_instance(data)
 
         # Param: dynamic_elcc_tuning_cost
-        self.assertEqual(instance.dynamic_elcc_tuning_cost, 10e-10)
+        self.assertEqual(instance.dynamic_elcc_tuning_cost_per_mw, 10e-10)
 
 
 if __name__ == "__main__":

--- a/tests/objective/transmission/test_carbon_imports_tuning_costs.py
+++ b/tests/objective/transmission/test_carbon_imports_tuning_costs.py
@@ -87,7 +87,7 @@ class TestTxAggregateCosts(unittest.TestCase):
         instance = m.create_instance(data)
 
         # Param: import_carbon_tuning_cost
-        self.assertEqual(instance.import_carbon_tuning_cost, 10e-10)
+        self.assertEqual(instance.import_carbon_tuning_cost_per_ton, 10e-10)
 
 
 if __name__ == "__main__":

--- a/tests/project/operations/test_tuning_costs.py
+++ b/tests/project/operations/test_tuning_costs.py
@@ -84,8 +84,8 @@ class TestOperationalTuningCosts(unittest.TestCase):
         )
         instance = m.create_instance(data)
 
-        # Param: ramp_tuning_cost
-        self.assertEqual(instance.ramp_tuning_cost, 10e-10)
+        # Param: ramp_tuning_cost_per_mw
+        self.assertEqual(instance.ramp_tuning_cost_per_mw, 10e-10)
 
 
 if __name__ == "__main__":

--- a/tests/test_data/inputs/tuning_params.tab
+++ b/tests/test_data/inputs/tuning_params.tab
@@ -1,2 +1,2 @@
-import_carbon_tuning_cost	ramp_tuning_cost	dynamic_elcc_tuning_cost
-10e-10	10e-10	10e-10
+import_carbon_tuning_cost_per_ton	ramp_tuning_cost_per_mw	dynamic_elcc_tuning_cost_per_mw
+1.00E-09	1.00E-09	1.00E-09


### PR DESCRIPTION
After thinking about it some, I'm inclined to keep the tuning functionality fairly bare-bones, as I don't want users messing around with it too much. I added some more comments and cleaned up a bit. The main piece we needed to document better is that the ramp tuning costs apply only to hydro and storage (zero-variable-cost, dispatchable resources). I suggest keeping the tuning cost the same for all of them to avoid strange behavior, so I didn't add project- or tech-specific tuning costs. This is therefore just a small clean-up pull request. @gerritdm, please let me know if you have any thoughts.

Closes #53.