### PR TITLE
Clean up line breaks

### DIFF
--- a/gridpath/project/operations/operational_types/gen_commit_bin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_bin.py
@@ -949,6 +949,7 @@ def active_startup_rule(mod, g, tmp):
 # Constraint Formulation Rules
 ###############################################################################
 
+
 # Commitment
 def binary_logic_constraint_rule(mod, g, tmp):
     """
@@ -972,10 +973,11 @@ def binary_logic_constraint_rule(mod, g, tmp):
     ):
         return Constraint.Skip
     else:
-       return mod.GenCommitBin_Commit[g, tmp] \
+        return mod.GenCommitBin_Commit[g, tmp] \
               - mod.GenCommitBin_Commit[
                   g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]] \
-              == mod.GenCommitBin_Startup[g, tmp] - mod.GenCommitBin_Shutdown[g, tmp]
+              == mod.GenCommitBin_Startup[g, tmp] \
+              - mod.GenCommitBin_Shutdown[g, tmp]
 
 
 def synced_constraint_rule(mod, g, tmp):
@@ -1021,8 +1023,8 @@ def min_power_constraint_rule(mod, g, tmp):
     don't look at downward reserves. In that case, enforcing
     provide_power_above_pmin to be within NonNegativeReals is sufficient.
     """
-    return mod.GenCommitBin_Provide_Power_Above_Pmin_MW[g, tmp] - \
-        mod.GenCommitBin_Downwards_Reserves_MW[g, tmp] \
+    return mod.GenCommitBin_Provide_Power_Above_Pmin_MW[g, tmp] \
+        - mod.GenCommitBin_Downwards_Reserves_MW[g, tmp] \
         >= 0
 
 
@@ -1381,17 +1383,11 @@ def ramp_during_startup_constraint_rule(mod, g, tmp, s):
         return Constraint.Skip
     else:
         return \
-            mod.GenCommitBin_Provide_Power_Startup_MW[g, tmp, s] - \
-            mod.GenCommitBin_Provide_Power_Startup_MW[g,
-                          mod.prev_tmp[tmp,
-                                                 mod
-                                                 .balancing_type_project[g]
-                                                 ], s
-                          ] \
+            mod.GenCommitBin_Provide_Power_Startup_MW[g, tmp, s] \
+            - mod.GenCommitBin_Provide_Power_Startup_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]], s] \
             <= mod.GenCommitBin_Startup_Ramp_Rate_MW_Per_Tmp[
-                g, mod.prev_tmp[tmp,
-                                          mod.balancing_type_project[g]], s
-            ]
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]], s]
 
 
 def increasing_startup_power_constraint_rule(mod, g, tmp, s):
@@ -1413,13 +1409,9 @@ def increasing_startup_power_constraint_rule(mod, g, tmp, s):
         return Constraint.Skip
     else:
         return \
-            mod.GenCommitBin_Provide_Power_Startup_MW[g, tmp, s] - \
-            mod.GenCommitBin_Provide_Power_Startup_MW[g,
-                          mod.prev_tmp[tmp,
-                                                 mod
-                                                 .balancing_type_project[g]
-                                                 ], s
-                          ] \
+            mod.GenCommitBin_Provide_Power_Startup_MW[g, tmp, s] \
+            - mod.GenCommitBin_Provide_Power_Startup_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]], s] \
             >= - mod.GenCommitBin_Startup_Type[g, tmp, s] \
             * mod.GenCommitBin_Pmin_MW[g, tmp]
 
@@ -1468,9 +1460,7 @@ def power_during_startup_constraint_rule(mod, g, tmp, s):
             * mod.GenCommitBin_Pmax_MW[g, tmp] \
             + mod.GenCommitBin_Startup[g, tmp] \
             * mod.GenCommitBin_Startup_Ramp_Rate_MW_Per_Tmp[
-                g, mod.prev_tmp[tmp,
-                                          mod.balancing_type_project[g]], s
-            ]
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]], s]
 
 
 # Shutdown Power
@@ -1511,9 +1501,7 @@ def ramp_during_shutdown_constraint_rule(mod, g, tmp):
             tmp, mod.balancing_type_project[g]]] \
             - mod.GenCommitBin_Provide_Power_Shutdown_MW[g, tmp] \
             <= mod.GenCommitBin_Shutdown_Ramp_Rate_MW_Per_Tmp[
-                g, mod.prev_tmp[tmp,
-                                          mod.balancing_type_project[g]]
-            ]
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
 
 
 def decreasing_shutdown_power_constraint_rule(mod, g, tmp):
@@ -1535,21 +1523,13 @@ def decreasing_shutdown_power_constraint_rule(mod, g, tmp):
         return Constraint.Skip
     else:
         return \
-            mod.GenCommitBin_Provide_Power_Shutdown_MW[g, tmp] - \
-            mod.GenCommitBin_Provide_Power_Shutdown_MW[g,
-                          mod.next_tmp[tmp,
-                                             mod
-                                             .balancing_type_project[g]
-                                             ]
-                          ] \
+            mod.GenCommitBin_Provide_Power_Shutdown_MW[g, tmp] \
+            - mod.GenCommitBin_Provide_Power_Shutdown_MW[
+                g, mod.next_tmp[tmp, mod.balancing_type_project[g]]] \
             >= \
-            - mod.GenCommitBin_Shutdown[g,
-                              mod.next_tmp[tmp,
-                                                 mod
-                                                 .balancing_type_project[g]
-                                                 ]
-                              ] * \
-            mod.GenCommitBin_Pmin_MW[g, tmp]
+            - mod.GenCommitBin_Shutdown[
+                g, mod.next_tmp[tmp, mod.balancing_type_project[g]]] \
+            * mod.GenCommitBin_Pmin_MW[g, tmp]
 
 
 def power_during_shutdown_constraint_rule(mod, g, tmp):
@@ -1585,8 +1565,7 @@ def power_during_shutdown_constraint_rule(mod, g, tmp):
     else:
         return (mod.GenCommitBin_Commit[g, tmp]
                 * mod.GenCommitBin_Pmin_MW[g, tmp]
-                + mod.GenCommitBin_Provide_Power_Above_Pmin_MW[g,
-                                                                   tmp]) \
+                + mod.GenCommitBin_Provide_Power_Above_Pmin_MW[g, tmp]) \
             + mod.GenCommitBin_Upwards_Reserves_MW[g, tmp] \
             - mod.GenCommitBin_Provide_Power_Shutdown_MW[g, mod.next_tmp[
                 tmp, mod.balancing_type_project[g]]] \
@@ -1950,8 +1929,8 @@ def export_module_specific_results(mod, d,
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_binary_commit.csv"), "w", newline="") \
-            as f:
+                           "dispatch_binary_commit.csv"),
+              "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "balancing_type_project",
                          "horizon", "timepoint", "timepoint_weight",

--- a/gridpath/project/operations/operational_types/gen_commit_cap.py
+++ b/gridpath/project/operations/operational_types/gen_commit_cap.py
@@ -778,8 +778,7 @@ def ramp_up_constraint_rule(mod, g, tmp):
             - (mod.GenCommitCap_Provide_Power_MW[
                     g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
                - mod.GenCommitCap_Downwards_Reserves_MW[
-                    g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
-               ) \
+                    g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]) \
             <= \
             mod.Ramp_Up_Startup_MW[g, tmp] \
             + mod.Ramp_Up_When_On_MW[g, tmp]
@@ -806,14 +805,13 @@ def ramp_down_on_to_off_constraint_rule(mod, g, tmp):
         return Constraint.Skip
     else:
         return mod.Ramp_Down_Shutdown_MW[g, tmp] \
-               >= \
-               (mod.Commit_Capacity_MW[g, tmp]
-                - mod.Commit_Capacity_MW[
-                    g, mod.prev_tmp[
-                        tmp, mod.balancing_type_project[g]]]) \
-               * mod.gen_commit_cap_shutdown_plus_ramp_down_rate[g] * 60 \
-               * mod.hrs_in_tmp[
-                   mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
+           >= \
+           (mod.Commit_Capacity_MW[g, tmp]
+            - mod.Commit_Capacity_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]) \
+           * mod.gen_commit_cap_shutdown_plus_ramp_down_rate[g] * 60 \
+           * mod.hrs_in_tmp[
+               mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
 
 
 def ramp_down_on_to_on_constraint_rule(mod, g, tmp):
@@ -831,12 +829,11 @@ def ramp_down_on_to_on_constraint_rule(mod, g, tmp):
         return Constraint.Skip
     else:
         return mod.Ramp_Down_When_On_MW[g, tmp] \
-               >= \
-               mod.Commit_Capacity_MW[g, tmp] \
-               * (-mod.gen_commit_cap_ramp_down_when_on_rate[g]) * 60 \
-               * mod.hrs_in_tmp[
-                   mod.prev_tmp[
-                       tmp, mod.balancing_type_project[g]]]
+            >= \
+            mod.Commit_Capacity_MW[g, tmp] \
+            * (-mod.gen_commit_cap_ramp_down_when_on_rate[g]) * 60 \
+            * mod.hrs_in_tmp[
+                mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
 
 
 def ramp_down_on_to_on_headroom_constraint_rule(mod, g, tmp):
@@ -857,10 +854,10 @@ def ramp_down_on_to_on_headroom_constraint_rule(mod, g, tmp):
         return Constraint.Skip
     else:
         return -mod.Ramp_Down_When_On_MW[g, tmp] \
-               <= \
-               mod.Commit_Capacity_MW[g, tmp] \
-               - (mod.GenCommitCap_Provide_Power_MW[g, tmp]
-                  - mod.GenCommitCap_Downwards_Reserves_MW[g, tmp])
+            <= \
+            mod.Commit_Capacity_MW[g, tmp] \
+            - (mod.GenCommitCap_Provide_Power_MW[g, tmp]
+               - mod.GenCommitCap_Downwards_Reserves_MW[g, tmp])
 
 
 def ramp_down_constraint_rule(mod, g, tmp):
@@ -903,16 +900,13 @@ def ramp_down_constraint_rule(mod, g, tmp):
     else:
         return (mod.GenCommitCap_Provide_Power_MW[g, tmp]
                 - mod.GenCommitCap_Downwards_Reserves_MW[g, tmp]) \
-               - (mod.GenCommitCap_Provide_Power_MW[
-                      g, mod.prev_tmp[
-                          tmp, mod.balancing_type_project[g]]]
-                  + mod.GenCommitCap_Upwards_Reserves_MW[
-                      g, mod.prev_tmp[
-                          tmp, mod.balancing_type_project[g]]]
-                  ) \
-               >= \
-               mod.Ramp_Down_Shutdown_MW[g, tmp] \
-               + mod.Ramp_Down_When_On_MW[g, tmp]
+            - (mod.GenCommitCap_Provide_Power_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
+               + mod.GenCommitCap_Upwards_Reserves_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]) \
+            >= \
+            mod.Ramp_Down_Shutdown_MW[g, tmp] \
+            + mod.Ramp_Down_When_On_MW[g, tmp]
 
 
 def startup_constraint_rule(mod, g, tmp):
@@ -929,10 +923,9 @@ def startup_constraint_rule(mod, g, tmp):
         return Constraint.Skip
     else:
         return mod.GenCommitCap_Startup_MW[g, tmp] \
-               >= mod.Commit_Capacity_MW[g, tmp] \
-               - mod.Commit_Capacity_MW[
-                   g, mod.prev_tmp[
-                       tmp, mod.balancing_type_project[g]]]
+            >= mod.Commit_Capacity_MW[g, tmp] \
+            - mod.Commit_Capacity_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
 
 
 def shutdown_constraint_rule(mod, g, tmp):
@@ -949,10 +942,9 @@ def shutdown_constraint_rule(mod, g, tmp):
         return Constraint.Skip
     else:
         return mod.GenCommitCap_Shutdown_MW[g, tmp] \
-               >= mod.Commit_Capacity_MW[
-                   g, mod.prev_tmp[
-                       tmp, mod.balancing_type_project[g]]] \
-               - mod.Commit_Capacity_MW[g, tmp]
+            >= mod.Commit_Capacity_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]] \
+            - mod.Commit_Capacity_MW[g, tmp]
 
 
 def min_up_time_constraint_rule(mod, g, tmp):
@@ -988,11 +980,10 @@ def min_up_time_constraint_rule(mod, g, tmp):
     # started up in the relevant timepoints
     else:
         capacity_turned_on_min_up_time_or_less_hours_ago = \
-            sum(mod.GenCommitCap_Startup_MW[g, tp]
-                for tp in relevant_tmps)
+            sum(mod.GenCommitCap_Startup_MW[g, tp] for tp in relevant_tmps)
 
         return mod.Commit_Capacity_MW[g, tmp] \
-               >= capacity_turned_on_min_up_time_or_less_hours_ago
+            >= capacity_turned_on_min_up_time_or_less_hours_ago
 
 
 def min_down_time_constraint_rule(mod, g, tmp):
@@ -1019,8 +1010,7 @@ def min_down_time_constraint_rule(mod, g, tmp):
     )
 
     capacity_turned_off_min_down_time_or_less_hours_ago = \
-        sum(mod.GenCommitCap_Shutdown_MW[g, tp]
-            for tp in relevant_tmps)
+        sum(mod.GenCommitCap_Shutdown_MW[g, tp] for tp in relevant_tmps)
 
     # If only the current timepoint is determined to be relevant,
     # this constraint is redundant (it will simplify to
@@ -1159,10 +1149,9 @@ def power_delta_rule(mod, g, tmp):
     ):
         pass
     else:
-        return mod.GenCommitCap_Provide_Power_MW[g, tmp] - \
-               mod.GenCommitCap_Provide_Power_MW[
-                   g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]
-               ]
+        return mod.GenCommitCap_Provide_Power_MW[g, tmp] \
+            - mod.GenCommitCap_Provide_Power_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
 
 
 def fix_commitment(mod, g, tmp):
@@ -1215,7 +1204,8 @@ def load_module_specific_data(mod, data_portal, scenario_directory,
 
     dynamic_components = \
         pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage, "inputs", "projects.tab"),
+            os.path.join(scenario_directory, subproblem, stage,
+                         "inputs", "projects.tab"),
             sep="\t",
             usecols=["project", "operational_type", "unit_size_mw",
                      "min_stable_level_fraction"] + used_columns
@@ -1245,8 +1235,7 @@ def load_module_specific_data(mod, data_portal, scenario_directory,
                 startup_plus_ramp_up_rate[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "gen_commit_cap_startup_plus_ramp_up_rate"] = \
+        data_portal.data()["gen_commit_cap_startup_plus_ramp_up_rate"] = \
             startup_plus_ramp_up_rate
 
     if "shutdown_plus_ramp_down_rate" in used_columns:
@@ -1258,8 +1247,7 @@ def load_module_specific_data(mod, data_portal, scenario_directory,
                 shutdown_plus_ramp_down_rate[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "gen_commit_cap_shutdown_plus_ramp_down_rate"] = \
+        data_portal.data()["gen_commit_cap_shutdown_plus_ramp_down_rate"] = \
             shutdown_plus_ramp_down_rate
 
     if "ramp_up_when_on_rate" in used_columns:
@@ -1271,8 +1259,7 @@ def load_module_specific_data(mod, data_portal, scenario_directory,
                 ramp_up_when_on_rate[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "gen_commit_cap_ramp_up_when_on_rate"] = \
+        data_portal.data()["gen_commit_cap_ramp_up_when_on_rate"] = \
             ramp_up_when_on_rate
 
     if "ramp_down_when_on_rate" in used_columns:
@@ -1284,37 +1271,32 @@ def load_module_specific_data(mod, data_portal, scenario_directory,
                 ramp_down_when_on_rate[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "gen_commit_cap_ramp_down_when_on_rate"] = \
+        data_portal.data()[ "gen_commit_cap_ramp_down_when_on_rate"] = \
             ramp_down_when_on_rate
 
     # Up and down time limits are optional, will default to 1 if not specified
     if "min_up_time_hours" in used_columns:
         for row in zip(dynamic_components["project"],
                        dynamic_components["operational_type"],
-                       dynamic_components[
-                           "min_up_time_hours"]
+                       dynamic_components["min_up_time_hours"]
                        ):
             if row[1] == "gen_commit_cap" and row[2] != ".":
                 min_up_time[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "gen_commit_cap_min_up_time_hours"] = \
+        data_portal.data()["gen_commit_cap_min_up_time_hours"] = \
             min_up_time
 
     if "min_down_time_hours" in used_columns:
         for row in zip(dynamic_components["project"],
                        dynamic_components["operational_type"],
-                       dynamic_components[
-                           "min_down_time_hours"]
+                       dynamic_components["min_down_time_hours"]
                        ):
             if row[1] == "gen_commit_cap" and row[2] != ".":
                 min_down_time[row[0]] = float(row[2])
             else:
                 pass
-        data_portal.data()[
-            "gen_commit_cap_min_down_time_hours"] = \
+        data_portal.data()["gen_commit_cap_min_down_time_hours"] = \
             min_down_time
 
     # Startup/shutdown costs are optional, will default to 0 if not specified
@@ -1355,7 +1337,9 @@ def load_module_specific_data(mod, data_portal, scenario_directory,
             startup_fuel
 
 
-def export_module_specific_results(mod, d, scenario_directory, subproblem, stage):
+def export_module_specific_results(
+        mod, d, scenario_directory, subproblem, stage
+):
     """
 
     :param scenario_directory:
@@ -1366,7 +1350,8 @@ def export_module_specific_results(mod, d, scenario_directory, subproblem, stage
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_capacity_commit.csv"), "w", newline="") as f:
+                           "dispatch_capacity_commit.csv"),
+              "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "balancing_type_project",
                          "horizon", "timepoint", "timepoint_weight",
@@ -1420,6 +1405,7 @@ def import_module_specific_results_to_database(
         results_file="dispatch_capacity_commit.csv"
     )
 
+
 # Validation
 ###############################################################################
 def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
@@ -1469,7 +1455,7 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
         "unit_size_mw"
     ]
     validation_errors = check_req_prj_columns(df, req_columns, True,
-                                          "gen_commit_cap")
+                                              "gen_commit_cap")
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,
@@ -1490,7 +1476,7 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
         "minimum_duration_hours"
     ]
     validation_errors = check_req_prj_columns(df, expected_na_columns, False,
-                                          "gen_commit_cap")
+                                              "gen_commit_cap")
     for error in validation_errors:
         validation_results.append(
             (subscenarios.SCENARIO_ID,

--- a/gridpath/project/operations/operational_types/gen_commit_lin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_lin.py
@@ -931,6 +931,7 @@ def active_startup_rule(mod, g, tmp):
 # Constraint Formulation Rules
 ###############################################################################
 
+
 # Commitment
 def binary_logic_constraint_rule(mod, g, tmp):
     """
@@ -954,10 +955,11 @@ def binary_logic_constraint_rule(mod, g, tmp):
     ):
         return Constraint.Skip
     else:
-       return mod.GenCommitLin_Commit[g, tmp] \
+        return mod.GenCommitLin_Commit[g, tmp] \
               - mod.GenCommitLin_Commit[
                   g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]] \
-              == mod.GenCommitLin_Startup[g, tmp] - mod.GenCommitLin_Shutdown[g, tmp]
+              == mod.GenCommitLin_Startup[g, tmp] \
+              - mod.GenCommitLin_Shutdown[g, tmp]
 
 
 def synced_constraint_rule(mod, g, tmp):
@@ -1003,8 +1005,8 @@ def min_power_constraint_rule(mod, g, tmp):
     don't look at downward reserves. In that case, enforcing
     provide_power_above_pmin to be within NonNegativeReals is sufficient.
     """
-    return mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp] - \
-        mod.GenCommitLin_Downwards_Reserves_MW[g, tmp] \
+    return mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp] \
+        - mod.GenCommitLin_Downwards_Reserves_MW[g, tmp] \
         >= 0
 
 
@@ -1363,17 +1365,11 @@ def ramp_during_startup_constraint_rule(mod, g, tmp, s):
         return Constraint.Skip
     else:
         return \
-            mod.GenCommitLin_Provide_Power_Startup_MW[g, tmp, s] - \
-            mod.GenCommitLin_Provide_Power_Startup_MW[g,
-                          mod.prev_tmp[tmp,
-                                                 mod
-                                                 .balancing_type_project[g]
-                                                 ], s
-                          ] \
+            mod.GenCommitLin_Provide_Power_Startup_MW[g, tmp, s] \
+            - mod.GenCommitLin_Provide_Power_Startup_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]], s] \
             <= mod.GenCommitLin_Startup_Ramp_Rate_MW_Per_Tmp[
-                g, mod.prev_tmp[tmp,
-                                          mod.balancing_type_project[g]], s
-            ]
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]], s]
 
 
 def increasing_startup_power_constraint_rule(mod, g, tmp, s):
@@ -1395,13 +1391,9 @@ def increasing_startup_power_constraint_rule(mod, g, tmp, s):
         return Constraint.Skip
     else:
         return \
-            mod.GenCommitLin_Provide_Power_Startup_MW[g, tmp, s] - \
-            mod.GenCommitLin_Provide_Power_Startup_MW[g,
-                          mod.prev_tmp[tmp,
-                                                 mod
-                                                 .balancing_type_project[g]
-                                                 ], s
-                          ] \
+            mod.GenCommitLin_Provide_Power_Startup_MW[g, tmp, s] \
+            - mod.GenCommitLin_Provide_Power_Startup_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]], s] \
             >= - mod.GenCommitLin_Startup_Type[g, tmp, s] \
             * mod.GenCommitLin_Pmin_MW[g, tmp]
 
@@ -1450,9 +1442,7 @@ def power_during_startup_constraint_rule(mod, g, tmp, s):
             * mod.GenCommitLin_Pmax_MW[g, tmp] \
             + mod.GenCommitLin_Startup[g, tmp] \
             * mod.GenCommitLin_Startup_Ramp_Rate_MW_Per_Tmp[
-                g, mod.prev_tmp[tmp,
-                                          mod.balancing_type_project[g]], s
-            ]
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]], s]
 
 
 # Shutdown Power
@@ -1493,9 +1483,7 @@ def ramp_during_shutdown_constraint_rule(mod, g, tmp):
             tmp, mod.balancing_type_project[g]]] \
             - mod.GenCommitLin_Provide_Power_Shutdown_MW[g, tmp] \
             <= mod.GenCommitLin_Shutdown_Ramp_Rate_MW_Per_Tmp[
-                g, mod.prev_tmp[tmp,
-                                          mod.balancing_type_project[g]]
-            ]
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]]
 
 
 def decreasing_shutdown_power_constraint_rule(mod, g, tmp):
@@ -1517,21 +1505,13 @@ def decreasing_shutdown_power_constraint_rule(mod, g, tmp):
         return Constraint.Skip
     else:
         return \
-            mod.GenCommitLin_Provide_Power_Shutdown_MW[g, tmp] - \
-            mod.GenCommitLin_Provide_Power_Shutdown_MW[g,
-                          mod.next_tmp[tmp,
-                                             mod
-                                             .balancing_type_project[g]
-                                             ]
-                          ] \
+            mod.GenCommitLin_Provide_Power_Shutdown_MW[g, tmp] \
+            - mod.GenCommitLin_Provide_Power_Shutdown_MW[
+                g, mod.next_tmp[tmp, mod.balancing_type_project[g]]] \
             >= \
-            - mod.GenCommitLin_Shutdown[g,
-                              mod.next_tmp[tmp,
-                                                 mod
-                                                 .balancing_type_project[g]
-                                                 ]
-                              ] * \
-            mod.GenCommitLin_Pmin_MW[g, tmp]
+            - mod.GenCommitLin_Shutdown[
+                g, mod.next_tmp[tmp, mod.balancing_type_project[g]]] \
+            * mod.GenCommitLin_Pmin_MW[g, tmp]
 
 
 def power_during_shutdown_constraint_rule(mod, g, tmp):
@@ -1567,8 +1547,7 @@ def power_during_shutdown_constraint_rule(mod, g, tmp):
     else:
         return (mod.GenCommitLin_Commit[g, tmp]
                 * mod.GenCommitLin_Pmin_MW[g, tmp]
-                + mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g,
-                                                                   tmp]) \
+                + mod.GenCommitLin_Provide_Power_Above_Pmin_MW[g, tmp]) \
             + mod.GenCommitLin_Upwards_Reserves_MW[g, tmp] \
             - mod.GenCommitLin_Provide_Power_Shutdown_MW[g, mod.next_tmp[
                 tmp, mod.balancing_type_project[g]]] \
@@ -1931,8 +1910,8 @@ def export_module_specific_results(mod, d,
     :return:
     """
     with open(os.path.join(scenario_directory, subproblem, stage, "results",
-                           "dispatch_continuous_commit.csv"), "w", newline="") \
-            as f:
+                           "dispatch_continuous_commit.csv"),
+              "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "balancing_type_project",
                          "horizon", "timepoint", "timepoint_weight",


### PR DESCRIPTION
Clean up line breaks in the operational type modules. Includes general clean up for consistency as well as clean up and consolidation that's possible after shortening variable names. 