### PR TITLE
Fix test db exceptions

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,19 +30,26 @@ class TestExamples(unittest.TestCase):
         :return:
         """
 
+        test_db_path = os.path.join(os.getcwd(),
+                                    "..", "db", "test_examples.db")
+
+        if os.path.exists(test_db_path):
+            os.remove(test_db_path)
+
+        create_database.main(["--db_location", "../db",
+                              "--db_name", "test_examples"])
+
         try:
-            create_database.main(["--db_location", "../db",
-                                  "--db_name", "test_examples"])
             port_csvs_to_gridpath.main(["--db_location", "../db/",
                                         "--db_name", "test_examples",
                                         "--csv_location",
                                         "../db/csvs_test_examples",
                                         "--quiet"])
         except Exception as e:
-            print("Error encountered during creation of testing database "
-                  "testing.db. Deleting database ...")
+            print("Error encountered during population of testing database "
+                  "test_examples.db. Deleting database ...")
             logging.exception(e)
-            os.remove("../db/test_examples.db")
+            os.remove(test_db_path)
 
         # TODO: create in memory instead and pass around connection?
 


### PR DESCRIPTION
The "except Exception" was not capturing the SystemExit exception from the create_database script when an existing database already exists. (see: https://stackoverflow.com/questions/18982610/difference-between-except-and-except-exception-as-e-in-python). That is fine because it was really there to capture any errors in the porting script. 

To handle a pre-existing testing database better (which to be fair shouldn't really happen), this PR just checks whether the db exists first and deletes it right-away if it does. That way the SystemExist from create_database.py is never encountered. 