### PR TITLE
Add availability derate to DR op-type

### DIFF
--- a/gridpath/project/operations/operational_types/dr.py
+++ b/gridpath/project/operations/operational_types/dr.py
@@ -160,8 +160,9 @@ def max_shift_up_rule(mod, p, tmp):
     Limits the added load to the available power capacity.
     """
     return mod.DR_Shift_Up_MW[p, tmp] <= \
-        mod.Capacity_MW[p, mod.period[tmp]]
-    
+        mod.Capacity_MW[p, mod.period[tmp]] \
+        * mod.Availability_Derate[p, tmp]
+
 
 def max_shift_down_rule(mod, p, tmp):
     """
@@ -171,7 +172,8 @@ def max_shift_down_rule(mod, p, tmp):
     Limits the removed load to the available power capacity.
     """
     return mod.DR_Shift_Down_MW[p, tmp] <= \
-        mod.Capacity_MW[p, mod.period[tmp]]
+        mod.Capacity_MW[p, mod.period[tmp]] \
+        * mod.Availability_Derate[p, tmp]
 
 
 def energy_balance_rule(mod, p, h):


### PR DESCRIPTION
This seemed to be missing. Now that this is added, all operational types (and capacity types) are compatible with all availability types so we can close the releated PR (#524). 