### PR TITLE
Require bokeh v1.3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name="GridPath",
       install_requires=[
           "Pyomo",  # Optimization modeling language
           "pandas",  # Data-processing
-          "bokeh>=1.3.4",  # Visualization library
+          "bokeh==1.3.4",  # Visualization library
           "pscript",  # Python to JavaScript compiler (for visualization)
           "networkx"  # network package for DC OPF
       ],


### PR DESCRIPTION
WIth the release of bokeh v2, the `.from_py` is now deprecated in the latest bokeh version, so we need to require bokeh v1.3.4 in order not to break our plots until we switch to using CustomJS (see issue #133).

@gerritdm, this is more of an FYI. Let me know if you have thoughts.