### PR TITLE
Fix input validation errors

### DIFF
--- a/gridpath/project/__init__.py
+++ b/gridpath/project/__init__.py
@@ -365,23 +365,6 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
              )
         )
 
-    # Check 0 < min stable fraction <= 1
-    if "min_stable_level" not in error_columns:
-        validation_errors = validate_min_stable_level(df)
-        for error in validation_errors:
-            validation_results.append(
-                (subscenarios.SCENARIO_ID,
-                 subproblem,
-                 stage,
-                 __name__,
-                 "PROJECT_OPERATIONAL_CHARS",
-                 "inputs_project_operational_chars",
-                 "High",
-                 "Invalid min_stable_level",
-                 error
-                 )
-            )
-
     # Check that we're not combining incompatible cap-types and op-types
     invalid_combos = c.execute(
         """SELECT capacity_type, operational_type 
@@ -446,27 +429,6 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
 
     # Write all input validation errors to database
     write_validation_to_database(validation_results, conn)
-
-
-def validate_min_stable_level(df):
-    """
-    Check 0 < min stable fraction <= 1
-    :param df:
-    :return:
-    """
-    results = []
-
-    invalids = ((df["min_stable_level"] <= 0) |
-                (df["min_stable_level"] > 1))
-    if invalids.any():
-        bad_projects = df["project"][invalids].values
-        print_bad_projects = ", ".join(bad_projects)
-        results.append(
-            "Project(s) '{}': expected 0 < min_stable_level <= 1"
-            .format(print_bad_projects)
-        )
-
-    return results
 
 
 def validate_op_cap_combos(df, invalid_combos):

--- a/gridpath/project/operations/operational_types/gen_commit_cap.py
+++ b/gridpath/project/operations/operational_types/gen_commit_cap.py
@@ -1423,13 +1423,13 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
         """SELECT project, operational_type,
         min_stable_level, unit_size_mw,
         charging_efficiency, discharging_efficiency,
-        minimum_duration_hours, maximum_duration_hours, maximum_duration_hours
+        minimum_duration_hours, maximum_duration_hours
         FROM inputs_project_portfolios
         INNER JOIN
         (SELECT project, operational_type,
         min_stable_level, unit_size_mw,
         charging_efficiency, discharging_efficiency,
-        minimum_duration_hours
+        minimum_duration_hours, maximum_duration_hours
         FROM inputs_project_operational_chars
         WHERE project_operational_chars_scenario_id = {}) as prj_chars
         USING (project)

--- a/tests/project/operations/test_init.py
+++ b/tests/project/operations/test_init.py
@@ -374,6 +374,33 @@ class TestOperationsInit(unittest.TestCase):
             self.assertDictEqual(expected_slopes, actual_slopes)
             self.assertDictEqual(expected_intercepts, actual_intercepts)
 
+    def test_project_validations(self):
+        cols = ["project", "min_stable_level"]
+        test_cases = {
+            # Make sure correct inputs don't throw error
+            1: {"df": pd.DataFrame(
+                    columns=cols,
+                    data=[["gas_ct", 0.5]
+                          ]),
+                "min_stable_level_error": [],
+                },
+            # Make sure invalid min_stable_level is flagged
+            2: {"df": pd.DataFrame(
+                columns=cols,
+                data=[["gas_ct1", 1.5],
+                      ["gas_ct2", 0]
+                      ]),
+                "min_stable_level_error": ["Project(s) 'gas_ct1, gas_ct2': expected 0 < min_stable_level <= 1"],
+                }
+        }
+
+        for test_case in test_cases.keys():
+            expected_list = test_cases[test_case]["min_stable_level_error"]
+            actual_list = MODULE_BEING_TESTED.validate_min_stable_level(
+                df=test_cases[test_case]["df"]
+            )
+            self.assertListEqual(expected_list, actual_list)
+
     def test_heat_rate_validations(self):
         hr_columns = ["project", "fuel", "heat_rate_curves_scenario_id",
                       "load_point_fraction", "average_heat_rate_mmbtu_per_mwh"]

--- a/tests/project/test_init.py
+++ b/tests/project/test_init.py
@@ -240,38 +240,29 @@ class TestProjectInit(unittest.TestCase):
         self.assertDictEqual(expected_op_type, actual_op_type)
 
     def test_project_validations(self):
-        cols = ["project", "capacity_type", "operational_type",
-                "min_stable_level"]
+        cols = ["project", "capacity_type", "operational_type"]
         test_cases = {
             # Make sure correct inputs don't throw error
             1: {"df": pd.DataFrame(
                     columns=cols,
                     data=[["gas_ct", "gen_new_lin",
-                           "gen_commit_cap", 0.5]
+                           "gen_commit_cap"]
                           ]),
                 "invalid_combos": [("invalid1", "invalid2")],
-                "min_stable_level_error": [],
                 "combo_error": [],
                 },
-            # Make sure invalid min_stable_level and invalid combo are flagged
+            # Make sure invalid combo is flagged
             2: {"df": pd.DataFrame(
                 columns=cols,
-                data=[["gas_ct1", "cap1", "op2", 1.5],
-                      ["gas_ct2", "cap1", "op3", 0]
+                data=[["gas_ct1", "cap1", "op2"],
+                      ["gas_ct2", "cap1", "op3"]
                       ]),
                 "invalid_combos": [("cap1", "op2")],
-                "min_stable_level_error": ["Project(s) 'gas_ct1, gas_ct2': expected 0 < min_stable_level <= 1"],
                 "combo_error": ["Project(s) 'gas_ct1': 'cap1' and 'op2'"],
                 }
         }
 
         for test_case in test_cases.keys():
-            expected_list = test_cases[test_case]["min_stable_level_error"]
-            actual_list = MODULE_BEING_TESTED.validate_min_stable_level(
-                df=test_cases[test_case]["df"]
-            )
-            self.assertListEqual(expected_list, actual_list)
-
             expected_list = test_cases[test_case]["combo_error"]
             actual_list = MODULE_BEING_TESTED.validate_op_cap_combos(
                 df=test_cases[test_case]["df"],


### PR DESCRIPTION
Some of the recent updates, including #528, #526 and #510 introduced errors in the input validation that weren't caught because we currently don't test the input validation (to be addressed in #533). This PR fixes these issues:

 - remove missing/duplicate max_duration_hours
 - make vom_curves query same as heat rates and return the scenario_id as well for input validation.
 - fix vom_curves input validation
 - move min_stable level validation from projects.init to projects.operations.init
 - fix unittests accordingly

Note: this will have conflicts with #539. 