### PR TITLE
Format undefined subscenarios in SubScenarios class

### DIFF
--- a/gridpath/auxiliary/scenario_chars.py
+++ b/gridpath/auxiliary/scenario_chars.py
@@ -174,8 +174,8 @@ class OptionalFeatures(object):
 
 class SubScenarios(object):
     """
-    The subscenario IDs will be used to format queries, so they'll be "NULL"
-    if an ID is not specified for the scenario.
+    The subscenario IDs will be used to format SQL queries, so we set them to
+    "NULL" (not None) if an ID is not specified for the scenario.
     """
     def __init__(self, cursor, scenario_id):
         """


### PR DESCRIPTION
In the SubScenarios class of `gridpath.auxiliary.scenario_chars`, format undefined scenario so that we get `NULL` rather than `None`. This is better since the subscenario elements of this class are used to format the various get-inputs queries, which can break unless we use NULL when a subscenario is not defined.

See #288 for the particular issue that prompted this update.

I tested a couple of large-ish cases and did not run into any problems.

Closes #288.