### PR TITLE
Add missing print statements for db utilities

### DIFF
--- a/db/csvs_to_db_utilities/csvs_read.py
+++ b/db/csvs_to_db_utilities/csvs_read.py
@@ -50,6 +50,8 @@ def csv_read_data(folder_path, quiet):
 
     # Get the data for the subscenarios
     for f in csv_files:
+        if not quiet:
+            print(f)
         # Get the subscenario ID and subscenario name from the file name
         # We're expecting the file name to start with an integer (the
         # subscenario ID), followed by an underscore, and then the
@@ -125,6 +127,8 @@ def csv_read_project_data(folder_path, quiet):
 
     # Get the data for the subscenarios
     for f in csv_files:
+        if not quiet:
+            print(f)
         # Get the subscenario ID and subscenario name from the file name
         # We're expecting the file name to start with the project name,
         # followed by a dash, an integer (the subscenario ID), followed
@@ -165,50 +169,6 @@ def csv_read_project_data(folder_path, quiet):
         row_number += 1
 
     return subscenario_df, data_df
-
-
-def csv_read_temporal_data(folder_path, quiet):
-    '''
-    :param folder_path: Path to folder with input csv files
-    :param quiet: boolean
-    :return csv_subscenario: A pandas dataframe with subscenario id, name, description
-    :return csv_data: Data for all subscenarios in a dataframe
-    '''
-    # The specific function will call a generic file scanner function, which will scan the folder and note the
-    # subscenario file. The file only needs the string 'subscenario' in its name. The function will then read
-    # each subscenario data using the filename in the subscenario file. All other files will be ignored.
-
-    csv_data = pd.DataFrame()
-    data_starting_from_row = 1  # Notes rows start from 0. So this is the 6th row in the csv.
-
-    for f in os.listdir(folder_path):
-        if f.endswith(".csv") and 'template' not in f and 'subscenario' in f and 'ignore' not in f:
-            if not quiet:
-                print(f)
-            csv_subscenario = pd.read_csv(os.path.join(folder_path, f))
-
-    csv_data = {}
-    csv_temporal_tables = ['horizon_timepoints',
-                  'horizons',
-                  'periods',
-                  'subproblems',
-                  'subproblems_stages',
-                  'timepoints']
-
-    for temporal_table in csv_temporal_tables:
-        csv_data[temporal_table] = pd.DataFrame()
-
-    for row in range(0, len(csv_subscenario.index)):
-        for temporal_table in csv_temporal_tables:
-            subscenario_filename = csv_subscenario.iloc[row][temporal_table + '_filename']
-            if '.csv' not in subscenario_filename:
-                subscenario_filename = subscenario_filename + '.csv'
-            if not quiet:
-                print(subscenario_filename)
-            csv_data[temporal_table] = csv_data[temporal_table].append(
-                pd.read_csv(os.path.join(folder_path, 'temporal_' + temporal_table, subscenario_filename)))
-
-    return (csv_subscenario, csv_data)
 
 
 def get_subscenario_description(folder_path, csv_filename):

--- a/db/port_csvs_to_gridpath.py
+++ b/db/port_csvs_to_gridpath.py
@@ -158,6 +158,8 @@ def load_csv_data(conn, csv_path, quiet):
     # passed here).
     temporal_subscenarios = sorted(next(os.walk(temporal_directory))[1])
     for temporal_subscenario in temporal_subscenarios:
+        if not quiet:
+            print(temporal_subscenario)
         if not temporal_subscenario.split("_")[0].isdigit():
             warnings.warn(
                 "Temporal subfolder `{}` does not start with an integer to "


### PR DESCRIPTION
With #467 and #441 the print statements were removed and the
"quiet" argument had become redundant. This commit prints the files
being processed again, when the "quiet" argument is False. An
alternative solution would be to get rid of the "quiet" argument
entirely and never print anything (note that the solver options and
scenario db utils are still using the "quiet" argument regardless of
this commit).

This commit also removes the no-longer-used function
"csv_read_temporal_data".