### PR TITLE
Add navigate-to-log-view-specific listener

### DIFF
--- a/ui/src/app/scenario-detail/scenario-detail.component.ts
+++ b/ui/src/app/scenario-detail/scenario-detail.component.ts
@@ -207,8 +207,8 @@ export class ScenarioDetailComponent implements OnInit, OnDestroy {
     const logFile = `e2e_${this.scenarioDetail.runStartTime}_pid_${this.scenarioDetail.runPID}.log`;
 
     // Ask Electron for any the current scenarios setting
-    electron.ipcRenderer.send('requestStoredSettings');
-    electron.ipcRenderer.on('sendStoredSettings',
+    electron.ipcRenderer.send('requestStoredScenarioDirectoryForLog');
+    electron.ipcRenderer.on('sendStoredScenarioDirectoryForLog',
       (event, data) => {
         const logFilePath = path.join(
           data.currentScenariosDirectory.value,

--- a/ui/src/electron-main.js
+++ b/ui/src/electron-main.js
@@ -468,3 +468,13 @@ ipcMain.on('requestStoredSettings', (event) => {
       }
     );
 });
+
+ipcMain.on('requestStoredScenarioDirectoryForLog', (event) => {
+    storage.getMany(
+      ['currentScenariosDirectory'],
+      (error, data) => {
+        if (error) throw error;
+        event.sender.send('sendStoredScenarioDirectoryForLog', data)
+      }
+    );
+});


### PR DESCRIPTION
Reusing the settings listener was resulting in unwanted behavior of re-navigating to the log view when attempting to navigate to the 'Home' and 'Settings' screens that used the same listener. The issue is fixed by adding a listener used specifically to navigate to the scenario run log view.