### PR TITLE
Validate multi-stage feature settings vs inputs.

### DIFF
--- a/gridpath/validate_inputs.py
+++ b/gridpath/validate_inputs.py
@@ -249,6 +249,55 @@ def validate_data_dependent_subscenario_ids(subscenarios, conn):
     return not bool(validation_results)
 
 
+def validate_multi_stage_settings(optional_features, subscenarios, subproblems,
+                                  conn):
+    """
+
+    :param optional_features:
+    :param subscenarios:
+    :param subproblems:
+    :param conn:
+    :return:
+    """
+
+    multi_stage = optional_features.OPTIONAL_FEATURE_MULTI_STAGE
+
+    # Check whether multi_stage setting is consistent with actual inputs
+    max_stages = max([len(stages) for subproblem, stages in
+                      subproblems.SUBPROBLEM_STAGE_DICT.items()])
+    if max_stages > 1 and not multi_stage:
+        validation_results = [(
+            subscenarios.SCENARIO_ID,
+            "N/A",
+            "N/A",
+            "N/A",
+            "temporal_scenario_id",
+            "scenarios and inputs_temporal_subproblems_stages",
+            "Invalid multi-stage settings",
+            "The inputs contain multiple dispatch stages while the multi-stage "
+            "optional feature is not selected. Please select the multi-stage "
+            "feature or remove the extra stages."
+        )]
+    elif max_stages <= 1 and multi_stage:
+        validation_results = [(
+            subscenarios.SCENARIO_ID,
+            "N/A",
+            "N/A",
+            "N/A",
+            "temporal_scenario_id",
+            "scenarios and inputs_temporal_subproblems_stages",
+            "Invalid multi-stage settings",
+            "The inputs contain only a single dispatch stage so the multi-stage"
+            " optional feature should not be selected. Please turn off the "
+            "multi-stage feature or add additional stages."
+        )]
+    else:
+        validation_results = []
+
+    # Write all input validation errors to database
+    write_validation_to_database(validation_results, conn)
+
+
 def reset_input_validation(conn, scenario_id):
     """
     Reset input validation: delete old input validation outputs and reset the
@@ -355,6 +404,10 @@ def main(args=None):
     optional_features = OptionalFeatures(cursor=c, scenario_id=scenario_id)
     subscenarios = SubScenarios(cursor=c, scenario_id=scenario_id)
     subproblems = SubProblems(cursor=c, scenario_id=scenario_id)
+
+    # Validate multi-stage settings
+    validate_multi_stage_settings(optional_features, subscenarios, subproblems,
+                                  conn)
 
     # Check whether subscenario_ids are valid
     is_valid = validate_subscenario_ids(subscenarios, optional_features, conn)


### PR DESCRIPTION
This PR adds input validation to make sure that there are in fact multiple stages in the inputs when the multi-stage feature is selected, or conversely, make sure that there is only one stage when the multi-stage feature is not selected. This avoids unnecessarily loading the fix_commitment module when there is only one stage, or not loading in the fix_commitment module (and therefore not passing the commitments between stages) when there are multiple stages. 

Closes #99