### PR TITLE
Fix DB utils for heat rate curves

### DIFF
--- a/db/csvs_to_db_utilities/load_project_operational_chars.py
+++ b/db/csvs_to_db_utilities/load_project_operational_chars.py
@@ -189,24 +189,21 @@ def load_project_hr_curves(io, c, subscenario_input, data_input):
         data_input_subscenario = data_input.loc[(data_input['heat_rate_curves_scenario_id'] == sc_id)]
 
         for prj in data_input_subscenario['project'].unique():
-            project_hr_scenarios[prj] = dict()
-            project_hr_scenarios[prj][sc_id] = (sc_name, sc_description)
+            project_hr_scenarios[(prj, sc_id)] = (sc_name, sc_description)
 
-            project_hr_chars[prj] = dict()
-            project_hr_chars[prj][sc_id] = dict()
+            project_hr_chars[(prj, sc_id)] = dict()
             project_hr_chars_by_project = data_input_subscenario.loc[data_input_subscenario['project'] == prj]
 
             for hr_curve_point in project_hr_chars_by_project['hr_curve_point'].to_list():
-                project_hr_chars[prj][sc_id][hr_curve_point] = dict()
-
-                project_hr_chars[prj][sc_id][hr_curve_point] = (float(project_hr_chars_by_project.loc[
-                                                                    project_hr_chars_by_project[
-                                                                        'hr_curve_point'] == hr_curve_point,
-                                                                    'load_point_mw'].iloc[0]),
-                                                                float(project_hr_chars_by_project.loc[
-                                                                    project_hr_chars_by_project[
-                                                                        'hr_curve_point'] == hr_curve_point,
-                                                                    'average_heat_rate_mmbtu_per_mwh'].iloc[0]))
+                project_hr_chars[(prj, sc_id)][hr_curve_point] = (float(
+                    project_hr_chars_by_project.loc[
+                        project_hr_chars_by_project[
+                            'hr_curve_point'] == hr_curve_point,
+                        'load_point_mw'].iloc[0]),
+                    float(project_hr_chars_by_project.loc[
+                        project_hr_chars_by_project[
+                            'hr_curve_point'] == hr_curve_point,
+                        'average_heat_rate_mmbtu_per_mwh'].iloc[0]))
 
     project_operational_chars.update_project_hr_curves(
         io=io, c=c,

--- a/db/utilities/project_operational_chars.py
+++ b/db/utilities/project_operational_chars.py
@@ -264,12 +264,11 @@ def update_project_hr_curves(
     """
     # Subscenarios
     subs_data = []
-    for prj in proj_opchar_names.keys():
-        for scenario_id in proj_opchar_names[prj].keys():
-            subs_data.append(
-                (prj, scenario_id, proj_opchar_names[prj][scenario_id][0],
-                 proj_opchar_names[prj][scenario_id][1])
-            )
+    for prj, scenario_id in proj_opchar_names.keys():
+        subs_data.append(
+            (prj, scenario_id, proj_opchar_names[(prj, scenario_id)][0],
+             proj_opchar_names[(prj, scenario_id)][1])
+        )
     subs_sql = """
         INSERT INTO subscenarios_project_heat_rate_curves
         (project, heat_rate_curves_scenario_id, name, description)
@@ -279,14 +278,13 @@ def update_project_hr_curves(
 
     # Insert data
     inputs_data = []
-    for p in list(proj_hr_chars.keys()):
-        for scenario in list(proj_hr_chars[p].keys()):
-            for hr_curve_point in list(proj_hr_chars[p][scenario].keys()):
-                inputs_data.append(
-                    (p, scenario,
-                     proj_hr_chars[p][scenario][hr_curve_point][0],
-                     proj_hr_chars[p][scenario][hr_curve_point][1])
-                )
+    for prj, scenario_id in list(proj_hr_chars.keys()):
+        for hr_curve_point in list(proj_hr_chars[(prj, scenario_id)].keys()):
+            inputs_data.append(
+                (prj, scenario_id,
+                 proj_hr_chars[(prj, scenario_id)][hr_curve_point][0],
+                 proj_hr_chars[(prj, scenario_id)][hr_curve_point][1])
+            )
     inputs_sql = """
         INSERT INTO inputs_project_heat_rate_curves
         (project, heat_rate_curves_scenario_id, load_point_mw, 


### PR DESCRIPTION
The way the file structure and for loops are set up in
load_project_operational_chars does not allow for different
heat rate curves subscenarios for one project (the subscenario gets
overwritten by latest subscenario in the latest project outer loop).

This update provides a quick fix to deal with this. A longer term fix
would be to further clean this up similar to the temporal PR (#441)
and/or to create csv input files separately for each project-subscenario
combination, similar to the variable profiles and hydro inputs.
(this would require adding the project column to the subscenario data
csv input).

Closes #453