### PR TITLE
Clean up after processes that did not exit cleanly

### DIFF
--- a/ui/server/scenario_process.py
+++ b/ui/server/scenario_process.py
@@ -12,6 +12,7 @@ import sys
 
 from db.common_functions import connect_to_database
 from gridpath.run_end_to_end import update_run_status
+from ui.server.db_ops.delete_scenario import clear as clear_scenario
 
 
 def launch_scenario_process(db_path, scenarios_directory, scenario_id, solver):
@@ -99,24 +100,36 @@ def stop_scenario_run(db_path, scenario_id):
     if run_status != "running":
         # TODO: Tell user scenario is not running
         pass
+    # If we can't find the process ID (None or psutil error),
+    # the process likely did not exit cleanly, so we'll clear scenario
+    # results and update the run status to 'run_error'
+    elif process_id is None:
+        clean_up_scenario_with_no_process_id(
+          db_path=db_path, scenario_id=scenario_id
+        )
     else:
+        print("Attempting to terminate process ID {}".format(process_id))
         # TODO: is there an additional check to do, to make sure we don't
         #  terminate the wrong process (e.g. because of a prior crash,
         #  scenario appearing as running, but a different process actually
         #  having this id)
-        p = psutil.Process(process_id)
-        p.terminate()
+        try:
+            p = psutil.Process(process_id)
+            p.terminate()
+        except psutil.NoSuchProcess:
+            clean_up_scenario_with_no_process_id(
+                db_path=db_path, scenario_id=scenario_id
+            )
 
         # Update the scenario status to 'run_stopped'
         # This is only needed on Windows; on Mac, the signal is caught by
-        # run_end_to_end
+        # run_end_to_end, which updates the scenario status
         if os.name == "nt":
-            conn = connect_to_database(db_path=db_path)
-            c = conn.cursor()
-            scenario_name = get_scenario_name_from_scenario_id(
-              cursor=c, scenario_id=scenario_id)
-            update_run_status(db_path=db_path, scenario=scenario_name,
-                              status_id=4)
+            connect_to_db_and_update_run_status(
+              db_path=db_path,
+              scenario_id=scenario_id,
+              status_id=4
+            )
 
 
 def get_scenario_name_from_scenario_id(cursor, scenario_id):
@@ -132,3 +145,34 @@ def get_scenario_name_from_scenario_id(cursor, scenario_id):
     ).fetchone()[0]
 
     return scenario_name
+
+
+def connect_to_db_and_update_run_status(db_path, scenario_id, status_id):
+    conn = connect_to_database(db_path=db_path)
+    c = conn.cursor()
+    scenario_name = get_scenario_name_from_scenario_id(
+      cursor=c, scenario_id=scenario_id)
+    update_run_status(db_path=db_path, scenario=scenario_name,
+                      status_id=status_id)
+
+
+def clean_up_scenario_with_no_process_id(db_path, scenario_id):
+    """
+
+    :param db_path:
+    :param scenario_id:
+    :return:
+    """
+    print("No such process")
+    # Warn the user about what we're about to do
+    emit(
+      "process_id_not_found"
+    )
+    # Clear scenario from database
+    clear_scenario(db_path=db_path, scenario_id=scenario_id)
+    # Update status to 'run_error'
+    connect_to_db_and_update_run_status(
+      db_path=db_path,
+      scenario_id=scenario_id,
+      status_id=3
+    )

--- a/ui/src/app/scenario-detail/scenario-detail.component.ts
+++ b/ui/src/app/scenario-detail/scenario-detail.component.ts
@@ -136,6 +136,14 @@ export class ScenarioDetailComponent implements OnInit, OnDestroy {
             this.getScenarioDetailAPI(this.scenarioID);
           });
     });
+
+    // If the process ID does not exist, warn the user that we'll clean up
+    // this scenario as a previous process run likely did not exit correctly
+    socket.on('process_id_not_found', () => {
+      alert('The process ID for this scenario was not found. This is likely ' +
+        'the result of a previous system error. Any scenario results will be ' +
+        'cleared.');
+    });
   }
 
   editScenario(): void {


### PR DESCRIPTION
In some cases, if a scenario processes crashes (e.g. due to a system problem), it will not clean up after itself, so scenarios will appear as running, even though they really crashed. If the user tries to
'stop' such a scenario, we now catch the fact that the process ID does not exist, update the scenario run status to 'run error' and clear any scenario results.

Addresses the 'Method for re-setting run status (e.g. for runs that did not exit cleanly)' item of #289.