### PR TITLE
Add prm types tables to database

### DIFF
--- a/db/create_database.py
+++ b/db/create_database.py
@@ -105,6 +105,7 @@ def load_data(db, omit_data):
         load_mod_reserve_types(db=db, c=c)
         load_mod_tx_capacity_types(db=db, c=c)
         load_mod_tx_operational_types(db=db, c=c)
+        load_mod_prm_types(db=db, c=c)
         load_mod_capacity_and_operational_type_invalid_combos(db=db, c=c)
         load_mod_tx_capacity_and_tx_operational_type_invalid_combos(db=db, c=c)
         load_mod_horizon_boundary_types(db=db, c=c)
@@ -181,6 +182,15 @@ def load_mod_tx_operational_types(db, c):
         (operational_type, description)
         VALUES (?, ?);"""
     load_aux_data(conn=db, cursor=c, filename="mod_tx_operational_types.csv",
+                  sql=sql)
+
+
+def load_mod_prm_types(db, c):
+    sql = """
+        INSERT INTO mod_prm_types
+        (prm_type, description)
+        VALUES (?, ?);"""
+    load_aux_data(conn=db, cursor=c, filename="mod_prm_types.csv",
                   sql=sql)
 
 

--- a/db/data/mod_prm_types.csv
+++ b/db/data/mod_prm_types.csv
@@ -1,0 +1,4 @@
+prm_type,description
+energy_only_allowed,
+fully_deliverable,
+fully_deliverable_energy_limited,

--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -62,6 +62,13 @@ capacity_type VARCHAR(32) PRIMARY KEY,
 description VARCHAR(128)
 );
 
+-- Implemented prm types
+DROP TABLE IF EXISTS mod_prm_types;
+CREATE TABLE mod_prm_types (
+prm_type VARCHAR(32) PRIMARY KEY,
+description VARCHAR(128)
+);
+
 -- Invalid combinations of capacity type and operational type
 DROP TABLE IF EXISTS mod_capacity_and_operational_type_invalid_combos;
 CREATE TABLE mod_capacity_and_operational_type_invalid_combos (
@@ -1236,6 +1243,7 @@ contributes_to_elcc_surface INTEGER,
 min_duration_for_full_capacity_credit_hours FLOAT,
 deliverability_group VARCHAR(64),  --optional
 PRIMARY KEY (project_elcc_chars_scenario_id, project),
+FOREIGN KEY (prm_type) REFERENCES mod_prm_types (prm_type),
 FOREIGN KEY (project_elcc_chars_scenario_id) REFERENCES
 subscenarios_project_elcc_chars (project_elcc_chars_scenario_id)
 );


### PR DESCRIPTION
Similar to the capacity types, operational types, etc., we should add a table with the available PRM types, and have foreign keys referencing to this table.

Note: this is currently untested because the irp port script branch is lagging the master branch. MIght be worth waiting for the port script branch to catch up, so we can test this branch, before merging this in. 

Closes #254