### PR TITLE
Clean up gen_commit_lin module

### DIFF
--- a/doc/source/advanced_docs.rst
+++ b/doc/source/advanced_docs.rst
@@ -170,8 +170,7 @@ gridpath.project.capacity.operational_types.gen_always_on
 
 gridpath.project.capacity.operational_types.gen_commit_lin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. automodule:: gridpath.project.operations.operational_types.gen_commit_lin
-    :members: add_module_specific_components, power_provision_rule
+.. automodule:: gridpath.project.operations.operational_types.gen_commit_lin.add_module_specific_components
 
 gridpath.project.capacity.operational_types.gen_commit_bin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/functionality.rst
+++ b/doc/source/functionality.rst
@@ -428,12 +428,7 @@ Binary-Commit Generation (*gen_commit_bin*)
 
 Continuous-Commit Generation (*gen_commit_lin*)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-This operational type is the same as the *gen_commit_bin* operational type,
-but the commitment decisions are declared as continuous (with bounds of 0 to
-1) instead of binary, so 'partial' generators can be committed. This
-treatment can be helpful in situations when mixed-integer problem runtimes
-are long and is similar to loosening the MIP gap (but can target specific
-generators).
+.. automodule:: gridpath.project.operations.operational_types.gen_commit_lin
 
 Capacity-Commit Generation (*gen_commit_cap*)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gridpath/project/operations/operational_types/gen_commit_bin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_bin.py
@@ -662,7 +662,7 @@ def add_module_specific_components(m, d):
 def pmax_rule(mod, g, tmp):
     """
     **Expression Name**: GenCommitBin_Pmax_MW
-    **Enforced Over**: GEN_COMMIT_BIN_OPR_TMPS
+    **Defined Over**: GEN_COMMIT_BIN_OPR_TMPS
     """
     return mod.Capacity_MW[g, mod.period[tmp]] \
         * mod.Availability_Derate[g, tmp]
@@ -671,7 +671,7 @@ def pmax_rule(mod, g, tmp):
 def pmin_rule(mod, g, tmp):
     """
     **Expression Name**: GenCommitBin_Pmin_MW
-    **Enforced Over**: GEN_COMMIT_BIN_OPR_TMPS
+    **Defined Over**: GEN_COMMIT_BIN_OPR_TMPS
     """
     return mod.Capacity_MW[g, mod.period[tmp]] \
         * mod.Availability_Derate[g, tmp] \
@@ -681,7 +681,7 @@ def pmin_rule(mod, g, tmp):
 def provide_power_rule(mod, g, tmp):
     """
     **Expression Name**: GenCommitBin_Provide_Power_MW
-    **Enforced Over**: GEN_COMMIT_BIN_OPR_TMPS
+    **Defined Over**: GEN_COMMIT_BIN_OPR_TMPS
     """
     return mod.GenCommitBin_Provide_Power_Above_Pmin_MW[g, tmp] \
         + mod.GenCommitBin_Pmin_MW[g, tmp] \
@@ -693,7 +693,7 @@ def provide_power_rule(mod, g, tmp):
 def ramp_up_rate_rule(mod, g, tmp):
     """
     **Expression Name**: GenCommitBin_Ramp_Up_Rate_MW_Per_Tmp
-    **Enforced Over**: GEN_COMMIT_BIN_OPR_TMPS
+    **Defined Over**: GEN_COMMIT_BIN_OPR_TMPS
 
     Ramp up rate limit in MW per timepoint, derived from input ramp rate
     which is given in fraction of installed capacity per minute. Longer
@@ -717,7 +717,7 @@ def ramp_up_rate_rule(mod, g, tmp):
 def ramp_down_rate_rule(mod, g, tmp):
     """
     **Expression Name**: GenCommitBin_Ramp_Down_Rate_MW_Per_Tmp
-    **Enforced Over**: GEN_COMMIT_BIN_OPR_TMPS
+    **Defined Over**: GEN_COMMIT_BIN_OPR_TMPS
 
     Ramp down rate limit in MW per timepoint, derived from input ramp rate
     which is given in fraction of installed capacity per minute. Longer
@@ -741,7 +741,7 @@ def ramp_down_rate_rule(mod, g, tmp):
 def startup_ramp_rate_rule(mod, g, tmp):
     """
     **Expression Name**: GenCommitBin_Startup_Ramp_Rate_MW_Per_Tmp
-    **Enforced Over**: GEN_COMMIT_BIN_OPR_TMPS
+    **Defined Over**: GEN_COMMIT_BIN_OPR_TMPS
     """
     return mod.Capacity_MW[g, mod.period[tmp]] \
         * mod.Availability_Derate[g, tmp] \
@@ -753,7 +753,7 @@ def startup_ramp_rate_rule(mod, g, tmp):
 def shutdown_ramp_rate_rule(mod, g, tmp):
     """
     **Expression Name**: GenCommitBin_Shutdown_Ramp_Rate_MW_Per_Tmp
-    **Enforced Over**: GEN_COMMIT_BIN_OPR_TMPS
+    **Defined Over**: GEN_COMMIT_BIN_OPR_TMPS
     """
     return mod.Capacity_MW[g, mod.period[tmp]] \
         * mod.Availability_Derate[g, tmp] \

--- a/gridpath/project/operations/operational_types/gen_commit_lin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_lin.py
@@ -2,13 +2,13 @@
 # Copyright 2017 Blue Marble Analytics LLC. All rights reserved.
 
 """
-This module describes the operations of 'continuous/linear-commit' generators,
-i.e. generators with on/off commitment decisions, but with the binary
-commitment decision relaxed. The relaxation replaces the binary variables
-(commit, start, stop, synced_units) with continuous variables within the range
-[0,1]. Except for this relaxation, the formulation is exactly the same as
-*gen_commit_bin*. Please refer to the *gen_commit_bin* module for more
-information on the formulation.
+This operational type is the same as the *gen_commit_bin* operational type,
+but the commitment decisions are declared as continuous (with bounds of 0 to
+1) instead of binary, so 'partial' generators can be committed. This
+linear relaxation treatment can be helpful in situations when mixed-integer
+problem run-times are long and is similar to loosening the MIP gap (but can
+target specific generators). Please refer to the *gen_commit_bin* module for
+more information on the formulation.
 
 .. Note:: Some of the more complex constraints in this module such as the
 startup trajectories might show weird behavior in the linearized version, e.g.
@@ -38,1023 +38,1342 @@ from gridpath.project.operations.operational_types.common_functions import \
 
 def add_module_specific_components(m, d):
     """
-    :param m: the Pyomo abstract model object we are adding components to
-    :param d: the DynamicComponents class object we will get components from
+    The following Pyomo model components are defined in this module:
 
-    First, we determine the project subset with 'gen_commit_lin'
-    as operational type. This is the *DISPATCHABLE_LINEAR_COMMIT_GENERATORS*
-    set, which we also designate with :math:`BCG\subset R` and index
-    :math:`bcg`.
-    We define several operational parameters over :math:`BCG`: \n
-    *displincommit_min_stable_level_fraction* \ :sub:`bcg`\ -- the
-    minimum stable level of the dispatchable-linear-commit generator, defined
-    as a fraction its capacity \n
-    *displincommit_startup_plus_ramp_up_rate* \ :sub:`bcg`\ -- the project's
-    upward ramp rate limit during startup, defined as a fraction of its capacity
-    per minute. This param, adjusted for timepoint duration, has to be equal or
-    larger than *displincommit_min_stable_level_fraction* for the unit to be
-    able to start up between timepoints. \n
-    *displincommit_shutdown_plus_ramp_down_rate* \ :sub:`bcg`\ -- the project's
-    downward ramp rate limit during shutdown, defined as a fraction of its
-    capacity per minute. This param, adjusted for timepoint duration, has to be
-    equal or larger than *displincommit_min_stable_level_fraction* for the
-    unit to be able to shut down between timepoints. \n
-    *displincommit_ramp_up_when_on_rate* \ :sub:`bcg`\ -- the project's
-    upward ramp rate limit during operations, defined as a fraction of its
-    capacity per minute. \n
-    *displincommit_ramp_down_when_on_rate* \ :sub:`bcg`\ -- the project's
-    downward ramp rate limit during operations, defined as a fraction of its
-    capacity per minute. \n
+    +-------------------------------------------------------------------------+
+    | Sets                                                                    |
+    +=========================================================================+
+    | | :code:`GEN_COMMIT_LIN`                                                |
+    |                                                                         |
+    | The set of generators of the :code:`gen_commit_lin` operational type.   |
+    +-------------------------------------------------------------------------+
+    | | :code:`GEN_COMMIT_LIN_OPR_TMPS`                                       |
+    |                                                                         |
+    | Two-dimensional set with generators of the :code:`gen_commit_lin`       |
+    | operational type and their operational timepoints.                      |
+    +-------------------------------------------------------------------------+
+    | | :code:`GEN_COMMIT_LIN_OPR_TMPS_FUEL_SEG`                              |
+    |                                                                         |
+    | Three-dimensional set with generators of the :code:`gen_commit_lin`     |
+    | operational type, their operational timepoints, and their fuel          |
+    | segments (if the project is in :code:`FUEL_PROJECTS`).                  |
+    +-------------------------------------------------------------------------+
 
-    *DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS* (
-    :math:`BCG\_OT\subset RT`) is a two-dimensional set that
-    defines all project-timepoint combinations when a
-    'gen_commit_lin' project can be operational.
+    |
 
-    There are four linear (continuous) decision variables, all defined over
-    *DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS*.
-    Commit_Linear is the linear commit variable to represent 'on' or 'off'
-    state of a generator.
-    Start_Linear is the linear variable to represent the state when a generator
-    is turning on.
-    Stop_Linear is the linear variable to represent the state when a generator
-    is shutting down.
-    Provide_Power_Above_Pmin_DispLinearCommit_MW is the power provision variable
-    for the generator.
+    +-------------------------------------------------------------------------+
+    | Required Input Params                                                   |
+    +=========================================================================+
+    | | :code:`gen_commit_lin_min_stable_level_fraction`                      |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN`                                |
+    | | *Within*: :code:`PercentFraction`                                     |
+    |                                                                         |
+    | The minimum stable level of this project as a fraction of its capacity. |
+    +-------------------------------------------------------------------------+
 
-    The main constraints on dispatchable-linear-commit generator power
-    provision are as follows:
-    For :math:`(bcg, tmp) \in BCG\_OT`: \n
-    :math:`Provide\_Power\_DispLinearCommit\_MW_{bcg, tmp} \geq
-    Commit\_MW_{bcg, tmp} \\times disp\_linear\_commit\_min\_stable\_level
-    \_fraction \\times Capacity\_MW_{bcg,p}` \n
-    :math:`Provide\_Power\_DispLinearCommit\_MW_{bcg, tmp} \leq
-    Commit\_MW_{bcg, tmp} \\times Capacity\_MW_{bcg,p}`
+    |
 
-    TODO: clean up or remove? --> wait for gen_commit_cap template
+    +-------------------------------------------------------------------------+
+    | Optional Input Params                                                   |
+    +=========================================================================+
+    | | :code:`gen_commit_lin_ramp_up_when_on_rate`                           |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN`                                |
+    | | *Within*: :code:`PercentFraction`                                     |
+    | | *Default*: :code:`1`                                                  |
+    |                                                                         |
+    | The project's upward ramp rate limit during operations, defined as a    |
+    | fraction of its capacity per minute.                                    |
+    +-------------------------------------------------------------------------+
+    | | :code:`gen_commit_lin_ramp_down_when_on_rate`                         |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN`                                |
+    | | *Within*: :code:`PercentFraction`                                     |
+    | | *Default*: :code:`1`                                                  |
+    |                                                                         |
+    | The project's downward ramp rate limit during operations, defined as a  |
+    | fraction of its capacity per minute.                                    |
+    +-------------------------------------------------------------------------+
+    | | :code:`gen_commit_lin_startup_plus_ramp_up_rate`                      |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN`                                |
+    | | *Within*: :code:`PercentFraction`                                     |
+    | | *Default*: :code:`1`                                                  |
+    |                                                                         |
+    | The project's upward ramp rate limit during startup, defined as a       |
+    | fraction of its capacity per minute. If, after adjusting for timepoint  |
+    | duration, this is smaller than the minimum stable level, the project    |
+    | will have a startup trajectory across multiple timepoitns.              |
+    +-------------------------------------------------------------------------+
+    | | :code:`gen_commit_lin_shutdown_plus_ramp_down_rate`                   |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN`                                |
+    | | *Within*: :code:`PercentFraction`                                     |
+    | | *Default*: :code:`1`                                                  |
+    |                                                                         |
+    | The project's downward ramp rate limit during startup, defined as a     |
+    | fraction of its capacity per minute. If, after adjusting for timepoint  |
+    | duration, this is smaller than the minimum stable level, the project    |
+    | will have a shutdown trajectory across multiple timepoitns.             |
+    +-------------------------------------------------------------------------+
+    | | :code:`gen_commit_lin_min_up_time_hrs`                                |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN`                                |
+    | | *Within*: :code:`NonNegativeReals`                                    |
+    | | *Default*: :code:`0`                                                  |
+    |                                                                         |
+    | The project's minimum up time in hours.                                 |
+    +-------------------------------------------------------------------------+
+    | | :code:`gen_commit_lin_min_down_time_hrs`                              |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN`                                |
+    | | *Within*: :code:`NonNegativeReals`                                    |
+    | | *Default*: :code:`0`                                                  |
+    |                                                                         |
+    | The project's minimum down time in hours.                               |
+    +-------------------------------------------------------------------------+
+
+    |
+
+    +-------------------------------------------------------------------------+
+    | Variables                                                               |
+    +=========================================================================+
+    | | :code:`GenCommitLin_Commit`                                           |
+    | | *Within*: :code:`PercentFraction`                                     |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Continuous variable which represents the commitment decision in each        |
+    | operational timepoint. It is one if the unit is committed and zero      |
+    | otherwise (including during a startup and shutdown trajectory).         |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Startup`                                          |
+    | | *Within*: :code:`PercentFraction`                                     |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Continuous variable which is one of the unit starts up and zero otherwise.  |
+    | A startup is defined as changing commitment from zero to one.           |
+    | Note: this variable is zero throughout a startup trajectory!            |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Shutdown`                                         |
+    | | *Within*: :code:`PercentFraction`                                     |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Continuous variable which is one of the unit shuts down and zero otherwise. |
+    | A shutdown is defined as changing commitment from one to zero.          |
+    | Note: this variable is zero throughout a shutdown trajectory!           |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Synced`                                           |
+    | | *Within*: :code:`PercentFraction`                                     |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Continuous variable which is one if the project is providing *any* power (  |
+    | either because it is committed or because it is in a startup or shutdown|
+    | trajectory), and zero otherwise.                                        |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Provide_Power_Above_Pmin_MW`                      |
+    | | *Within*: :code:`NonNegativeReals`                                    |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Power provision above the minimum stable level in MW from this project  |
+    | in each timepoint in which the project is committed.                    |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Provide_Power_Startup_MW`                         |
+    | | *Within*: :code:`NonNegativeReals`                                    |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Power provision during startup in each timepoint in which the project   |
+    | is starting up (zero if project is committed or not starting up).       |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Provide_Power_Shutdown_MW`                        |
+    | | *Within*: :code:`NonNegativeReals`                                    |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Power provision during shutdown in each timepoint in which the project  |
+    | is shutting down (zero if project is committed or not shutting down).   |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Fuel_Burn_MMBTU`                                  |
+    | | *Within*: :code:`NonNegativeReals`                                    |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_FUEL_PRJ_OPR_TMPS`              |
+    |                                                                         |
+    | Fuel burn in MMBTU by this project in each operational timepoint.       |
+    +-------------------------------------------------------------------------+
+
+    |
+
+    +-------------------------------------------------------------------------+
+    | Expressions                                                             |
+    +=========================================================================+
+    | | :code:`GenCommitLin_Pmax_MW`                                          |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | The project's maximum power output (in MW) if the unit was committed.   |
+    | Depends on the project's availability and capacity in the timepoint.    |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Pmin_MW`                                          |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | The project's minimum power output (in MW) if the unit was committed.   |
+    | Depends on the project's availability and capacity in the timepoint,    |
+    | and the minimum stable level.                                           |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Provide_Power_MW`                                 |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | The project's total power output (in MW) in each operational timepoint, |
+    | including power from a startup or shutdown trajectory.                  |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Ramp_Up_Rate_MW_Per_Tmp`                          |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | The project's upward ramp-able capacity (in MW) in each operational     |
+    | timepoint. Depends on the :code:`gen_commit_lin_ramp_up_when_on_rate`,  |
+    | the availability and capacity in the timepoint, and the timepoint's     |
+    | duration.                                                               |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Ramp_Down_Rate_MW_Per_Tmp`                        |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | The project's downward ramp-able capacity (in MW) in each operationa    |
+    | timepoint. Depends on the :code:`gen_commit_lin_ramp_down_when_on_rate` |
+    | , the availability and capacity in the timepoint, and the timepoint's   |
+    | duration.                                                               |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Startup_Ramp_Rate_MW_Per_Tmp`                     |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | The project's upward ramp-able capacity (in MW) during startup in each  |
+    | operational timepoint. Depends on the                                   |
+    | :code:`gen_commit_lin_startup_plus_ramp_up_rate`, the availability and  |
+    | capacity in the timepoint, and the timepoint's duration.                |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Shutdown_Ramp_Rate_MW_Per_Tmp`                    |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | The project's downward ramp-able capacity (in MW) during shutdown in    |
+    | each operational timepoint. Depends on the                              |
+    | :code:`gen_commit_lin_shutdown_plus_ramp_down_rate`, the availability   |
+    | and capacity in the timepoint, and the timepoint's duration.            |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Upwards_Reserves_MW`                              |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | The project's total upward reserves offered (in MW) in each timepoint.  |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Downwards_Reserves_MW`                            |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | The project's total downward reserves offered (in MW) in each timepoint.|
+    +-------------------------------------------------------------------------+
+
+    |
+
+    +-------------------------------------------------------------------------+
+    | Constraints                                                             |
+    +=========================================================================+
+    | Commitment                                                              |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Binary_Logic_Constraint`                          |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Defines the relationship between the binary commitment, startup, and    |
+    | shutdown variables. When the commitment changes from zero to one, the   |
+    | startup variable is one, when it changes from one to zero, the shutdown |
+    | variable is one.                                                        |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Synced_Constraint`                                |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Sets the GenCommitLin_Synced variable to one if the project is          |
+    | providing  *any* power (either because it is committed or because it is |
+    | in a startup or shutdown trajectory), and zero otherwise.               |
+    +-------------------------------------------------------------------------+
+    | Power                                                                   |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Max_Power_Constraint`                             |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Limits the power plus upward reserves to the available capacity.        |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Min_Power_Constraint`                             |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Power provision minus downward reserves should exceed the minimum       |
+    | stable level for the project.                                           |
+    +-------------------------------------------------------------------------+
+    | Minimum Up and Down Time                                                |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Min_Up_Time_Constraint`                           |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Requires that when the project is started, it stays on for at least     |
+    | :code:`gen_commit_lin_min_up_time_hrs`.                                 |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Min_Down_Time_Constraint`                         |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Requires that when the project is shut down, it stays off for at least  |
+    | :code:`gen_commit_lin_min_up_time_hrs`.                                 |
+    +-------------------------------------------------------------------------+
+    | Ramps                                                                   |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Ramp_Up_Constraint`                               |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Limits the allowed project upward ramp during operations based on the   |
+    | :code:`gen_commit_lin_ramp_up_when_on_rate`.                            |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Ramp_Down_Constraint`                             |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Limits the allowed project downward ramp during operations based on the |
+    | :code:`gen_commit_lin_ramp_down_when_on_rate`.                          |
+    +-------------------------------------------------------------------------+
+    | Startup Power                                                           |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Max_Startup_Power_Constraint`                     |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Limits startup power to zero when the project is committed and to the   |
+    | minimum stable level when it is not committed.                          |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Ramp_During_Startup_Constraint`                   |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Limits the allowed project upward startup power ramp based on the       |
+    | :code:`gen_commit_lin_startup_plus_ramp_up_rate`.                       |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Increasing_Startup_Power_Constraint`              |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Requires that the startup power always increases, except for the        |
+    | startup timepoint (when :code:`GenCommitLin_Startup` is one).           |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Power_During_Startup_Constraint`                  |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Limits the difference between the power provision in the startup        |
+    | timepoint and the startup power in the previous timepoint based on the  |
+    | :code:`gen_commit_lin_startup_plus_ramp_up_rate`.                       |
+    +-------------------------------------------------------------------------+
+    | Shutdown Power                                                          |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Max_Shutdown_Power_Constraint`                    |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Limits shutdown power to zero when the project is committed and to the  |
+    | minimum stable level when it is not committed.                          |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Ramp_During_Shutdown_Constraint`                  |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Limits the allowed project downward shutdown power ramp based on the    |
+    | :code:`gen_commit_lin_shutdown_plus_ramp_down_rate`.                    |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Decreasing_Shutdown_Power_Constraint`             |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Requires that the shutdown power always decreases, except for the       |
+    | shutdown timepoint (when :code:`GenCommitLin_Shutdown` is one).         |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Power_During_Shutdown_Constraint`                 |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
+    |                                                                         |
+    | Limits the difference between the power provision in the shutdown       |
+    | timepoint and the shutdown power in the next timepoint based on the     |
+    | :code:`gen_commit_lin_shutdown_plus_ramp_down_rate`.                    |
+    +-------------------------------------------------------------------------+
+    | Fuel Burn                                                               |
+    +-------------------------------------------------------------------------+
+    | | :code:`GenCommitLin_Fuel_Burn_Constraint`                             |
+    | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS_FUEL_SEG`              |
+    |                                                                         |
+    | Determines fuel burn from the project in each timepoint based on its    |
+    | heat rate curve.                                                        |
+    +-------------------------------------------------------------------------+
     """
+
     # Sets
-    m.DISPATCHABLE_LINEAR_COMMIT_GENERATORS = Set(
+    ###########################################################################
+
+    m.GEN_COMMIT_LIN = Set(
         within=m.PROJECTS,
-        initialize=
-        generator_subset_init("operational_type", "gen_commit_lin")
+        initialize=generator_subset_init("operational_type", "gen_commit_lin")
     )
 
-    m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS = \
-        Set(dimen=2, within=m.PROJECT_OPERATIONAL_TIMEPOINTS,
-            rule=lambda mod:
-            set((g, tmp) for (g, tmp) in mod.PROJECT_OPERATIONAL_TIMEPOINTS
-                if g in mod.DISPATCHABLE_LINEAR_COMMIT_GENERATORS))
+    m.GEN_COMMIT_LIN_OPR_TMPS = Set(
+        dimen=2, within=m.PROJECT_OPERATIONAL_TIMEPOINTS,
+        rule=lambda mod:
+        set((g, tmp) for (g, tmp) in mod.PROJECT_OPERATIONAL_TIMEPOINTS
+            if g in mod.GEN_COMMIT_LIN)
+    )
 
-    m.DISPATCHABLE_LINEAR_COMMIT_FUEL_PROJECT_SEGMENTS_OPERATIONAL_TIMEPOINTS = \
-        Set(dimen=3,
-            within=m.FUEL_PROJECT_SEGMENTS_OPERATIONAL_TIMEPOINTS,
-            rule=lambda mod:
-            set((g, tmp, s) for (g, tmp, s)
-                in mod.FUEL_PROJECT_SEGMENTS_OPERATIONAL_TIMEPOINTS
-                if g in mod.DISPATCHABLE_LINEAR_COMMIT_GENERATORS))
+    m.GEN_COMMIT_LIN_OPR_TMPS_FUEL_SEG = Set(
+        dimen=3,
+        within=m.FUEL_PROJECT_SEGMENTS_OPERATIONAL_TIMEPOINTS,
+        rule=lambda mod:
+        set((g, tmp, s) for (g, tmp, s)
+            in mod.FUEL_PROJECT_SEGMENTS_OPERATIONAL_TIMEPOINTS
+            if g in mod.GEN_COMMIT_LIN)
+    )
 
-    # Params - Required
-    m.disp_linear_commit_min_stable_level_fraction = \
-        Param(m.DISPATCHABLE_LINEAR_COMMIT_GENERATORS,
-              within=PercentFraction)
+    # Required Params
+    ###########################################################################
+    m.gen_commit_lin_min_stable_level_fraction = Param(
+        m.GEN_COMMIT_LIN,
+        within=PercentFraction
+    )
 
-    # Params - Optional
+    # Optional Params
+    ###########################################################################
 
-    # Ramp rates can be optionally specified and will default to 1 if not
-    # Ramp rate units are "percent of project capacity per minute"
-    # Startup and shutdown ramp rate are defined as the amount you can
-    # ramp when starting up or shutting down. When adjusted for the timepoint
-    # duration, it should be at least equal to the min_stable_level_fraction
-    m.displincommit_startup_plus_ramp_up_rate = \
-        Param(m.DISPATCHABLE_LINEAR_COMMIT_GENERATORS,
-              within=PercentFraction, default=1)
-    m.displincommit_shutdown_plus_ramp_down_rate = \
-        Param(m.DISPATCHABLE_LINEAR_COMMIT_GENERATORS,
-              within=PercentFraction, default=1)
-    m.displincommit_ramp_up_when_on_rate = \
-        Param(m.DISPATCHABLE_LINEAR_COMMIT_GENERATORS,
-              within=PercentFraction, default=1)
-    m.displincommit_ramp_down_when_on_rate = \
-        Param(m.DISPATCHABLE_LINEAR_COMMIT_GENERATORS,
-              within=PercentFraction, default=1)
+    m.gen_commit_lin_ramp_up_when_on_rate = Param(
+        m.GEN_COMMIT_LIN,
+        within=PercentFraction, default=1
+    )
+    m.gen_commit_lin_ramp_down_when_on_rate = Param(
+        m.GEN_COMMIT_LIN,
+        within=PercentFraction, default=1
+    )
+    m.gen_commit_lin_startup_plus_ramp_up_rate = Param(
+        m.GEN_COMMIT_LIN,
+        within=PercentFraction, default=1
+    )
+    m.gen_commit_lin_shutdown_plus_ramp_down_rate = Param(
+        m.GEN_COMMIT_LIN,
+        within=PercentFraction, default=1
+    )
 
-    m.displincommit_min_up_time_hours = \
-        Param(m.DISPATCHABLE_LINEAR_COMMIT_GENERATORS,
-              within=NonNegativeReals, default=0)
-    m.displincommit_min_down_time_hours = \
-        Param(m.DISPATCHABLE_LINEAR_COMMIT_GENERATORS,
-              within=NonNegativeReals, default=0)
+    m.gen_commit_lin_min_up_time_hrs = Param(
+        m.GEN_COMMIT_LIN,
+        within=NonNegativeReals, default=0
+    )
+    m.gen_commit_lin_min_down_time_hrs = Param(
+        m.GEN_COMMIT_LIN,
+        within=NonNegativeReals, default=0
+    )
 
-    # Variables - Linear (relaxed from binary)
-    m.Commit_Linear = Var(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        within=PercentFraction)
-    # Start_Linear is 1 for the first timepoint the unit is committed after
-    # being offline; it will be able to provide power in that timepoint.
-    m.Start_Linear = Var(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        within=PercentFraction)
-    # Stop_Linear is 1 for the first timepoint the unit is offline after
-    # being committed; it will not be able to provide power in that timepoint.
-    m.Stop_Linear = Var(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        within=PercentFraction)
-    # This auxiliary variable is 1 if the unit is committed or in a startup or
-    # shutdown trajectory and zero otherwise.
-    m.DispLinCommit_Synced_Units = Var(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        within=PercentFraction)
+    # Variables
+    ###########################################################################
 
-    # Variables - Continuous
-    m.Provide_Power_Above_Pmin_DispLinearCommit_MW = \
-        Var(m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-            within=NonNegativeReals)
+    m.GenCommitLin_Commit = Var(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        within=PercentFraction
+    )
 
-    m.Fuel_Burn_DispLinCommit_MMBTU = Var(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Startup = Var(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        within=PercentFraction
+    )
+
+    m.GenCommitLin_Shutdown = Var(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        within=PercentFraction
+    )
+
+    m.GenCommitLin_Synced = Var(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        within=PercentFraction
+    )
+
+    m.GenCommitLin_Provide_Power_Above_Pmin_MW = Var(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         within=NonNegativeReals
     )
 
-    m.DispLinCommit_Pstarting_MW = Var(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Provide_Power_Startup_MW = Var(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         within=NonNegativeReals
     )
 
-    m.DispLinCommit_Pstopping_MW = Var(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Provide_Power_Shutdown_MW = Var(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        within=NonNegativeReals
+    )
+
+    m.GenCommitLin_Fuel_Burn_MMBTU = Var(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         within=NonNegativeReals
     )
 
     # Expressions
-    def pmax_rule(mod, g, tmp):
-        return mod.Capacity_MW[g, mod.period[tmp]] \
-               * mod.Availability_Derate[g, tmp]
+    ###########################################################################
 
-    m.DispLinCommit_Pmax_MW = Expression(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=pmax_rule)
+    m.GenCommitLin_Pmax_MW = Expression(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=pmax_rule
+    )
 
-    def pmin_rule(mod, g, tmp):
-        return mod.Capacity_MW[g, mod.period[tmp]] \
-               * mod.Availability_Derate[g, tmp] \
-               * mod.disp_linear_commit_min_stable_level_fraction[g]
+    m.GenCommitLin_Pmin_MW = Expression(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=pmin_rule
+    )
 
-    m.DispLinCommit_Pmin_MW = Expression(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=pmin_rule)
+    m.GenCommitLin_Provide_Power_MW = Expression(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=provide_power_rule
+    )
 
-    def provide_power_rule(mod, g, tmp):
-        return mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[g, tmp] \
-               + mod.DispLinCommit_Pmin_MW[g, tmp] \
-               * mod.Commit_Linear[g, tmp] \
-               + mod.DispLinCommit_Pstarting_MW[g, tmp] \
-               + mod.DispLinCommit_Pstopping_MW[g, tmp]
+    m.GenCommitLin_Ramp_Up_Rate_MW_Per_Tmp = Expression(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=ramp_up_rate_rule
+    )
 
-    m.Provide_Power_DispLinearCommit_MW = Expression(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=provide_power_rule)
+    m.GenCommitLin_Ramp_Down_Rate_MW_Per_Tmp = Expression(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=ramp_down_rate_rule
+    )
 
-    def ramp_up_rate_rule(mod, g, tmp):
-        """
-        Ramp up rate limit in MW per timepoint, derived from input ramp rate
-        which is given in fraction of installed capacity per minute. Longer
-        timepoints will lead to a larger ramp up rate limit, since ramping
-        can take place over a longer duration.
-        Unit check:
-            capacity [MW]
-            * availability [unit-less]
-            * ramp up rate [1/min]
-            * hours in timepoint [hours/timepoint]
-            * minutes per hour [min/hour]
-            = ramp up rate [MW/timepoint]
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-        return mod.Capacity_MW[g, mod.period[tmp]] \
-               * mod.Availability_Derate[g, tmp] \
-               * mod.displincommit_ramp_up_when_on_rate[g] \
-               * mod.number_of_hours_in_timepoint[tmp] \
-               * 60  # convert min to hours
+    m.GenCommitLin_Startup_Ramp_Rate_MW_Per_Tmp = Expression(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=startup_ramp_rate_rule
+    )
 
-    m.DispLinCommit_Ramp_Up_Rate_MW_Per_Timepoint = Expression(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=ramp_up_rate_rule)
-
-    def ramp_down_rate_rule(mod, g, tmp):
-        """
-        Ramp down rate limit in MW per timepoint, derived from input ramp rate
-        which is given in fraction of installed capacity per minute. Longer
-        timepoints will lead to a larger ramp down rate limit, since ramping
-        can take place over a longer duration.
-        Unit check:
-            capacity [MW]
-            * availability [unit-less]
-            * ramp down rate [1/min]
-            * hours in timepoint [hours/timepoint]
-            * minutes per hour [min/hour]
-            = ramp down rate [MW/timepoint]
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-        return mod.Capacity_MW[g, mod.period[tmp]] \
-               * mod.Availability_Derate[g, tmp] \
-               * mod.displincommit_ramp_down_when_on_rate[g] \
-               * mod.number_of_hours_in_timepoint[tmp] \
-               * 60  # convert min to hours
-
-    m.DispLinCommit_Ramp_Down_Rate_MW_Per_Timepoint = Expression(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=ramp_down_rate_rule)
-
-    def startup_ramp_rate_rule(mod, g, tmp):
-        return mod.Capacity_MW[g, mod.period[tmp]] \
-               * mod.Availability_Derate[g, tmp] \
-               * min(mod.displincommit_startup_plus_ramp_up_rate[g]
-                     * mod.number_of_hours_in_timepoint[tmp]
-                     * 60, 1)
-
-    m.DispLinCommit_Startup_Ramp_Rate_MW_Per_Timepoint = Expression(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=startup_ramp_rate_rule)
-
-    def shutdown_ramp_rate_rule(mod, g, tmp):
-        return mod.Capacity_MW[g, mod.period[tmp]] \
-               * mod.Availability_Derate[g, tmp] \
-               * min(mod.displincommit_shutdown_plus_ramp_down_rate[g]
-                     * mod.number_of_hours_in_timepoint[tmp]
-                     * 60, 1)
-
-    m.DispLinCommit_Shutdown_Ramp_Rate_MW_Per_Timepoint = Expression(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=shutdown_ramp_rate_rule)
+    m.GenCommitLin_Shutdown_Ramp_Rate_MW_Per_Tmp = Expression(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=shutdown_ramp_rate_rule
+    )
 
     def upwards_reserve_rule(mod, g, tmp):
         return sum(getattr(mod, c)[g, tmp]
                    for c in getattr(d, headroom_variables)[g])
 
-    m.DispLinCommit_Upwards_Reserves_MW = Expression(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=upwards_reserve_rule)
+    m.GenCommitLin_Upwards_Reserves_MW = Expression(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=upwards_reserve_rule
+    )
 
     def downwards_reserve_rule(mod, g, tmp):
         return sum(getattr(mod, c)[g, tmp]
                    for c in getattr(d, footroom_variables)[g])
 
-    m.DispLinCommit_Downwards_Reserves_MW = Expression(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=downwards_reserve_rule)
+    m.GenCommitLin_Downwards_Reserves_MW = Expression(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=downwards_reserve_rule
+    )
 
     # Constraints
-    def linear_logic_constraint_rule(mod, g, tmp):
-        """
-        If commit status changes, unit is turning on or shutting down.
-        The *Start_Linear* variable is 1 for the first timepoint the unit is
-        committed after being offline; it will be able to provide power in that
-        timepoint. The *Stop_Linear* variable is 1 for the first timepoint the
-        unit is not committed after being online; it will not be able to
-        provide power in that timepoint.
+    ###########################################################################
 
-        Constraint (8) in Morales-Espana et al. (2013)
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-
-        # TODO: if we can link horizons, input commit from previous horizon's
-        #  last timepoint rather than skipping the constraint
-        if tmp == mod.first_horizon_timepoint[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                and mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                == "linear":
-            return Constraint.Skip
-        else:
-            return mod.Commit_Linear[g, tmp] \
-                   - mod.Commit_Linear[
-                       g, mod.previous_timepoint[
-                           tmp, mod.balancing_type_project[g]]] \
-                   == mod.Start_Linear[g, tmp] - mod.Stop_Linear[g, tmp]
-
-    m.DispLinCommit_Linear_Logic_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=linear_logic_constraint_rule
+    # Commitment
+    m.GenCommitLin_Binary_Logic_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=binary_logic_constraint_rule
     )
 
-    def synced_units_constraint_rule(mod, g, tmp):
-        """
-        Synced Units is 1 if the unit is committed, starting, or stopping and
-        zero otherwise.
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-        return mod.DispLinCommit_Synced_Units[g, tmp] \
-               >= mod.Commit_Linear[g, tmp] \
-               + (mod.DispLinCommit_Pstarting_MW[g, tmp]
-                  + mod.DispLinCommit_Pstopping_MW[g, tmp]) \
-               / mod.DispLinCommit_Pmin_MW[g, tmp]
-
-    m.DispLinCommit_Synced_Units_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=synced_units_constraint_rule
+    m.GenCommitLin_Synced_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=synced_constraint_rule
     )
 
-    def min_power_constraint_rule(mod, g, tmp):
-        """
-        Power minus downward services cannot be below minimum stable level.
-        This constraint is not in Morales-Espana et al. (2013) because they
-        don't look at downward reserves. In that case, enforcing
-        provide_power_above_pmin to be within NonNegativeReals is sufficient.
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-        return mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[g, tmp] - \
-               mod.DispLinCommit_Downwards_Reserves_MW[g, tmp] \
-               >= 0
-
-    m.DispLinCommit_Min_Power_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
-        rule=min_power_constraint_rule
-    )
-
-    def max_power_constraint_rule(mod, g, tmp):
-        """
-        Power provision plus upward reserves shall not exceed maximum power.
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-        return \
-            (mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[g, tmp]
-             + mod.DispLinCommit_Upwards_Reserves_MW[g, tmp]) \
-            <= \
-            (mod.DispLinCommit_Pmax_MW[g, tmp]
-             - mod.DispLinCommit_Pmin_MW[g, tmp]) \
-            * mod.Commit_Linear[g, tmp]
-
-    m.DispLinCommit_Max_Power_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    # Power
+    m.GenCommitLin_Max_Power_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=max_power_constraint_rule
     )
 
-    def min_up_time_constraint_rule(mod, g, tmp):
-        """
-        When units are started, they have to stay on for a minimum number
-        of hours described by the displincommit_min_up_time_hours parameter.
-        The constraint is enforced by ensuring that the linear commitment
-        is at least as large as the number of unit starts within min up time
-        hours.
+    m.GenCommitLin_Min_Power_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
+        rule=min_power_constraint_rule
+    )
 
-        We ensure a unit turned on less than the minimum up time ago is
-        still on in the current timepoint *tmp* by checking how much units
-        were turned on in each 'relevant' timepoint (i.e. a timepoint that
-        begins more than or equal to displincommit_min_up_time_hours ago
-        relative to the start of timepoint *tmp*) and then summing those
-        starts.
-
-        If using linear horizon boundaries, the constraint is skipped for all
-        timepoints less than min up time hours from the start of the timepoint's
-        horizon because the constraint for the first included timepoint
-        will sufficiently constrain the linear start variables of all the
-        timepoints before it.
-
-        Constraint (6) in Morales-Espana et al. (2013)
-
-        Example 1:
-          min_up_time = 4; tmps = [0,1,2,3];
-          hours_in_tmps = [1,3,1,1];
-          tmp = 2; relevant_tmps = [1,2]
-          --> if there is a start in tmp 1, you have to be committed in tmp 2
-          --> starts in all other tmps (incl. tmp 0) don't affect tmp 2
-        Example 2:
-          min_up_time = 4; tmps = [0,1,2,3];
-          hours_in_tmps = [1,4,1,1];
-          tmp = 2; relevant_tmps = [2]
-          --> start in t1 does not affect state of t2; tmp 1 is 4 hrs long
-          --> so even if you start in tmp 1 you can stop again in tmp 2
-          --> The constraint simply ensures that the unit is committed if
-          --> it is turned on.
-        Example 3:
-          min_up_time = 4; tmps = [0,1,2,3];
-          hours_in_tmps = [1,1,1,1];
-          tmp = 2; relevant_tmps = [0,1,2,3]
-          --> if there is a start in tmp 0, 1, 2, or 3, you have to be committed
-          --> in tmp 2. The unit either has to be on for all timepoints, or off
-          --> for all timepoints
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-
-        relevant_tmps = determine_relevant_timepoints(
-            mod, g, tmp, mod.displincommit_min_up_time_hours[g]
-        )
-
-        number_of_starts_min_up_time_or_less_hours_ago = \
-            sum(mod.Start_Linear[g, tp] for tp in relevant_tmps)
-
-        # If we've reached the first timepoint in linear boundary mode and
-        # the total duration of the relevant timepoints (which includes *tmp*)
-        # is less than the minimum up time, skip the constraint since the next
-        # timepoint's constraint will already cover these same timepoints.
-        # Don't skip if this timepoint is the last timepoint of the horizon
-        # (since there will be no next timepoint).
-        if (mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] == "linear"
-                and
-                relevant_tmps[-1]
-                == mod.first_horizon_timepoint[
-                    mod.horizon[tmp, mod.balancing_type_project[g]]]
-                and
-                sum(mod.number_of_hours_in_timepoint[t] for t in relevant_tmps)
-                < mod.displincommit_min_up_time_hours[g]
-                and
-                tmp != mod.last_horizon_timepoint[
-                    mod.horizon[tmp, mod.balancing_type_project[g]]]):
-            return Constraint.Skip
-        # Otherwise, if there was a start min_up_time or less ago, the unit has
-        # to remain committed.
-        else:
-            return mod.Commit_Linear[g, tmp] \
-                   >= number_of_starts_min_up_time_or_less_hours_ago
-
-    m.DispLinCommit_Min_Up_Time_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    # Minimum Up and Down Time
+    m.GenCommitLin_Min_Up_Time_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=min_up_time_constraint_rule
     )
 
-    def min_down_time_constraint_rule(mod, g, tmp):
-        """
-        When units are shut down, they have to stay off for a minimum number
-        of hours described by the displincommit_min_down_time_hours parameter.
-        The constraint is enforced by ensuring that (1-linear commitment)
-        is at least as large as the number of unit shutdowns within min down
-        time hours.
-
-        We ensure a unit shut down less than the minimum up time ago is
-        still off in the current timepoint *tmp* by checking how much units
-        were shut down in each 'relevant' timepoint (i.e. a timepoint that
-        begins more than or equal to displincommit_min_down_time_hours ago
-        relative to the start of timepoint *tmp*) and then summing those
-        shutdowns.
-
-        If using linear horizon boundaries, the constraint is skipped for all
-        timepoints less than min down time hours from the start of the
-        timepoint's horizon because the constraint for the first included
-        timepoint will sufficiently constrain the linear stop variables of all
-        the timepoints before it.
-
-        Constraint (7) in Morales-Espana et al. (2013)
-        """
-
-        relevant_tmps = determine_relevant_timepoints(
-            mod, g, tmp, mod.displincommit_min_down_time_hours[g]
-        )
-
-        number_of_stops_min_down_time_or_less_hours_ago = \
-            sum(mod.Stop_Linear[g, tp] for tp in relevant_tmps)
-
-        # If we've reached the first timepoint in linear boundary mode and
-        # the total duration of the relevant timepoints (which includes *tmp*)
-        # is less than the minimum down time, skip the constraint since the
-        # next timepoint's constraint will already cover these same timepoints.
-        # Don't skip if this timepoint is the last timepoint of the horizon
-        # (since there will be no next timepoint).
-        if (mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] == "linear"
-                and
-                relevant_tmps[-1]
-                == mod.first_horizon_timepoint[
-                    mod.horizon[tmp, mod.balancing_type_project[g]]]
-                and
-                sum(mod.number_of_hours_in_timepoint[t] for t in relevant_tmps)
-                < mod.displincommit_min_down_time_hours[g]
-                and
-                tmp != mod.last_horizon_timepoint[
-                    mod.horizon[tmp, mod.balancing_type_project[g]]]):
-            return Constraint.Skip
-        # Otherwise, if there was a shutdown min_down_time or less ago, the unit
-        # has to remain shut down.
-        else:
-            return 1 - mod.Commit_Linear[g, tmp] \
-                   >= number_of_stops_min_down_time_or_less_hours_ago
-
-    m.DispLinCommit_Min_Down_Time_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Min_Down_Time_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=min_down_time_constraint_rule
     )
 
-    def ramp_up_constraint_rule(mod, g, tmp):
-        """
-        Difference between power generation of consecutive timepoints has to
-        obey ramp up rates.
-        We assume that a unit has to reach its setpoint at the start of the
-        timepoint; as such, the ramping between 2 timepoints is assumed to
-        take place during the duration of the first timepoint, and the
-        ramp rate is adjusted for the duration of the first timepoint.
-        Constraint (12) in Morales-Espana et al. (2013)
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-        if tmp == mod.first_horizon_timepoint[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                and mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                == "linear":
-            return Constraint.Skip
-        # If ramp rate limits, adjusted for timepoint duration, allow you to
-        # ramp up the full operable range between timepoints, constraint
-        # won't bind, so skip
-        elif (mod.displincommit_ramp_up_when_on_rate[g] * 60
-              * mod.number_of_hours_in_timepoint[
-                  mod.previous_timepoint[tmp, mod.balancing_type_project[g]]]
-              >= (1 - mod.disp_linear_commit_min_stable_level_fraction[g])):
-            return Constraint.Skip
-        else:
-            return \
-                (mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[g, tmp]
-                 + mod.DispLinCommit_Upwards_Reserves_MW[g, tmp]) \
-                - \
-                (mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[
-                     g, mod.previous_timepoint[
-                         tmp, mod.balancing_type_project[g]]]
-                 - mod.DispLinCommit_Downwards_Reserves_MW[
-                     g, mod.previous_timepoint[
-                         tmp, mod.balancing_type_project[g]]]) \
-                <= \
-                mod.DispLinCommit_Ramp_Up_Rate_MW_Per_Timepoint[
-                    g, mod.previous_timepoint[
-                        tmp, mod.balancing_type_project[g]]]
-
-    m.Ramp_Up_Constraint_DispLinearCommit = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    # Ramps
+    m.GenCommitLin_Ramp_Up_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=ramp_up_constraint_rule
     )
 
-    def ramp_down_constraint_rule(mod, g, tmp):
-        """
-        Difference between power generation of consecutive timepoints has to
-        obey ramp down rates.
-        We assume that a unit has to reach its setpoint at the start of the
-        timepoint; as such, the ramping between 2 timepoints is assumed to
-        take place during the duration of the first timepoint, and the
-        ramp rate is adjusted for the duration of the first timepoint.
-        Constraint (13) in Morales-Espana et al. (2013)
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-        if tmp == mod.first_horizon_timepoint[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                and mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                == "linear":
-            return Constraint.Skip
-        # If ramp rate limits, adjusted for timepoint duration, allow you to
-        # ramp down the full operable range between timepoints, constraint
-        # won't bind, so skip
-        elif (mod.displincommit_ramp_down_when_on_rate[g] * 60
-              * mod.number_of_hours_in_timepoint[
-                  mod.previous_timepoint[tmp, mod.balancing_type_project[g]]]
-              >= (1 - mod.disp_linear_commit_min_stable_level_fraction[g])):
-            return Constraint.Skip
-        else:
-            return \
-                (mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[
-                     g, mod.previous_timepoint[
-                         tmp, mod.balancing_type_project[g]]]
-                 + mod.DispLinCommit_Upwards_Reserves_MW[
-                     g, mod.previous_timepoint[
-                         tmp, mod.balancing_type_project[g]]]) \
-                - \
-                (mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[g, tmp]
-                 - mod.DispLinCommit_Downwards_Reserves_MW[g, tmp]) \
-                <= mod.DispLinCommit_Ramp_Down_Rate_MW_Per_Timepoint[
-                    g, mod.previous_timepoint[
-                        tmp, mod.balancing_type_project[g]]]
-
-    m.Ramp_Down_Constraint_DispLinearCommit = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Ramp_Down_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=ramp_down_constraint_rule
     )
 
-    # Startup power
-    def max_startup_power_constraint_rule(mod, g, tmp):
-        """
-        Startup power is 0 when the unit is committed and must be less than or
-        equal to the minimum stable level when not committed.
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-
-        return mod.DispLinCommit_Pstarting_MW[g, tmp] \
-               <= (1 - mod.Commit_Linear[g, tmp]) \
-               * mod.DispLinCommit_Pmin_MW[g, tmp]
-
-    m.DispLinCommit_Max_Startup_Power_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    # Startup Power
+    m.GenCommitLin_Max_Startup_Power_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=max_startup_power_constraint_rule
     )
 
-    def ramp_during_startup_constraint_rule(mod, g, tmp):
-        """
-        The difference between startup power of consecutive timepoints has to
-        obey startup ramp up rates.
-
-        We assume that a unit has to reach its setpoint at the start of the
-        timepoint; as such, the ramping between 2 timepoints is assumed to
-        take place during the duration of the first timepoint, and the
-        ramp rate is adjusted for the duration of the first timepoint.
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-
-        if tmp == mod.first_horizon_timepoint[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                and mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                == "linear":
-            return Constraint.Skip
-        else:
-            return \
-                mod.DispLinCommit_Pstarting_MW[g, tmp] - \
-                mod.DispLinCommit_Pstarting_MW[g,
-                                               mod.previous_timepoint[tmp,
-                                                                      mod
-                                                                          .balancing_type_project[
-                                                                          g]
-                                               ]
-                ] \
-                <= mod.DispLinCommit_Startup_Ramp_Rate_MW_Per_Timepoint[
-                    g, mod.previous_timepoint[tmp,
-                                              mod.balancing_type_project[g]]
-                ]
-
-    m.DispLinCommit_Ramp_During_Startup_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Ramp_During_Startup_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=ramp_during_startup_constraint_rule
     )
 
-    def increasing_startup_power_constraint_rule(mod, g, tmp):
-        """
-        DispLinCommit_Pstarting_MW[t] can only be less than
-        DispLinCommit_Pstarting_MW[t-1] in the starting timepoint (when it is
-        is back at 0). In other words, DispLinCommit_Pstarting_MW can only
-        decrease in the starting timepoint; in all other timepoints it should
-        increase or stay constant. This prevents situations in which the model
-        can abuse this by providing starting power in some timepoints and then
-        reducing power back to 0 without ever committing the unit.
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-        if tmp == mod.first_horizon_timepoint[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                and mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                == "linear":
-            return Constraint.Skip
-        else:
-            return \
-                mod.DispLinCommit_Pstarting_MW[g, tmp] - \
-                mod.DispLinCommit_Pstarting_MW[g,
-                                               mod.previous_timepoint[tmp,
-                                                                      mod
-                                                                          .balancing_type_project[
-                                                                          g]
-                                               ]
-                ] \
-                >= - mod.Start_Linear[g, tmp] \
-                * mod.DispLinCommit_Pmin_MW[g, tmp]
-
-    m.DispLinCommit_Increasing_Startup_Power_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Increasing_Startup_Power_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=increasing_startup_power_constraint_rule
     )
 
-    def power_during_startup_constraint_rule(mod, g, tmp):
-        """
-        Power provision in the start timepoint (i.e. the timepoint when the unit
-        is first committed) is constrained by the startup ramp rate (adjusted
-        for timepoint duration).
-
-        In other words, to provide 'committed' power in the start timepoint, we
-        need to have provided startup power in the previous timepoint, which
-        will in turn set the whole startup trajectory based on the previous
-        constraints.
-
-        When we are not in the start timepoint, simply constrain power provision
-        by the capacity, which may not bind. To elaborate, when we are not in a
-        start timepoint, t-1 could have had:
-        1) the unit committed, meaning Pstarting[t-1]=0, resulting in
-        power provision <= capacity, or
-        2) the unit not committed, meaning that we are also not committed in t,
-        i.e. power provision[t]=0, resulting in -Pstarting[t-1] <= capacity
-
-        (Commit[t] x Pmin + P_above_Pmin[t]) - Pstarting[t-1]
-        <=
-        (1 - Start[t]) x Pmax + Start[t] x Startup_Ramp_Rate x Pmax
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-
-        if tmp == mod.first_horizon_timepoint[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                and mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                == "linear":
-            return Constraint.Skip
-        else:
-            return (mod.Commit_Linear[g, tmp]
-                    * mod.DispLinCommit_Pmin_MW[g, tmp]
-                    + mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[g, tmp]
-                    ) \
-                   + mod.DispLinCommit_Upwards_Reserves_MW[g, tmp] \
-                   - mod.DispLinCommit_Pstarting_MW[g, mod.previous_timepoint[
-                tmp, mod.balancing_type_project[g]]] \
-                   <= \
-                   (1 - mod.Start_Linear[g, tmp]) \
-                   * mod.DispLinCommit_Pmax_MW[g, tmp] \
-                   + mod.Start_Linear[g, tmp] \
-                   * mod.DispLinCommit_Startup_Ramp_Rate_MW_Per_Timepoint[
-                       g, mod.previous_timepoint[tmp,
-                                                 mod.balancing_type_project[g]]
-                   ]
-
-    m.DispLinCommit_Power_During_Startup_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Power_During_Startup_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=power_during_startup_constraint_rule
     )
 
-    # Shutdown power
-    def max_shutdown_power_constraint_rule(mod, g, tmp):
-        """
-        Shutdown power is 0 when the unit is committed and must be less than or
-        equal to the minimum stable level when not committed
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-
-        return mod.DispLinCommit_Pstopping_MW[g, tmp] \
-               <= (1 - mod.Commit_Linear[g, tmp]) \
-               * mod.DispLinCommit_Pmin_MW[g, tmp]
-
-    m.DispLinCommit_Max_Shutdown_Power_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    # Shutdown Power
+    m.GenCommitLin_Max_Shutdown_Power_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=max_shutdown_power_constraint_rule
     )
 
-    def ramp_during_shutdown_constraint_rule(mod, g, tmp):
-        """
-        The difference between shutdown power of consecutive timepoints has to
-        obey shutdown ramp up rates.
-
-        We assume that a unit has to reach its setpoint at the start of the
-        timepoint; as such, the ramping between 2 timepoints is assumed to
-        take place during the duration of the first timepoint, and the
-        ramp rate is adjusted for the duration of the first timepoint.
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-
-        if tmp == mod.first_horizon_timepoint[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                and mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                == "linear":
-            return Constraint.Skip
-        else:
-            return mod.DispLinCommit_Pstopping_MW[g, mod.previous_timepoint[
-                tmp, mod.balancing_type_project[g]]] \
-                   - mod.DispLinCommit_Pstopping_MW[g, tmp] \
-                   <= mod.DispLinCommit_Shutdown_Ramp_Rate_MW_Per_Timepoint[
-                       g, mod.previous_timepoint[tmp,
-                                                 mod.balancing_type_project[g]]
-                   ]
-
-    m.DispLinCommit_Ramp_During_Shutdown_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Ramp_During_Shutdown_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=ramp_during_shutdown_constraint_rule
     )
 
-    def decreasing_shutdown_power_constraint_rule(mod, g, tmp):
-        """
-        DispLinCommit_Pstopping_MW[t] can only be less than
-        DispLinCommit_Pstopping_MW[t+1] if the unit stops in t+1 (when it is
-        back above 0). In other words, DispLinCommit_Pstopping_MW can only
-        increase in the stopping timepoint; in all other timepoints it should
-        decrease or stay constant. This prevents situations in which the model
-        can abuse this by providing stopping power in some timepoints without
-        previously having committed the unit.
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-        if tmp == mod.last_horizon_timepoint[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                and mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                == "linear":
-            return Constraint.Skip
-        else:
-            return \
-                mod.DispLinCommit_Pstopping_MW[g, tmp] - \
-                mod.DispLinCommit_Pstopping_MW[g,
-                                               mod.next_timepoint[tmp,
-                                                                  mod
-                                                                      .balancing_type_project[
-                                                                      g]
-                                               ]
-                ] \
-                >= \
-                - mod.Stop_Linear[g,
-                                  mod.next_timepoint[tmp,
-                                                     mod
-                                                         .balancing_type_project[
-                                                         g]
-                                  ]
-                ] * \
-                mod.DispLinCommit_Pmin_MW[g, tmp]
-
-    m.DispLinCommit_Decreasing_Shutdown_Power_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Decreasing_Shutdown_Power_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=decreasing_shutdown_power_constraint_rule
     )
 
-    def power_during_shutdown_constraint_rule(mod, g, tmp):
-        """
-        Power provision in the stop timepoint (i.e. the first timepoint the unit
-        is not committed after having been committed) is constrained by the
-        shutdown ramp rate (adjusted for timepoint duration).
-
-        In other words, to provide 'committed' power in the stop timepoint, we
-        need to provide shutdown power in the next timepoint, which will in turn
-        set the whole shutdown trajectory based on the previous constraints.
-
-        When we are not in the stop timepoint, simply constrain power provision
-        by the capacity, which may not bind. To elaborate, when we are not in a
-        stop timepoint, t+1 could have:
-        1) the unit committed, meaning Pstopping[t+1]=0, resulting in
-        power provision <= capacity, or
-        2) the unit not committed, meaning that we are also not committed in t
-        i.e. power provision[t]=0, resulting in -Pstopping[t+1] <= capacity
-
-        (Commit[t] x Pmin + P_above_Pmin[t]) - Pstopping[t+1]
-        <=
-        (1 - Stop[t+1]) x Pmax + Stop[t+1] x Shutdown_Ramp_Rate x Pmax
-        :param mod:
-        :param g:
-        :param tmp:
-        :return:
-        """
-
-        if tmp == mod.last_horizon_timepoint[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                and mod.boundary[
-            mod.horizon[tmp, mod.balancing_type_project[g]]] \
-                == "linear":
-            return Constraint.Skip
-        else:
-            return (mod.Commit_Linear[g, tmp]
-                    * mod.DispLinCommit_Pmin_MW[g, tmp]
-                    + mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[g,
-                                                                       tmp]) \
-                   + mod.DispLinCommit_Upwards_Reserves_MW[g, tmp] \
-                   - mod.DispLinCommit_Pstopping_MW[g, mod.next_timepoint[
-                tmp, mod.balancing_type_project[g]]] \
-                   <= \
-                   (1 - mod.Stop_Linear[g, mod.next_timepoint[
-                       tmp, mod.balancing_type_project[g]]]) \
-                   * mod.DispLinCommit_Pmax_MW[
-                       g, mod.next_timepoint[
-                           tmp, mod.balancing_type_project[g]]] \
-                   + mod.Stop_Linear[
-                       g, mod.next_timepoint[
-                           tmp, mod.balancing_type_project[g]]] \
-                   * mod.DispLinCommit_Shutdown_Ramp_Rate_MW_Per_Timepoint[
-                       g, tmp]
-
-    m.DispLinCommit_Power_During_Shutdown_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS,
+    m.GenCommitLin_Power_During_Shutdown_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS,
         rule=power_during_shutdown_constraint_rule
     )
 
-    def fuel_burn_constraint_rule(mod, g, tmp, s):
-        """
-        Fuel burn is set by piecewise linear representation of input/output
-        curve.
-
-        Note: we assume that when projects are derated for availability, the
-        input/output curve is derated by the same amount. The implicit
-        assumption is that when a generator is de-rated, some of its units
-        are out rather than it being forced to run below minimum stable level
-        at very inefficient operating points.
-        :param mod:
-        :param g:
-        :param tmp:
-        :param s:
-        :return:
-        """
-        return \
-            mod.Fuel_Burn_DispLinCommit_MMBTU[g, tmp] \
-            >= \
-            mod.fuel_burn_slope_mmbtu_per_mwh[g, s] \
-            * mod.Provide_Power_DispLinearCommit_MW[g, tmp] \
-            + mod.fuel_burn_intercept_mmbtu_per_hr[g, s] \
-            * mod.Availability_Derate[g, tmp] \
-            * mod.DispLinCommit_Synced_Units[g, tmp]
-
-    m.Fuel_Burn_DispLinCommit_Constraint = Constraint(
-        m.DISPATCHABLE_LINEAR_COMMIT_FUEL_PROJECT_SEGMENTS_OPERATIONAL_TIMEPOINTS,
+    # Fuel Burn
+    m.GenCommitLin_Fuel_Burn_Constraint = Constraint(
+        m.GEN_COMMIT_LIN_OPR_TMPS_FUEL_SEG,
         rule=fuel_burn_constraint_rule
     )
 
 
-def power_provision_rule(mod, g, tmp):
+# Expression Rules
+###########################################################################
+
+def pmax_rule(mod, g, tmp):
     """
-    :param mod: the Pyomo abstract model
-    :param g: the project
-    :param tmp: the operational timepoint
-    :return: expression for power provision by dispatchable-linear-commit
-     generators
-
-    Power provision for dispatchable-linear-commit generators is a
-    variable constrained to be between the generator's minimum stable level
-    and its capacity if the generator is committed and 0 otherwise.
-
+    **Expression Name**: GenCommitLin_Pmax_MW
+    **Defined Over**: GEN_COMMIT_LIN_OPR_TMPS
     """
-    return mod.Provide_Power_DispLinearCommit_MW[g, tmp]
+    return mod.Capacity_MW[g, mod.period[tmp]] \
+           * mod.Availability_Derate[g, tmp]
 
 
-# RPS
-def rec_provision_rule(mod, g, tmp):
+def pmin_rule(mod, g, tmp):
     """
-    REC provision of dispatchable generators is an endogenous variable.
+    **Expression Name**: GenCommitLin_Pmin_MW
+    **Defined Over**: GEN_COMMIT_LIN_OPR_TMPS
+    """
+    return mod.Capacity_MW[g, mod.period[tmp]] \
+           * mod.Availability_Derate[g, tmp] \
+           * mod.gen_commit_lin_min_stable_level_fraction[g]
+
+
+def provide_power_rule(mod, g, tmp):
+    """
+    **Expression Name**: GenCommitLin_Provide_Power_MW
+    **Defined Over**: GEN_COMMIT_LIN_OPR_TMPS
+    """
+    return mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp] \
+           + mod.GenCommitLin_Pmin_MW[g, tmp] \
+           * mod.GenCommitLin_Commit[g, tmp] \
+           + mod.GenCommitLin_Provide_Power_Startup_MW[g, tmp] \
+           + mod.GenCommitLin_Provide_Power_Shutdown_MW[g, tmp]
+
+
+def ramp_up_rate_rule(mod, g, tmp):
+    """
+    **Expression Name**: GenCommitLin_Ramp_Up_Rate_MW_Per_Tmp
+    **Defined Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Ramp up rate limit in MW per timepoint, derived from input ramp rate
+    which is given in fraction of installed capacity per minute. Longer
+    timepoints will lead to a larger ramp up rate limit, since ramping
+    can take place over a longer duration.
+    Unit check:
+        capacity [MW]
+        * availability [unit-less]
+        * ramp up rate [1/min]
+        * hours in timepoint [hours/timepoint]
+        * minutes per hour [min/hour]
+        = ramp up rate [MW/timepoint]
+    """
+    return mod.Capacity_MW[g, mod.period[tmp]] \
+           * mod.Availability_Derate[g, tmp] \
+           * mod.gen_commit_lin_ramp_up_when_on_rate[g] \
+           * mod.number_of_hours_in_timepoint[tmp] \
+           * 60  # convert min to hours
+
+
+def ramp_down_rate_rule(mod, g, tmp):
+    """
+    **Expression Name**: GenCommitLin_Ramp_Down_Rate_MW_Per_Tmp
+    **Defined Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Ramp down rate limit in MW per timepoint, derived from input ramp rate
+    which is given in fraction of installed capacity per minute. Longer
+    timepoints will lead to a larger ramp down rate limit, since ramping
+    can take place over a longer duration.
+    Unit check:
+        capacity [MW]
+        * availability [unit-less]
+        * ramp down rate [1/min]
+        * hours in timepoint [hours/timepoint]
+        * minutes per hour [min/hour]
+        = ramp down rate [MW/timepoint]
+    """
+    return mod.Capacity_MW[g, mod.period[tmp]] \
+           * mod.Availability_Derate[g, tmp] \
+           * mod.gen_commit_lin_ramp_down_when_on_rate[g] \
+           * mod.number_of_hours_in_timepoint[tmp] \
+           * 60  # convert min to hours
+
+
+def startup_ramp_rate_rule(mod, g, tmp):
+    """
+    **Expression Name**: GenCommitLin_Startup_Ramp_Rate_MW_Per_Tmp
+    **Defined Over**: GEN_COMMIT_LIN_OPR_TMPS
+    """
+    return mod.Capacity_MW[g, mod.period[tmp]] \
+           * mod.Availability_Derate[g, tmp] \
+           * min(mod.gen_commit_lin_startup_plus_ramp_up_rate[g]
+                 * mod.number_of_hours_in_timepoint[tmp]
+                 * 60, 1)
+
+
+def shutdown_ramp_rate_rule(mod, g, tmp):
+    """
+    **Expression Name**: GenCommitLin_Shutdown_Ramp_Rate_MW_Per_Tmp
+    **Defined Over**: GEN_COMMIT_LIN_OPR_TMPS
+    """
+    return mod.Capacity_MW[g, mod.period[tmp]] \
+           * mod.Availability_Derate[g, tmp] \
+           * min(mod.gen_commit_lin_shutdown_plus_ramp_down_rate[g]
+                 * mod.number_of_hours_in_timepoint[tmp]
+                 * 60, 1)
+
+
+# Constraint Formulation Rules
+###############################################################################
+
+# Commitment
+def binary_logic_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Binary_Logic_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    If commit status changes, unit is turning on or shutting down.
+    The *GenCommitLin_Startup* variable is 1 for the first timepoint the unit
+    is committed after being offline; it will be able to provide power in that
+    timepoint. The *GenCommitLin_Shutdown* variable is 1 for the first
+    timepoint the unit is not committed after being online; it will not be
+    able to provide power in that timepoint.
+
+    Constraint (8) in Morales-Espana et al. (2013)
+    """
+
+    # TODO: if we can link horizons, input commit from previous horizon's
+    #  last timepoint rather than skipping the constraint
+    if tmp == mod.first_horizon_timepoint[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            and mod.boundary[mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            == "linear":
+        return Constraint.Skip
+    else:
+        return mod.GenCommitLin_Commit[g, tmp] \
+               - mod.GenCommitLin_Commit[
+                   g, mod.previous_timepoint[
+                       tmp, mod.balancing_type_project[g]]] \
+               == mod.GenCommitLin_Startup[g, tmp] - mod.GenCommitLin_Shutdown[
+                   g, tmp]
+
+
+def synced_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Synced_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Synced is 1 if the unit is committed, starting, or stopping and zero
+    otherwise.
+    """
+    return mod.GenCommitLin_Synced[g, tmp] \
+           >= mod.GenCommitLin_Commit[g, tmp] \
+           + (mod.GenCommitLin_Provide_Power_Startup_MW[g, tmp]
+              + mod.GenCommitLin_Provide_Power_Shutdown_MW[g, tmp]) \
+           / mod.GenCommitLin_Pmin_MW[g, tmp]
+
+
+# Power
+def max_power_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Max_Power_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Power provision plus upward reserves shall not exceed maximum power.
+    """
+    return \
+        (mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp]
+         + mod.GenCommitLin_Upwards_Reserves_MW[g, tmp]) \
+        <= \
+        (mod.GenCommitLin_Pmax_MW[g, tmp]
+         - mod.GenCommitLin_Pmin_MW[g, tmp]) \
+        * mod.GenCommitLin_Commit[g, tmp]
+
+
+def min_power_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Min_Power_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Power minus downward services cannot be below minimum stable level.
+    This constraint is not in Morales-Espana et al. (2013) because they
+    don't look at downward reserves. In that case, enforcing
+    provide_power_above_pmin to be within NonNegativeReals is sufficient.
+    """
+    return mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp] \
+        - mod.GenCommitLin_Downwards_Reserves_MW[g, tmp] \
+        >= 0
+
+
+# Minimum Up and Down Time
+def min_up_time_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Min_Up_Time_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    When units are started, they have to stay on for a minimum number
+    of hours described by the gen_commit_lin_min_up_time_hrs parameter.
+    The constraint is enforced by ensuring that the binary commitment
+    is at least as large as the number of unit starts within min up time
+    hours.
+
+    We ensure a unit turned on less than the minimum up time ago is
+    still on in the current timepoint *tmp* by checking how much units
+    were turned on in each 'relevant' timepoint (i.e. a timepoint that
+    begins more than or equal to gen_commit_lin_min_up_time_hrs ago
+    relative to the start of timepoint *tmp*) and then summing those
+    starts.
+
+    If using linear horizon boundaries, the constraint is skipped for all
+    timepoints less than min up time hours from the start of the timepoint's
+    horizon because the constraint for the first included timepoint
+    will sufficiently constrain the binary start variables of all the
+    timepoints before it.
+
+    Constraint (6) in Morales-Espana et al. (2013)
+
+    Example 1:
+      min_up_time = 4; tmps = [0,1,2,3];
+      hours_in_tmps = [1,3,1,1];
+      tmp = 2; relevant_tmps = [1,2]
+      --> if there is a start in tmp 1, you have to be committed in tmp 2
+      --> starts in all other tmps (incl. tmp 0) don't affect tmp 2
+    Example 2:
+      min_up_time = 4; tmps = [0,1,2,3];
+      hours_in_tmps = [1,4,1,1];
+      tmp = 2; relevant_tmps = [2]
+      --> start in t1 does not affect state of t2; tmp 1 is 4 hrs long
+      --> so even if you start in tmp 1 you can stop again in tmp 2
+      --> The constraint simply ensures that the unit is committed if
+      --> it is turned on.
+    Example 3:
+      min_up_time = 4; tmps = [0,1,2,3];
+      hours_in_tmps = [1,1,1,1];
+      tmp = 2; relevant_tmps = [0,1,2,3]
+      --> if there is a start in tmp 0, 1, 2, or 3, you have to be committed
+      --> in tmp 2. The unit either has to be on for all timepoints, or off
+      --> for all timepoints
+    """
+
+    relevant_tmps = determine_relevant_timepoints(
+        mod, g, tmp, mod.gen_commit_lin_min_up_time_hrs[g]
+    )
+
+    number_of_starts_min_up_time_or_less_hours_ago = \
+        sum(mod.GenCommitLin_Startup[g, tp] for tp in relevant_tmps)
+
+    # If we've reached the first timepoint in linear boundary mode and
+    # the total duration of the relevant timepoints (which includes *tmp*)
+    # is less than the minimum up time, skip the constraint since the next
+    # timepoint's constraint will already cover these same timepoints.
+    # Don't skip if this timepoint is the last timepoint of the horizon
+    # (since there will be no next timepoint).
+    if (mod.boundary[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] == "linear"
+            and
+            relevant_tmps[-1]
+            == mod.first_horizon_timepoint[
+                mod.horizon[tmp, mod.balancing_type_project[g]]]
+            and
+            sum(mod.number_of_hours_in_timepoint[t] for t in relevant_tmps)
+            < mod.gen_commit_lin_min_up_time_hrs[g]
+            and
+            tmp != mod.last_horizon_timepoint[
+                mod.horizon[tmp, mod.balancing_type_project[g]]]):
+        return Constraint.Skip
+    # Otherwise, if there was a start min_up_time or less ago, the unit has
+    # to remain committed.
+    else:
+        return mod.GenCommitLin_Commit[g, tmp] \
+               >= number_of_starts_min_up_time_or_less_hours_ago
+
+
+def min_down_time_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Min_Down_Time_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    When units are shut down, they have to stay off for a minimum number
+    of hours described by the gen_commit_lin_min_down_time_hrs parameter.
+    The constraint is enforced by ensuring that (1-binary commitment)
+    is at least as large as the number of unit shutdowns within min down
+    time hours.
+
+    We ensure a unit shut down less than the minimum up time ago is
+    still off in the current timepoint *tmp* by checking how much units
+    were shut down in each 'relevant' timepoint (i.e. a timepoint that
+    begins more than or equal to gen_commit_lin_min_down_time_hrs ago
+    relative to the start of timepoint *tmp*) and then summing those
+    shutdowns.
+
+    If using linear horizon boundaries, the constraint is skipped for all
+    timepoints less than min down time hours from the start of the
+    timepoint's horizon because the constraint for the first included
+    timepoint will sufficiently constrain the binary stop variables of all
+    the timepoints before it.
+
+    Constraint (7) in Morales-Espana et al. (2013)
+    """
+
+    relevant_tmps = determine_relevant_timepoints(
+        mod, g, tmp, mod.gen_commit_lin_min_down_time_hrs[g]
+    )
+
+    number_of_stops_min_down_time_or_less_hours_ago = \
+        sum(mod.GenCommitLin_Shutdown[g, tp] for tp in relevant_tmps)
+
+    # If we've reached the first timepoint in linear boundary mode and
+    # the total duration of the relevant timepoints (which includes *tmp*)
+    # is less than the minimum down time, skip the constraint since the
+    # next timepoint's constraint will already cover these same timepoints.
+    # Don't skip if this timepoint is the last timepoint of the horizon
+    # (since there will be no next timepoint).
+    if (mod.boundary[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] == "linear"
+            and
+            relevant_tmps[-1]
+            == mod.first_horizon_timepoint[
+                mod.horizon[tmp, mod.balancing_type_project[g]]]
+            and
+            sum(mod.number_of_hours_in_timepoint[t] for t in relevant_tmps)
+            < mod.gen_commit_lin_min_down_time_hrs[g]
+            and
+            tmp != mod.last_horizon_timepoint[
+                mod.horizon[tmp, mod.balancing_type_project[g]]]):
+        return Constraint.Skip
+    # Otherwise, if there was a shutdown min_down_time or less ago, the unit
+    # has to remain shut down.
+    else:
+        return 1 - mod.GenCommitLin_Commit[g, tmp] \
+               >= number_of_stops_min_down_time_or_less_hours_ago
+
+
+# Ramps
+def ramp_up_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Ramp_Up_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Difference between power generation of consecutive timepoints has to
+    obey ramp up rates.
+
+    We assume that a unit has to reach its setpoint at the start of the
+    timepoint; as such, the ramping between 2 timepoints is assumed to
+    take place during the duration of the first timepoint, and the
+    ramp rate is adjusted for the duration of the first timepoint.
+    Constraint (12) in Morales-Espana et al. (2013)
+    """
+    if tmp == mod.first_horizon_timepoint[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            and mod.boundary[mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            == "linear":
+        return Constraint.Skip
+    # If ramp rate limits, adjusted for timepoint duration, allow you to
+    # ramp up the full operable range between timepoints, constraint
+    # won't bind, so skip
+    elif (mod.gen_commit_lin_ramp_up_when_on_rate[g] * 60
+          * mod.number_of_hours_in_timepoint[
+              mod.previous_timepoint[tmp, mod.balancing_type_project[g]]]
+          >= (1 - mod.gen_commit_lin_min_stable_level_fraction[g])):
+        return Constraint.Skip
+    else:
+        return \
+            (mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp]
+             + mod.GenCommitLin_Upwards_Reserves_MW[g, tmp]) \
+            - \
+            (mod.GenCommitLin_Provide_Power_Above_Pmin_MW[
+                 g, mod.previous_timepoint[tmp, mod.balancing_type_project[g]]]
+             - mod.GenCommitLin_Downwards_Reserves_MW[
+                 g, mod.previous_timepoint[
+                     tmp, mod.balancing_type_project[g]]]) \
+            <= \
+            mod.GenCommitLin_Ramp_Up_Rate_MW_Per_Tmp[
+                g, mod.previous_timepoint[tmp, mod.balancing_type_project[g]]]
+
+
+def ramp_down_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Ramp_Down_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Difference between power generation of consecutive timepoints has to
+    obey ramp down rates.
+    We assume that a unit has to reach its setpoint at the start of the
+    timepoint; as such, the ramping between 2 timepoints is assumed to
+    take place during the duration of the first timepoint, and the
+    ramp rate is adjusted for the duration of the first timepoint.
+    Constraint (13) in Morales-Espana et al. (2013)
+    """
+    if tmp == mod.first_horizon_timepoint[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            and mod.boundary[mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            == "linear":
+        return Constraint.Skip
+    # If ramp rate limits, adjusted for timepoint duration, allow you to
+    # ramp down the full operable range between timepoints, constraint
+    # won't bind, so skip
+    elif (mod.gen_commit_lin_ramp_down_when_on_rate[g] * 60
+          * mod.number_of_hours_in_timepoint[
+              mod.previous_timepoint[tmp, mod.balancing_type_project[g]]]
+          >= (1 - mod.gen_commit_lin_min_stable_level_fraction[g])):
+        return Constraint.Skip
+    else:
+        return \
+            (mod.GenCommitLin_Provide_Power_Above_Pmin_MW[
+                 g, mod.previous_timepoint[tmp, mod.balancing_type_project[g]]]
+             + mod.GenCommitLin_Upwards_Reserves_MW[
+                 g, mod.previous_timepoint[
+                     tmp, mod.balancing_type_project[g]]]) \
+            - \
+            (mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp]
+             - mod.GenCommitLin_Downwards_Reserves_MW[g, tmp]) \
+            <= mod.GenCommitLin_Ramp_Down_Rate_MW_Per_Tmp[
+                g, mod.previous_timepoint[tmp, mod.balancing_type_project[g]]]
+
+
+# Startup Power
+def max_startup_power_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Max_Startup_Power_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Startup power is 0 when the unit is committed and must be less than or
+    equal to the minimum stable level when not committed.
+    """
+
+    return mod.GenCommitLin_Provide_Power_Startup_MW[g, tmp] \
+           <= (1 - mod.GenCommitLin_Commit[g, tmp]) \
+           * mod.GenCommitLin_Pmin_MW[g, tmp]
+
+
+def ramp_during_startup_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Ramp_During_Startup_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    The difference between startup power of consecutive timepoints has to
+    obey startup ramp up rates.
+
+    We assume that a unit has to reach its setpoint at the start of the
+    timepoint; as such, the ramping between 2 timepoints is assumed to
+    take place during the duration of the first timepoint, and the
+    ramp rate is adjusted for the duration of the first timepoint.
+    """
+
+    if tmp == mod.first_horizon_timepoint[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            and mod.boundary[mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            == "linear":
+        return Constraint.Skip
+    else:
+        return \
+            mod.GenCommitLin_Provide_Power_Startup_MW[g, tmp] - \
+            mod.GenCommitLin_Provide_Power_Startup_MW[g,
+                                                      mod.previous_timepoint[
+                                                          tmp,
+                                                          mod
+                                                              .balancing_type_project[
+                                                              g]
+                                                      ]
+            ] \
+            <= mod.GenCommitLin_Startup_Ramp_Rate_MW_Per_Tmp[
+                g, mod.previous_timepoint[tmp,
+                                          mod.balancing_type_project[g]]
+            ]
+
+
+def increasing_startup_power_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Increasing_Startup_Power_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    GenCommitLin_Provide_Power_Startup_MW[t] can only be less than
+    GenCommitLin_Provide_Power_Startup_MW[t-1] in the starting timepoint (when
+    it is is back at 0). In other words, GenCommitLin_Provide_Power_Startup_MW
+    can only decrease in the starting timepoint; in all other timepoints it
+    should increase or stay constant. This prevents situations in which the
+    model can abuse this by providing starting power in some timepoints and
+    then reducing power back to 0 without ever committing the unit.
+    """
+    if tmp == mod.first_horizon_timepoint[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            and mod.boundary[mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            == "linear":
+        return Constraint.Skip
+    else:
+        return \
+            mod.GenCommitLin_Provide_Power_Startup_MW[g, tmp] \
+            - mod.GenCommitLin_Provide_Power_Startup_MW[
+                g, mod.previous_timepoint[tmp, mod.balancing_type_project[g]]]\
+            >= - mod.GenCommitLin_Startup[g, tmp] \
+            * mod.GenCommitLin_Pmin_MW[g, tmp]
+
+
+def power_during_startup_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Power_During_Startup_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Power provision in the start timepoint (i.e. the timepoint when the unit
+    is first committed) is constrained by the startup ramp rate (adjusted
+    for timepoint duration).
+
+    In other words, to provide 'committed' power in the start timepoint, we
+    need to have provided startup power in the previous timepoint, which
+    will in turn set the whole startup trajectory based on the previous
+    constraints.
+
+    When we are not in the start timepoint, simply constrain power provision
+    by the capacity, which may not bind. To elaborate, when we are not in a
+    start timepoint, t-1 could have had:
+    1) the unit committed, meaning Pstarting[t-1]=0, resulting in
+    power provision <= capacity, or
+    2) the unit not committed, meaning that we are also not committed in t,
+    i.e. power provision[t]=0, resulting in -Pstarting[t-1] <= capacity
+
+    (Commit[t] x Pmin + P_above_Pmin[t]) - Pstarting[t-1]
+    <=
+    (1 - Start[t]) x Pmax + Start[t] x Startup_Ramp_Rate x Pmax
     :param mod:
     :param g:
     :param tmp:
     :return:
     """
-    return mod.Provide_Power_DispLinearCommit_MW[g, tmp]
+
+    if tmp == mod.first_horizon_timepoint[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            and mod.boundary[mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            == "linear":
+        return Constraint.Skip
+    else:
+        return (mod.GenCommitLin_Commit[g, tmp]
+                * mod.GenCommitLin_Pmin_MW[g, tmp]
+                + mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp]
+                ) \
+               + mod.GenCommitLin_Upwards_Reserves_MW[g, tmp] \
+               - mod.GenCommitLin_Provide_Power_Startup_MW[
+                   g, mod.previous_timepoint[
+                       tmp, mod.balancing_type_project[g]]] \
+               <= \
+               (1 - mod.GenCommitLin_Startup[g, tmp]) \
+               * mod.GenCommitLin_Pmax_MW[g, tmp] \
+               + mod.GenCommitLin_Startup[g, tmp] \
+               * mod.GenCommitLin_Startup_Ramp_Rate_MW_Per_Tmp[
+                   g, mod.previous_timepoint[tmp,
+                                             mod.balancing_type_project[g]]
+               ]
+
+
+# Shutdown Power
+def max_shutdown_power_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Max_Shutdown_Power_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Shutdown power is 0 when the unit is committed and must be less than or
+    equal to the minimum stable level when not committed
+    """
+
+    return mod.GenCommitLin_Provide_Power_Shutdown_MW[g, tmp] \
+           <= (1 - mod.GenCommitLin_Commit[g, tmp]) \
+           * mod.GenCommitLin_Pmin_MW[g, tmp]
+
+
+def ramp_during_shutdown_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Ramp_During_Shutdown_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    The difference between shutdown power of consecutive timepoints has to
+    obey shutdown ramp up rates.
+
+    We assume that a unit has to reach its setpoint at the start of the
+    timepoint; as such, the ramping between 2 timepoints is assumed to
+    take place during the duration of the first timepoint, and the
+    ramp rate is adjusted for the duration of the first timepoint.
+    """
+
+    if tmp == mod.first_horizon_timepoint[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            and mod.boundary[mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            == "linear":
+        return Constraint.Skip
+    else:
+        return mod.GenCommitLin_Provide_Power_Shutdown_MW[
+                   g, mod.previous_timepoint[
+                       tmp, mod.balancing_type_project[g]]] \
+               - mod.GenCommitLin_Provide_Power_Shutdown_MW[g, tmp] \
+               <= mod.GenCommitLin_Shutdown_Ramp_Rate_MW_Per_Tmp[
+                   g, mod.previous_timepoint[tmp,
+                                             mod.balancing_type_project[g]]
+               ]
+
+
+def decreasing_shutdown_power_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Decreasing_Shutdown_Power_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    GenCommitLin_Provide_Power_Shutdown_MW[t] can only be less than
+    GenCommitLin_Provide_Power_Shutdown_MW[t+1] if the unit stops in t+1 (when
+    it is back above 0). In other words, GenCommitLin_Provide_Power_Shutdown_MW
+    can only increase in the stopping timepoint; in all other timepoints it
+    should decrease or stay constant. This prevents situations in which the
+    model can abuse this by providing stopping power in some timepoints without
+    previously having committed the unit.
+    """
+    if tmp == mod.last_horizon_timepoint[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            and mod.boundary[mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            == "linear":
+        return Constraint.Skip
+    else:
+        return \
+            mod.GenCommitLin_Provide_Power_Shutdown_MW[g, tmp] - \
+            mod.GenCommitLin_Provide_Power_Shutdown_MW[
+                g, mod.next_timepoint[tmp, mod.balancing_type_project[g]]] \
+            >= - mod.GenCommitLin_Shutdown[
+                g, mod.next_timepoint[tmp, mod.balancing_type_project[g]]] \
+            * mod.GenCommitLin_Pmin_MW[g, tmp]
+
+
+def power_during_shutdown_constraint_rule(mod, g, tmp):
+    """
+    **Constraint Name**: GenCommitLin_Power_During_Shutdown_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Power provision in the stop timepoint (i.e. the first timepoint the unit
+    is not committed after having been committed) is constrained by the
+    shutdown ramp rate (adjusted for timepoint duration).
+
+    In other words, to provide 'committed' power in the stop timepoint, we
+    need to provide shutdown power in the next timepoint, which will in turn
+    set the whole shutdown trajectory based on the previous constraints.
+
+    When we are not in the stop timepoint, simply constrain power provision
+    by the capacity, which may not bind. To elaborate, when we are not in a
+    stop timepoint, t+1 could have:
+    1) the unit committed, meaning Pstopping[t+1]=0, resulting in
+    power provision <= capacity, or
+    2) the unit not committed, meaning that we are also not committed in t
+    i.e. power provision[t]=0, resulting in -Pstopping[t+1] <= capacity
+
+    (Commit[t] x Pmin + P_above_Pmin[t]) - Pstopping[t+1]
+    <=
+    (1 - Stop[t+1]) x Pmax + Stop[t+1] x Shutdown_Ramp_Rate x Pmax
+    """
+
+    if tmp == mod.last_horizon_timepoint[
+        mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            and mod.boundary[mod.horizon[tmp, mod.balancing_type_project[g]]] \
+            == "linear":
+        return Constraint.Skip
+    else:
+        return (mod.GenCommitLin_Commit[g, tmp]
+                * mod.GenCommitLin_Pmin_MW[g, tmp]
+                + mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g,
+                                                               tmp]) \
+               + mod.GenCommitLin_Upwards_Reserves_MW[g, tmp] \
+               - mod.GenCommitLin_Provide_Power_Shutdown_MW[
+                   g, mod.next_timepoint[
+                       tmp, mod.balancing_type_project[g]]] \
+               <= \
+               (1 - mod.GenCommitLin_Shutdown[g, mod.next_timepoint[
+                   tmp, mod.balancing_type_project[g]]]) \
+               * mod.GenCommitLin_Pmax_MW[
+                   g, mod.next_timepoint[tmp, mod.balancing_type_project[g]]] \
+               + mod.GenCommitLin_Shutdown[
+                   g, mod.next_timepoint[tmp, mod.balancing_type_project[g]]] \
+               * mod.GenCommitLin_Shutdown_Ramp_Rate_MW_Per_Tmp[g, tmp]
+
+
+def fuel_burn_constraint_rule(mod, g, tmp, s):
+    """
+    **Constraint Name**: GenCommitLin_Fuel_Burn_Constraint
+    **Enforced Over**: GEN_COMMIT_LIN_OPR_TMPS
+
+    Fuel burn is set by piecewise linear representation of input/output
+    curve.
+
+    Note: we assume that when projects are derated for availability, the
+    input/output curve is derated by the same amount. The implicit
+    assumption is that when a generator is de-rated, some of its units
+    are out rather than it being forced to run below minimum stable level
+    at very inefficient operating points.
+    """
+    return \
+        mod.GenCommitLin_Fuel_Burn_MMBTU[g, tmp] \
+        >= \
+        mod.fuel_burn_slope_mmbtu_per_mwh[g, s] \
+        * mod.GenCommitLin_Provide_Power_MW[g, tmp] \
+        + mod.fuel_burn_intercept_mmbtu_per_hr[g, s] \
+        * mod.Availability_Derate[g, tmp] \
+        * mod.GenCommitLin_Synced[g, tmp]
+
+
+# Operational Type Methods
+###############################################################################
+
+def power_provision_rule(mod, g, tmp):
+    """
+    Power provision for gen_commit_lin generators is a variable constrained
+    constrained to be between the generator's minimum stable level and its
+    capacity if the generator is committed and 0 otherwise.
+    """
+    return mod.GenCommitLin_Provide_Power_MW[g, tmp]
+
+
+def rec_provision_rule(mod, g, tmp):
+    """
+    REC provision of dispatchable generators is an endogenous variable.
+    """
+    return mod.GenCommitLin_Provide_Power_MW[g, tmp]
 
 
 def commitment_rule(mod, g, tmp):
     """
     Commitment decision in each timepoint
-    :param mod:
-    :param g:
-    :param tmp:
-    :return:
     """
-    # TODO: shouldn't we return MW here to make this general?
-    return mod.Commit_Linear[g, tmp]
+    # TODO: shouldn't we return MW here to make this consistent w
+    #  gen_commit_cap?
+    return mod.GenCommitLin_Commit[g, tmp]
 
 
 def online_capacity_rule(mod, g, tmp):
     """
-    Capacity online in each timepoint
-    :param mod:
-    :param g:
-    :param tmp:
-    :return:
+    Capacity online in each timepoint.
     """
-    return mod.DispLinCommit_Pmax_MW[g, tmp] \
-           * mod.Commit_Linear[g, tmp]
+    return mod.GenCommitLin_Pmax_MW[g, tmp] \
+           * mod.GenCommitLin_Commit[g, tmp]
 
 
 def scheduled_curtailment_rule(mod, g, tmp):
     """
     No 'curtailment' -- simply dispatch down
-    :param mod:
-    :param g:
-    :param tmp:
-    :return:
     """
     return 0
 
@@ -1062,36 +1381,21 @@ def scheduled_curtailment_rule(mod, g, tmp):
 # TODO: ignoring subhourly behavior for dispatchable gens for now
 def subhourly_curtailment_rule(mod, g, tmp):
     """
-
-    :param mod:
-    :param g:
-    :param tmp:
-    :return:
     """
     return 0
 
 
 def subhourly_energy_delivered_rule(mod, g, tmp):
     """
-
-    :param mod:
-    :param g:
-    :param tmp:
-    :return:
     """
     return 0
 
 
 def fuel_burn_rule(mod, g, tmp, error_message):
     """
-    :param mod:
-    :param g:
-    :param tmp:
-    :param error_message:
-    :return:
     """
     if g in mod.FUEL_PROJECTS:
-        return mod.Fuel_Burn_DispLinCommit_MMBTU[g, tmp]
+        return mod.GenCommitLin_Fuel_Burn_MMBTU[g, tmp]
     else:
         raise ValueError(error_message)
 
@@ -1104,11 +1408,7 @@ def startup_shutdown_rule(mod, g, tmp):
     If horizon is circular, the last timepoint of the horizon is the
     previous_timepoint for the first timepoint if the horizon;
     if the horizon is linear, no previous_timepoint is defined for the first
-    timepoint of the horizon, so return 'None' here
-    :param mod:
-    :param g:
-    :param tmp:
-    :return:
+    timepoint of the horizon, so return 'None' here.
     """
     if tmp == mod.first_horizon_timepoint[
         mod.horizon[tmp, mod.balancing_type_project[g]]] \
@@ -1116,21 +1416,17 @@ def startup_shutdown_rule(mod, g, tmp):
             == "linear":
         return None
     else:
-        return (mod.Commit_Linear[g, tmp]
-                - mod.Commit_Linear[
+        return (mod.GenCommitLin_Commit[g, tmp]
+                - mod.GenCommitLin_Commit[
                     g, mod.previous_timepoint[
                         tmp, mod.balancing_type_project[g]]]) \
-               * mod.DispLinCommit_Pmax_MW[g, tmp]
+               * mod.GenCommitLin_Pmax_MW[g, tmp]
 
 
 def power_delta_rule(mod, g, tmp):
     """
     Ramp between this timepoint and the previous timepoint
     Actual ramp rate in MW/hr depends on the duration of the timepoints.
-    :param mod:
-    :param g:
-    :param tmp:
-    :return:
     """
     if tmp == mod.first_horizon_timepoint[
         mod.horizon[tmp, mod.balancing_type_project[g]]] \
@@ -1138,23 +1434,22 @@ def power_delta_rule(mod, g, tmp):
             == "linear":
         pass
     else:
-        return mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[g, tmp] - \
-               mod.Provide_Power_Above_Pmin_DispLinearCommit_MW[
+        return mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp] \
+               - mod.GenCommitLin_Provide_Power_Above_Pmin_MW[
                    g, mod.previous_timepoint[
                        tmp, mod.balancing_type_project[g]]]
 
 
 def fix_commitment(mod, g, tmp):
     """
-    :param mod:
-    :param g:
-    :param tmp:
-    :return:
     """
-    mod.Commit_Linear[g, tmp] = \
+    mod.GenCommitLin_Commit[g, tmp] = \
         mod.fixed_commitment[g, mod.previous_stage_timepoint_map[tmp]]
-    mod.Commit_Linear[g, tmp].fixed = True
+    mod.GenCommitLin_Commit[g, tmp].fixed = True
 
+
+# Input-Output
+###############################################################################
 
 def load_module_specific_data(mod, data_portal,
                               scenario_directory, subproblem, stage):
@@ -1204,7 +1499,7 @@ def load_module_specific_data(mod, data_portal,
             min_stable_fraction[row[0]] = float(row[2])
         else:
             pass
-    data_portal.data()["disp_linear_commit_min_stable_level_fraction"] = \
+    data_portal.data()["gen_commit_lin_min_stable_level_fraction"] = \
         min_stable_fraction
 
     # Ramp rate limits are optional, will default to 1 if not specified
@@ -1216,8 +1511,7 @@ def load_module_specific_data(mod, data_portal,
                 startup_plus_ramp_up_rate[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "displincommit_startup_plus_ramp_up_rate"] = \
+        data_portal.data()["gen_commit_lin_startup_plus_ramp_up_rate"] = \
             startup_plus_ramp_up_rate
 
     if "shutdown_plus_ramp_down_rate" in used_columns:
@@ -1228,8 +1522,7 @@ def load_module_specific_data(mod, data_portal,
                 shutdown_plus_ramp_down_rate[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "displincommit_shutdown_plus_ramp_down_rate"] = \
+        data_portal.data()["gen_commit_lin_shutdown_plus_ramp_down_rate"] = \
             shutdown_plus_ramp_down_rate
 
     if "ramp_up_when_on_rate" in used_columns:
@@ -1240,8 +1533,7 @@ def load_module_specific_data(mod, data_portal,
                 ramp_up_when_on_rate[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "displincommit_ramp_up_when_on_rate"] = \
+        data_portal.data()["gen_commit_lin_ramp_up_when_on_rate"] = \
             ramp_up_when_on_rate
 
     if "ramp_down_when_on_rate" in used_columns:
@@ -1252,8 +1544,7 @@ def load_module_specific_data(mod, data_portal,
                 ramp_down_when_on_rate[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "displincommit_ramp_down_when_on_rate"] = \
+        data_portal.data()["gen_commit_lin_ramp_down_when_on_rate"] = \
             ramp_down_when_on_rate
 
     # Up and down time limits are optional, will default to 1 if not specified
@@ -1265,9 +1556,7 @@ def load_module_specific_data(mod, data_portal,
                 min_up_time[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "displincommit_min_up_time_hours"] = \
-            min_up_time
+        data_portal.data()["gen_commit_lin_min_up_time_hrs"] = min_up_time
 
     if "min_down_time_hours" in used_columns:
         for row in zip(dynamic_components["project"],
@@ -1277,9 +1566,7 @@ def load_module_specific_data(mod, data_portal,
                 min_down_time[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "displincommit_min_down_time_hours"] = \
-            min_down_time
+        data_portal.data()["gen_commit_lin_min_down_time_hrs"] = min_down_time
 
 
 def export_module_specific_results(mod, d,
@@ -1293,7 +1580,8 @@ def export_module_specific_results(mod, d,
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_linear_commit.csv"), "w", newline="") as f:
+                           "dispatch_continuous_commit.csv"),
+              "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "balancing_type_project",
                          "horizon", "timepoint", "timepoint_weight",
@@ -1303,9 +1591,7 @@ def export_module_specific_results(mod, d,
                          "synced_units"
                          ])
 
-        for (p, tmp) \
-                in mod. \
-                DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS:
+        for (p, tmp) in mod.GEN_COMMIT_LIN_OPR_TMPS:
             writer.writerow([
                 p,
                 mod.period[tmp],
@@ -1316,15 +1602,18 @@ def export_module_specific_results(mod, d,
                 mod.number_of_hours_in_timepoint[tmp],
                 mod.technology[p],
                 mod.load_zone[p],
-                value(mod.Provide_Power_DispLinearCommit_MW[p, tmp]),
-                value(mod.DispLinCommit_Pmax_MW[p, tmp])
-                * value(mod.Commit_Linear[p, tmp]),
-                value(mod.Commit_Linear[p, tmp]),
-                value(mod.Start_Linear[p, tmp]),
-                value(mod.Stop_Linear[p, tmp]),
-                value(mod.DispLinCommit_Synced_Units[p, tmp])
+                value(mod.GenCommitLin_Provide_Power_MW[p, tmp]),
+                value(mod.GenCommitLin_Pmax_MW[p, tmp])
+                * value(mod.GenCommitLin_Commit[p, tmp]),
+                value(mod.GenCommitLin_Commit[p, tmp]),
+                value(mod.GenCommitLin_Startup[p, tmp]),
+                value(mod.GenCommitLin_Shutdown[p, tmp]),
+                value(mod.GenCommitLin_Synced[p, tmp])
             ])
 
+
+# Database
+###############################################################################
 
 def import_module_specific_results_to_database(
         scenario_id, subproblem, stage, c, db, results_directory
@@ -1338,8 +1627,8 @@ def import_module_specific_results_to_database(
     :param results_directory:
     :return:
     """
-    print("project dispatch linear commit")
-    # dispatch_linear_commit.csv
+    print("project dispatch continuous commit")
+    # dispatch_continuous_commit.csv
     # Delete prior results and create temporary import table for ordering
     setup_results_import(
         conn=db, cursor=c,
@@ -1350,7 +1639,7 @@ def import_module_specific_results_to_database(
     # Load results into the temporary table
     results = []
     with open(os.path.join(
-            results_directory, "dispatch_linear_commit.csv"), "r") \
+            results_directory, "dispatch_continuous_commit.csv"), "r") \
             as cc_dispatch_file:
         reader = csv.reader(cc_dispatch_file)
 
@@ -1412,6 +1701,9 @@ def import_module_specific_results_to_database(
     spin_on_database_lock(conn=db, cursor=c, sql=insert_sql, data=(),
                           many=False)
 
+
+# Validation
+###############################################################################
 
 def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     """

--- a/tests/project/operations/operational_types/test_gen_commit_lin.py
+++ b/tests/project/operations/operational_types/test_gen_commit_lin.py
@@ -85,26 +85,24 @@ class TestDispatchableContinuousCommitOperationalType(unittest.TestCase):
         )
         instance = m.create_instance(data)
 
-        # Set: DISPATCHABLE_LINEAR_COMMIT_GENERATORS
-        expected_disp_lin_commit_gen_set = sorted([
+        # Set: GEN_COMMIT_LIN
+        expected_gen_commit_lin_set = sorted([
             "Disp_Cont_Commit", "Clunky_Old_Gen", "Clunky_Old_Gen2"
         ])
-        actual_disp_lin_commit_gen_set = sorted([
-            prj for prj in instance.DISPATCHABLE_LINEAR_COMMIT_GENERATORS
+        actual_gen_commit_lin_set = sorted([
+            prj for prj in instance.GEN_COMMIT_LIN
             ])
-        self.assertListEqual(expected_disp_lin_commit_gen_set,
-                             actual_disp_lin_commit_gen_set)
+        self.assertListEqual(expected_gen_commit_lin_set,
+                             actual_gen_commit_lin_set)
 
-        # Set: DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS
+        # Set: GEN_COMMIT_LIN_OPR_TMPS
         expected_operational_timepoints_by_project = sorted(
             get_project_operational_timepoints(
-                expected_disp_lin_commit_gen_set
+                expected_gen_commit_lin_set
             )
         )
         actual_operational_timepoints_by_project = sorted(
-            [(g, tmp) for (g, tmp) in
-             instance.
-                DISPATCHABLE_LINEAR_COMMIT_GENERATOR_OPERATIONAL_TIMEPOINTS]
+            [(g, tmp) for (g, tmp) in instance.GEN_COMMIT_LIN_OPR_TMPS]
         )
         self.assertListEqual(expected_operational_timepoints_by_project,
                              actual_operational_timepoints_by_project)
@@ -114,75 +112,75 @@ class TestDispatchableContinuousCommitOperationalType(unittest.TestCase):
                                         "Clunky_Old_Gen": 0.4,
                                         "Clunky_Old_Gen2": 0.4}
         actual_min_stable_fraction = {
-            prj: instance.disp_linear_commit_min_stable_level_fraction[prj]
-            for prj in instance.DISPATCHABLE_LINEAR_COMMIT_GENERATORS
+            prj: instance.gen_commit_lin_min_stable_level_fraction[prj]
+            for prj in instance.GEN_COMMIT_LIN
         }
         self.assertDictEqual(expected_min_stable_fraction,
                              actual_min_stable_fraction)
 
-        # Param: displincommit_startup_plus_ramp_up_rate
+        # Param: gen_commit_lin_startup_plus_ramp_up_rate
         expected_startup_plus_ramp_up_rate = {"Disp_Cont_Commit": 0.6,
                                               "Clunky_Old_Gen": 1,
                                               "Clunky_Old_Gen2": 1}
         actual_startup_plus_ramp_up_rate = {
-            prj: instance.displincommit_startup_plus_ramp_up_rate[prj]
-            for prj in instance.DISPATCHABLE_LINEAR_COMMIT_GENERATORS
+            prj: instance.gen_commit_lin_startup_plus_ramp_up_rate[prj]
+            for prj in instance.GEN_COMMIT_LIN
         }
         self.assertDictEqual(expected_startup_plus_ramp_up_rate,
                              actual_startup_plus_ramp_up_rate)
 
-        # Param: displincommit_shutdown_plus_ramp_down_rate
+        # Param: gen_commit_lin_shutdown_plus_ramp_down_rate
         expected_shutdown_plus_ramp_down_rate = {"Disp_Cont_Commit": 0.6,
                                                  "Clunky_Old_Gen": 1,
                                                  "Clunky_Old_Gen2": 1}
         actual_shutdown_plus_ramp_down_rate = {
-            prj: instance.displincommit_shutdown_plus_ramp_down_rate[prj]
-            for prj in instance.DISPATCHABLE_LINEAR_COMMIT_GENERATORS
+            prj: instance.gen_commit_lin_shutdown_plus_ramp_down_rate[prj]
+            for prj in instance.GEN_COMMIT_LIN
         }
         self.assertDictEqual(expected_shutdown_plus_ramp_down_rate,
                              actual_shutdown_plus_ramp_down_rate)
 
-        # Param: displincommit_ramp_up_when_on_rate
+        # Param: gen_commit_lin_ramp_up_when_on_rate
         expected_ramp_up_when_on_rate = {"Disp_Cont_Commit": 0.3,
                                          "Clunky_Old_Gen": 1,
                                          "Clunky_Old_Gen2": 1}
         actual_ramp_down_when_on_rate = {
-            prj: instance.displincommit_ramp_up_when_on_rate[prj]
-            for prj in instance.DISPATCHABLE_LINEAR_COMMIT_GENERATORS
+            prj: instance.gen_commit_lin_ramp_up_when_on_rate[prj]
+            for prj in instance.GEN_COMMIT_LIN
         }
         self.assertDictEqual(expected_ramp_up_when_on_rate,
                              actual_ramp_down_when_on_rate)
 
-        # Param: displincommit_ramp_down_when_on_rate
+        # Param: gen_commit_lin_ramp_down_when_on_rate
         expected_ramp_down_when_on_rate = {"Disp_Cont_Commit": 0.5,
                                            "Clunky_Old_Gen": 1,
                                            "Clunky_Old_Gen2": 1}
         actual_ramp_down_when_on_rate = {
-            prj: instance.displincommit_ramp_down_when_on_rate[prj]
-            for prj in instance.DISPATCHABLE_LINEAR_COMMIT_GENERATORS
+            prj: instance.gen_commit_lin_ramp_down_when_on_rate[prj]
+            for prj in instance.GEN_COMMIT_LIN
         }
         self.assertDictEqual(expected_ramp_down_when_on_rate,
                              actual_ramp_down_when_on_rate)
 
-        # Param: displincommit_min_up_time_hours
+        # Param: gen_commit_lin_min_up_time_hrs
         expected_min_up_time = {"Disp_Cont_Commit": 3,
                                 "Clunky_Old_Gen": 0,
                                 "Clunky_Old_Gen2": 0}
         actual_min_up_time = {
-            prj: instance.displincommit_min_up_time_hours[prj]
-            for prj in instance.DISPATCHABLE_LINEAR_COMMIT_GENERATORS
+            prj: instance.gen_commit_lin_min_up_time_hrs[prj]
+            for prj in instance.GEN_COMMIT_LIN
         }
 
         self.assertDictEqual(expected_min_up_time,
                              actual_min_up_time)
 
-        # Param: displincommit_min_down_time_hours
+        # Param: gen_commit_lin_min_down_time_hrs
         expected_min_down_time = {"Disp_Cont_Commit": 7,
                                   "Clunky_Old_Gen": 0,
                                   "Clunky_Old_Gen2": 0}
         actual_min_down_time = {
-            prj: instance.displincommit_min_down_time_hours[prj]
-            for prj in instance.DISPATCHABLE_LINEAR_COMMIT_GENERATORS
+            prj: instance.gen_commit_lin_min_down_time_hrs[prj]
+            for prj in instance.GEN_COMMIT_LIN
         }
         self.assertDictEqual(expected_min_down_time,
                              actual_min_down_time)


### PR DESCRIPTION
 - standardize documentation
 - standardize variable naming
 - update documentation with automodules
 - various cleanup of syntax and formatting

 Also fix typos in gen_commit_bin