### PR TITLE
Enable 'Run Scenario' button after clearing results

### DIFF
--- a/ui/src/app/scenario-detail/scenario-detail.component.html
+++ b/ui/src/app/scenario-detail/scenario-detail.component.html
@@ -84,7 +84,7 @@
             <button
               class='button-secondary'
               *ngIf="scenarioDetail.runStatus=='complete'"
-              (click)="clearScenario(); runScenarioClicked = true">
+              (click)="clearScenario(); runScenarioClicked = false">
               Clear Scenario Results
             </button>
           </td>


### PR DESCRIPTION
Addresses "'Run Scenario' button doesn't seem to work after clearing scenario results (works on re-launching scenario-detail screen)" item of #289.