### PR TITLE
Make sure results plot exclude spinup/lookahead

### DIFF
--- a/gridpath/project/operations/power.py
+++ b/gridpath/project/operations/power.py
@@ -138,6 +138,7 @@ def summarize_results(d, scenario_directory, subproblem, stage):
 
     # Next, our goal is to get a summary table of power production by load
     # zone, technology, and period
+    # Note: this includes power from spinup_or_lookahead timepoints as well!
 
     # Get the results CSV as dataframe
     operational_results_df = pd.read_csv(

--- a/viz/capacity_factor_plot.py
+++ b/viz/capacity_factor_plot.py
@@ -82,12 +82,14 @@ def get_plotting_data(conn, scenario_id, load_zone, stage, **kwargs):
             sum(timepoint_weight * number_of_hours_in_timepoint) 
             AS period_weight
             FROM results_project_dispatch
-            
+
+            -- add temporal scenario id so we can join timepoints table
             INNER JOIN
             
             (SELECT temporal_scenario_id, scenario_id FROM scenarios)
             USING (scenario_id)
             
+            -- filter out spinup_or_lookahead timepoints
             INNER JOIN
             
             (SELECT temporal_scenario_id, stage_id, subproblem_id, timepoint, 
@@ -99,6 +101,7 @@ def get_plotting_data(conn, scenario_id, load_zone, stage, **kwargs):
             AND stage_id = ?
             AND load_zone = ?
             AND spinup_or_lookahead is NULL
+            
             group by period, project) 
             
             AS energy_table

--- a/viz/carbon_plot.py
+++ b/viz/carbon_plot.py
@@ -58,6 +58,9 @@ def get_plotting_data(conn, scenario_id, carbon_cap_zone, subproblem, stage,
     Get the carbon results by period for a given
     scenario/carbon_cap_zone/subproblem/stage.
 
+    Note: Emissions in spinup and lookahead timepoints are included
+    since the emissions in those timepoints will still count towards the cap.
+
     **kwargs needed, so that an error isn't thrown when calling this
     function with extra arguments from the UI.
 

--- a/viz/curtailment_variable_heatmap_plot.py
+++ b/viz/curtailment_variable_heatmap_plot.py
@@ -79,14 +79,33 @@ def get_plotting_data(conn, scenario_id, load_zone, period, stage, **kwargs):
     :return:
     """
 
-    # Curtailment by period and timepoint
+    # Curtailment by month and hour of day
+    # Spinup/lookahead timepoints are ignored by adding the resp. column tag
+    # through inner joins and adding a conditional to ignore those timepoints
     sql = """SELECT month, hour_of_day, 
         SUM(scheduled_curtailment_mw) AS scheduled_curtailment_mwh
         FROM results_project_curtailment_variable
+        
+        -- add temporal scenario id so we can join timepoints table
+        INNER JOIN
+        
+        (SELECT temporal_scenario_id, scenario_id FROM scenarios)
+        USING (scenario_id)
+        
+        -- filter out spinup_or_lookahead timepoints
+        INNER JOIN
+        
+        (SELECT temporal_scenario_id, stage_id, subproblem_id, timepoint, 
+        spinup_or_lookahead
+        FROM inputs_temporal_timepoints)
+        USING (temporal_scenario_id, stage_id, subproblem_id, timepoint)
+        
         WHERE scenario_id = ?
         AND load_zone = ?
         AND period = ?
         AND stage_id = ?       
+        AND spinup_or_lookahead is NULL
+        
         GROUP BY month, hour_of_day
         ORDER BY month, hour_of_day
         ;"""

--- a/viz/energy_plot.py
+++ b/viz/energy_plot.py
@@ -70,19 +70,27 @@ def get_plotting_data(conn, scenario_id, load_zone, stage, **kwargs):
         sum(power_mw * timepoint_weight * number_of_hours_in_timepoint)/1000000
         as energy_twh
         FROM results_project_dispatch_by_technology
+        
+        -- add temporal scenario id so we can join timepoints table
         INNER JOIN
+        
         (SELECT temporal_scenario_id, scenario_id
         FROM scenarios)
         USING (scenario_id)
+        
+        -- filter out spinup_or_lookahead timepoints
         INNER JOIN
+        
         (SELECT temporal_scenario_id, stage_id, subproblem_id, timepoint, 
         spinup_or_lookahead
         FROM inputs_temporal_timepoints)
         USING (temporal_scenario_id, stage_id, subproblem_id, timepoint)
+        
         WHERE scenario_id = ?
         AND load_zone = ?
         AND stage_id = ?
         AND spinup_or_lookahead is NULL
+        
         GROUP BY period, technology"""
 
     df = pd.read_sql(

--- a/viz/rps_plot.py
+++ b/viz/rps_plot.py
@@ -61,6 +61,9 @@ def get_plotting_data(conn, scenario_id, rps_zone, subproblem, stage,
     """
     Get the RPS results by period for a given scenario/rps_zone/subproblem/stage
 
+    Note: RPS energy in spinup and lookahead timepoints is included since the
+    RPS energy in those timepoints will still count towards the target.
+
     **kwargs needed, so that an error isn't thrown when calling this
     function with extra arguments from the UI.
 


### PR DESCRIPTION
Only do so when appropriate. For the carbon and RPS plots, the spinup
and lookahead timepoints are counted towards the target/cap so they
should be included in the results. Generally we don't expect to have
spinup/lookahead timepoints when running a carbon cap or RPS target
scenario.

Also, the results summary.txt file includes the spinup and lookahead timepoints 
when calculating the total energy. I added a comment in the code to make this clear. 

Closes #486