### PR TITLE
Validation should expect 'NULL' strings for non-existent subscenarios

### DIFF
--- a/gridpath/validate_inputs.py
+++ b/gridpath/validate_inputs.py
@@ -120,7 +120,7 @@ def validate_feature_subscenario_ids(subscenarios, optional_features, conn):
                 # If the feature is requested, and the associated subscenarios
                 # are not specified, raise a validation error
                 if feature in feature_list and \
-                        getattr(subscenarios, sc_id) is None:
+                        getattr(subscenarios, sc_id) == "NULL":
                     validation_results.append(
                         (subscenarios.SCENARIO_ID,
                          "N/A",
@@ -136,7 +136,7 @@ def validate_feature_subscenario_ids(subscenarios, optional_features, conn):
                 # If the feature is not requested, and the associated
                 # subscenarios are specified, raise a validation error
                 elif feature not in feature_list and \
-                        getattr(subscenarios, sc_id) is not None:
+                        getattr(subscenarios, sc_id) != "NULL":
                     validation_results.append(
                         (subscenarios.SCENARIO_ID,
                          "N/A",


### PR DESCRIPTION
The validation script was expecting `None` for non-existent subscenarios, but we changed those to be formatted to `"NULL"` strings with #322. This was resulting in false validation warnings.

@gerritdm, does the fix look good to you and can you think of anything else I may have missed?