### PR TITLE
Fix naming of violation penalties

### DIFF
--- a/examples/2periods_new_build_rps/inputs/rps_zones.tab
+++ b/examples/2periods_new_build_rps/inputs/rps_zones.tab
@@ -1,2 +1,2 @@
-rps_zone	allow_violation	violation_penalty
+rps_zone	allow_violation	violation_penalty_per_mwh
 RPSZone1	0	0

--- a/examples/2periods_new_build_rps_variable_reserves/inputs/rps_zones.tab
+++ b/examples/2periods_new_build_rps_variable_reserves/inputs/rps_zones.tab
@@ -1,2 +1,2 @@
-rps_zone	allow_violation	violation_penalty
+rps_zone	allow_violation	violation_penalty_per_mwh
 RPSZone1	0	0

--- a/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/inputs/rps_zones.tab
+++ b/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/inputs/rps_zones.tab
@@ -1,2 +1,2 @@
-rps_zone	allow_violation	violation_penalty
+rps_zone	allow_violation	violation_penalty_per_mwh
 RPSZone1	0	0

--- a/examples/2periods_new_build_rps_w_rps_eligible_storage/inputs/rps_zones.tab
+++ b/examples/2periods_new_build_rps_w_rps_eligible_storage/inputs/rps_zones.tab
@@ -1,2 +1,2 @@
-rps_zone	allow_violation	violation_penalty
+rps_zone	allow_violation	violation_penalty_per_mwh
 RPSZone1	0	0

--- a/examples/2periods_new_build_rps_w_rps_ineligible_storage/inputs/rps_zones.tab
+++ b/examples/2periods_new_build_rps_w_rps_ineligible_storage/inputs/rps_zones.tab
@@ -1,2 +1,2 @@
-rps_zone	allow_violation	violation_penalty
+rps_zone	allow_violation	violation_penalty_per_mwh
 RPSZone1	0	0

--- a/examples/test_new_solar_carbon_cap/inputs/carbon_cap_zones.tab
+++ b/examples/test_new_solar_carbon_cap/inputs/carbon_cap_zones.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	allow_violation	violation_penalty
+carbon_cap_zone	allow_violation	violation_penalty_per_mmt
 Zone1	0	0

--- a/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/inputs/carbon_cap_zones.tab
+++ b/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/inputs/carbon_cap_zones.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	allow_violation	violation_penalty
+carbon_cap_zone	allow_violation	violation_penalty_per_mmt
 Zone1	0	0

--- a/examples/test_new_solar_carbon_cap_2zones_tx/inputs/carbon_cap_zones.tab
+++ b/examples/test_new_solar_carbon_cap_2zones_tx/inputs/carbon_cap_zones.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	allow_violation	violation_penalty
+carbon_cap_zone	allow_violation	violation_penalty_per_mmt
 Zone1	0	0

--- a/gridpath/geography/carbon_cap_zones.py
+++ b/gridpath/geography/carbon_cap_zones.py
@@ -96,7 +96,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         writer = csv.writer(carbon_cap_zones_file, delimiter="\t")
 
         # Write header
-        writer.writerow(["carbon_cap_zone", "violation",
+        writer.writerow(["carbon_cap_zone", "allow_violation",
                          "violation_penalty_per_mmt"])
 
         for row in carbon_cap_zone:


### PR DESCRIPTION
Make naming of violation penalty column header consistent with the database table names and param names.

This is a silent fix since the tab files are read in position-wise, not by their column name.