### PR TITLE
Define OP TMPS for gen_var and gen_var_must_take based on capacity package

### DIFF
--- a/gridpath/project/operations/operational_types/gen_var.py
+++ b/gridpath/project/operations/operational_types/gen_var.py
@@ -466,7 +466,6 @@ def load_module_specific_data(mod, data_portal,
             pass
 
     # Determine subset of project-timepoints in variable profiles file
-    project_timepoints = list()
     cap_factor = dict()
 
     prj_tmp_cf_df = pd.read_csv(
@@ -479,7 +478,6 @@ def load_module_specific_data(mod, data_portal,
                    prj_tmp_cf_df["timepoint"],
                    prj_tmp_cf_df["cap_factor"]):
         if row[0] in projects:
-            project_timepoints.append((row[0], row[1]))
             cap_factor[(row[0], row[1])] = float(row[2])
         # Profile could be for a 'gen_var' project, in which case ignore
         elif row[0] in var_must_take_prjs:
@@ -494,7 +492,6 @@ def load_module_specific_data(mod, data_portal,
             )
 
     # Load data
-    data_portal.data()["GEN_VAR_OPR_TMPS"] = {None: project_timepoints}
     data_portal.data()["gen_var_cap_factor"] = cap_factor
 
 

--- a/gridpath/project/operations/operational_types/gen_var_must_take.py
+++ b/gridpath/project/operations/operational_types/gen_var_must_take.py
@@ -309,7 +309,6 @@ def load_module_specific_data(mod, data_portal,
             pass
 
     # Determine subset of project-timepoints in variable profiles file
-    project_timepoints = list()
     cap_factor = dict()
 
     prj_tmp_cf_df = pd.read_csv(
@@ -322,7 +321,6 @@ def load_module_specific_data(mod, data_portal,
                    prj_tmp_cf_df["timepoint"],
                    prj_tmp_cf_df["cap_factor"]):
         if row[0] in projects:
-            project_timepoints.append((row[0], row[1]))
             cap_factor[(row[0], row[1])] = float(row[2])
         # Profile could be for a 'gen_var' project, in which case ignore
         elif row[0] in var_proj:
@@ -339,8 +337,6 @@ def load_module_specific_data(mod, data_portal,
             )
 
     # Load data
-    data_portal.data()["GEN_VAR_MUST_TAKE_OPR_TMPS"] = \
-        {None: project_timepoints}
     data_portal.data()["gen_var_must_take_cap_factor"] = cap_factor
 
 


### PR DESCRIPTION
In general, we create the `TYPE_OPERATIONAL_TIMEPOINT` sets from the `PROJECT_OPERATIONAL_TIMEPOINTS` (based on definitions in the capacity package) within each operational module. It appears we were overwriting that behavior in the two variable operational types by loading data for the set from the capacity factor inputs. Operational status should be defined via the capacity type and associated inputs, and the operations inputs should conform to that, so I have removed the overwriting behavior here.