### PR TITLE
Fix shutdown costs bug

### DIFF
--- a/gridpath/project/operations/costs.py
+++ b/gridpath/project/operations/costs.py
@@ -151,9 +151,6 @@ def add_model_components(m, d):
         Constraint(m.STARTUP_COST_PROJECT_OPERATIONAL_TIMEPOINTS,
                    rule=startup_cost_rule)
 
-    # TODO: this looks like a bug -- this constraint is missing a negative
-    #  Needs to be:
-    #  Shutdown_Cost >= - Startup_Shutdown_Expression X shutdown_cost
     def shutdown_cost_rule(mod, g, tmp):
         """
         Shutdown expression is positive when more units were on in the previous
@@ -176,7 +173,7 @@ def add_model_components(m, d):
             return Constraint.Skip
         else:
             return mod.Shutdown_Cost[g, tmp] \
-                   >= mod.Startup_Shutdown_Expression[g, tmp] \
+                   >= - mod.Startup_Shutdown_Expression[g, tmp] \
                    * mod.shutdown_cost_per_mw[g]
 
     m.Shutdown_Cost_Constraint = Constraint(


### PR DESCRIPTION
I decided to fix this bug, so that we're starting with a clean base if we make any changes to this as part of the run-up rate changes. We don't really have a test to cover this, but I ran a large-ish 2030 IRP case with this and the objective function changed only minimally (124614780705.02228 vs 124614780705.02206 previously). This makes sense to me, as the bug simply causes the shutdown costs to get applied on startup, not on shutdown. Let me know if you have other thoughts.