### PR TITLE
Add carbon emissions to fuel burn results

### DIFF
--- a/db/csvs_test_examples/fuels/project_fuels/1_project_fuels_1.csv
+++ b/db/csvs_test_examples/fuels/project_fuels/1_project_fuels_1.csv
@@ -1,4 +1,1 @@
-fuel,co2_intensity_tons_per_mmbtu
-Coal,0.09552
-Gas,0.05306
-Uranium,0
+fuel,co2_intensity_tons_per_mmbtuCoal,0.09552Gas,0.05306Uranium,0

--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -2458,11 +2458,17 @@ rps_zone VARCHAR(32),
 carbon_cap_zone VARCHAR(32),
 technology VARCHAR(32),
 fuel VARCHAR(32),
-fuel_burn_mmbtu FLOAT,
+operations_fuel_burn_mmbtu FLOAT,
+startup_fuel_burn_mmbtu FLOAT,
+total_fuel_burn_mmbtu FLOAT,
+operations_carbon_emissions_tonnes FLOAT,
+startup_carbon_emissions_tonnes FLOAT,
+total_carbon_emissions_tonnes FLOAT,
 PRIMARY KEY (scenario_id, project, subproblem_id, stage_id, timepoint)
 );
 
 
+-- TODO: could drop this since duplicate of data in fuel burn?
 DROP TABLE IF EXISTS results_project_carbon_emissions;
 CREATE TABLE results_project_carbon_emissions (
 scenario_id INTEGER,

--- a/gridpath/project/operations/carbon_emissions.py
+++ b/gridpath/project/operations/carbon_emissions.py
@@ -125,8 +125,12 @@ def carbon_emissions_rule(mod, g, tmp):
     **Expression Name**: Carbon_Emissions_Tons
     **Defined Over**: CRBN_PRJ_OPR_TMPS
 
-    Emissions from each project based on operational type
-    (and whether a project burns fuel)
+    Emissions (in metric tonnes CO2) from each project (with a carbon cap zone
+    assigned to it) for each operational timepoint. Includes emissions from
+    startup fuel burn as well (assuming startup uses the same fuel as
+    operations). Note: if a project has no carbon cap zone assigned, it will
+    not be included here, even though emissions will be reported in the fuel
+    burn table.
     """
     return mod.Total_Fuel_Burn_MMBtu[g, tmp] \
         * mod.co2_intensity_tons_per_mmbtu[mod.fuel[g]]
@@ -158,6 +162,9 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     }
 
 
+# TODO: remove carbon emissions table since duplicate of data in fuel burn?
+#  (only difference is that fuel burn includes ALL projects whereas this table
+#  only includes carbon emissions from from projects with a carbon cap zone).
 def export_results(scenario_directory, subproblem, stage, m, d):
     """
 
@@ -284,6 +291,9 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage,
         writer.writerows(new_rows)
 
 
+# TODO: remove carbon emissions table since duplicate of data in fuel burn?
+#  (only difference is that fuel burn includes ALL projects whereas this table
+#  only includes carbon emissions from from projects with a carbon cap zone).
 def import_results_into_database(
         scenario_id, subproblem, stage, c, db, results_directory, quiet
 ):


### PR DESCRIPTION
Carbon emissions are not output unless you were running a scenario
with a carbon cap. It is likely though that users want to look at
emissions without running a scenario with a cap, e.g. when doing
production simulation. You could get around this by adding a really
large cap but that still requires users to make up inputs for the carbon
cap zones and assigning carbon cap zones to projects.

With this update, the fuel burn table now includes the carbon emissions
as well. It doesn't require any additional user inputs since the
emission factors were already part of the fuels table.

The down side is that there are now duplicate inputs between the fuel
burn table and the carbon emissions table, and there could be a
discrepancy between the tables if there are projects that don't have
a carbon cap zone. This could be fixed by removing the carbon emissions
table entirely and simply using the fuel burn table. However, that
would remove some of the analogy between the carbon module and rps
modules (right now they're pretty much the same structure).

Closes #155. 