### PR TITLE
Simplify endogenous availability module

### DIFF
--- a/db/csvs_test_examples/project/project_availability/project_availability_endogenous/Nuclear-1-base.csv
+++ b/db/csvs_test_examples/project/project_availability/project_availability_endogenous/Nuclear-1-base.csv
@@ -1,1 +1,1 @@
-unavailable_hours_per_period,unavailable_hours_per_event_min,unavailable_hours_per_event_max,available_hours_between_events_min,available_hours_between_events_max1,1,1,1,1
+unavailable_hours_per_period,unavailable_hours_per_event_min,available_hours_between_events_min1,1,1

--- a/db/csvs_to_db_utilities/load_project_availability.py
+++ b/db/csvs_to_db_utilities/load_project_availability.py
@@ -145,9 +145,7 @@ def load_project_availability_endogenous(io, c, subscenario_input, data_input):
         key_cols = ["project", "id"]
         value_cols = ["unavailable_hours_per_period",
                       "unavailable_hours_per_event_min",
-                      "unavailable_hours_per_event_max",
-                      "available_hours_between_events_min",
-                      "available_hours_between_events_max"]
+                      "available_hours_between_events_min"]
 
         df = data_input_subscenario.groupby(key_cols)[value_cols].apply(
             lambda x: x.values.tolist()[0]).to_frame().reset_index()

--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -915,9 +915,7 @@ project VARCHAR(64),
 endogenous_availability_scenario_id INTEGER,
 unavailable_hours_per_period FLOAT,
 unavailable_hours_per_event_min FLOAT,
-unavailable_hours_per_event_max FLOAT,
 available_hours_between_events_min FLOAT,
-available_hours_between_events_max FLOAT,
 PRIMARY KEY (project, endogenous_availability_scenario_id),
 FOREIGN KEY (project, endogenous_availability_scenario_id)
     REFERENCES subscenarios_project_availability_endogenous

--- a/db/utilities/project_availability.py
+++ b/db/utilities/project_availability.py
@@ -118,9 +118,7 @@ def insert_project_availability_endogenous(
     :param project_avail: {project: {scenario_id: (
         unavailable_hours_per_period,
         unavailable_hours_per_event_min,
-        unavailable_hours_per_event_max,
-        available_hours_between_events_min,
-        available_hours_between_events_max)}}
+        available_hours_between_events_min)}}
     """
 
     # "Subscenario"
@@ -148,9 +146,7 @@ def insert_project_availability_endogenous(
                  subscenario_id,
                  project_avail[prj][subscenario_id][0],
                  project_avail[prj][subscenario_id][1],
-                 project_avail[prj][subscenario_id][2],
-                 project_avail[prj][subscenario_id][3],
-                 project_avail[prj][subscenario_id][4])
+                 project_avail[prj][subscenario_id][2])
             )
     inputs_sql = """
         INSERT OR IGNORE INTO inputs_project_availability_endogenous
@@ -158,9 +154,7 @@ def insert_project_availability_endogenous(
         endogenous_availability_scenario_id, 
         unavailable_hours_per_period,
         unavailable_hours_per_event_min,
-        unavailable_hours_per_event_max,
-        available_hours_between_events_min,
-        available_hours_between_events_max)
-        VALUES (?, ?, ?, ?, ?, ?, ?);
+        available_hours_between_events_min)
+        VALUES (?, ?, ?, ?, ?);
         """
     spin_on_database_lock(conn=io, cursor=c, sql=inputs_sql, data=inputs_data)

--- a/examples/2horizons_w_hydro_and_nuclear_binary_availability/inputs/project_availability_endogenous.tab
+++ b/examples/2horizons_w_hydro_and_nuclear_binary_availability/inputs/project_availability_endogenous.tab
@@ -1,2 +1,2 @@
-project	unavailable_hours_per_period	unavailable_hours_per_event_min	unavailable_hours_per_event_max	available_hours_between_events_min	available_hours_between_events_max
-Nuclear	1.0	1.0	1.0	1.0	1.0
+project	unavailable_hours_per_period	unavailable_hours_per_event_min	available_hours_between_events_min
+Nuclear	1.0	1.0	1.0

--- a/tests/project/availability/availability_types/test_binary.py
+++ b/tests/project/availability/availability_types/test_binary.py
@@ -135,19 +135,6 @@ class TestBinaryAvailabilityType(unittest.TestCase):
         self.assertDictEqual(expected_unavailable_hours_per_event,
                              actual_unavailable_hours_per_event)
 
-        # Param: avl_bin_max_unavl_hrs_per_event
-        expected_unavailable_hours_per_event = get_endogenous_params(
-            test_data_directory=TEST_DATA_DIRECTORY,
-            param="unavailable_hours_per_event_max",
-            project_subset=actual_project_subset
-        )
-        actual_unavailable_hours_per_event = {
-            prj: instance.avl_bin_max_unavl_hrs_per_event[prj]
-            for prj in instance.AVL_BIN
-        }
-        self.assertDictEqual(expected_unavailable_hours_per_event,
-                             actual_unavailable_hours_per_event)
-
         # Param: avl_bin_min_avl_hrs_between_events
         expected_unavailable_hours_per_event = get_endogenous_params(
             test_data_directory=TEST_DATA_DIRECTORY,
@@ -156,19 +143,6 @@ class TestBinaryAvailabilityType(unittest.TestCase):
         )
         actual_unavailable_hours_per_event = {
             prj: instance.avl_bin_min_avl_hrs_between_events[prj]
-            for prj in instance.AVL_BIN
-        }
-        self.assertDictEqual(expected_unavailable_hours_per_event,
-                             actual_unavailable_hours_per_event)
-
-        # Param: avl_bin_max_avl_hrs_between_events
-        expected_unavailable_hours_per_event = get_endogenous_params(
-            test_data_directory=TEST_DATA_DIRECTORY,
-            param="available_hours_between_events_max",
-            project_subset=actual_project_subset
-        )
-        actual_unavailable_hours_per_event = {
-            prj: instance.avl_bin_max_avl_hrs_between_events[prj]
             for prj in instance.AVL_BIN
         }
         self.assertDictEqual(expected_unavailable_hours_per_event,

--- a/tests/project/availability/availability_types/test_continuous.py
+++ b/tests/project/availability/availability_types/test_continuous.py
@@ -135,19 +135,6 @@ class TestContinuousAvailabilityType(unittest.TestCase):
         self.assertDictEqual(expected_unavailable_hours_per_event,
                              actual_unavailable_hours_per_event)
 
-        # Param: avl_cont_max_unavl_hrs_per_event
-        expected_unavailable_hours_per_event = get_endogenous_params(
-            test_data_directory=TEST_DATA_DIRECTORY,
-            param="unavailable_hours_per_event_max",
-            project_subset=actual_project_subset
-        )
-        actual_unavailable_hours_per_event = {
-            prj: instance.avl_cont_max_unavl_hrs_per_event[prj]
-            for prj in instance.AVL_CONT
-        }
-        self.assertDictEqual(expected_unavailable_hours_per_event,
-                             actual_unavailable_hours_per_event)
-
         # Param: avl_cont_min_avl_hrs_between_events
         expected_unavailable_hours_per_event = get_endogenous_params(
             test_data_directory=TEST_DATA_DIRECTORY,
@@ -156,19 +143,6 @@ class TestContinuousAvailabilityType(unittest.TestCase):
         )
         actual_unavailable_hours_per_event = {
             prj: instance.avl_cont_min_avl_hrs_between_events[prj]
-            for prj in instance.AVL_CONT
-        }
-        self.assertDictEqual(expected_unavailable_hours_per_event,
-                             actual_unavailable_hours_per_event)
-
-        # Param: avl_cont_max_avl_hrs_between_events
-        expected_unavailable_hours_per_event = get_endogenous_params(
-            test_data_directory=TEST_DATA_DIRECTORY,
-            param="available_hours_between_events_max",
-            project_subset=actual_project_subset
-        )
-        actual_unavailable_hours_per_event = {
-            prj: instance.avl_cont_max_avl_hrs_between_events[prj]
             for prj in instance.AVL_CONT
         }
         self.assertDictEqual(expected_unavailable_hours_per_event,

--- a/tests/test_data/inputs/project_availability_endogenous.tab
+++ b/tests/test_data/inputs/project_availability_endogenous.tab
@@ -1,3 +1,3 @@
-project	unavailable_hours_per_period	unavailable_hours_per_event_min	unavailable_hours_per_event_max	available_hours_between_events_min	available_hours_between_events_max
-Gas_CCGT	288	72	96	1680	3360
-Gas_CT	288	72	96	1680	3360
+project	unavailable_hours_per_period	unavailable_hours_per_event_min	available_hours_between_events_min
+Gas_CCGT	288	72	1680
+Gas_CT	288	72	1680


### PR DESCRIPTION
The constraints in the endogenous availability module were somewhat redundant, could easily result in infeasible problems, and appeared to be resulting in MIP problems that were very difficult to solve for larger cases. I am removing the 'max' constraints here to simplify those, as the 'min' ones only -- provided the inputs are well thought-through -- produce a meaningful solution.