### PR TITLE
Refactor loading in variable profiles

### DIFF
--- a/gridpath/project/operations/operational_types/gen_var.py
+++ b/gridpath/project/operations/operational_types/gen_var.py
@@ -31,7 +31,8 @@ from gridpath.project.operations.reserves.subhourly_energy_adjustment import \
 from gridpath.project.common_functions import \
     check_if_linear_horizon_first_timepoint
 from gridpath.project.operations.operational_types.common_functions import \
-    update_dispatch_results_table, load_var_op_type_profiles
+    update_dispatch_results_table, load_var_profile_inputs, \
+    get_var_profile_inputs_from_database, write_var_profile_model_inputs
 
 
 def add_module_specific_components(m, d):
@@ -437,8 +438,6 @@ def power_delta_rule(mod, g, tmp):
 def load_module_specific_data(mod, data_portal,
                               scenario_directory, subproblem, stage):
     """
-    Capacity factors vary by horizon and stage, so get inputs from appropriate
-    directory
     :param mod:
     :param data_portal:
     :param scenario_directory:
@@ -447,9 +446,9 @@ def load_module_specific_data(mod, data_portal,
     :return:
     """
 
-    load_var_op_type_profiles(
-        mod, data_portal, scenario_directory, subproblem, stage,
-        "gen_var")
+    load_var_profile_inputs(
+        data_portal, scenario_directory, subproblem, stage, "gen_var"
+    )
 
 
 def export_module_specific_results(mod, d,
@@ -508,92 +507,10 @@ def get_module_specific_inputs_from_database(
     :param conn: database connection
     :return:
     """
-    subproblem = 1 if subproblem == "" else subproblem
-    stage = 1 if stage == "" else stage
 
-    c = conn.cursor()
-    # Select only profiles of projects in the portfolio
-    # Select only profiles of projects with 'gen_var'
-    # operational type
-    # Select only profiles for timepoints from the correct temporal scenario
-    # and the correct subproblem
-    # Select only timepoints on periods when the project is operational
-    # (periods with existing project capacity for existing projects or
-    # with costs specified for new projects)
-    variable_profiles = c.execute("""
-        SELECT project, timepoint, cap_factor
-        FROM (
-        -- Select only projects from the relevant portfolio
-        SELECT project
-        FROM inputs_project_portfolios
-        WHERE project_portfolio_scenario_id = {}
-        ) as portfolio_tbl
-        -- Of the projects in the portfolio, select only those that are in 
-        -- this project_operational_chars_scenario_id and have 'gen_var' as 
-        -- their operational_type
-        INNER JOIN
-        (SELECT project, variable_generator_profile_scenario_id
-        FROM inputs_project_operational_chars
-        WHERE project_operational_chars_scenario_id = {}
-        AND operational_type = 'gen_var'
-        ) AS op_char
-        USING (project)
-        -- Cross join to the timepoints in the relevant 
-        -- temporal_scenario_id, subproblem_id, and stage_id
-        -- Get the period since we'll need that to get only the operational 
-        -- timepoints for a project via an INNER JOIN below
-        CROSS JOIN
-        (SELECT stage_id, timepoint, period
-        FROM inputs_temporal_timepoints
-        WHERE temporal_scenario_id = {}
-        AND subproblem_id = {}
-        AND stage_id = {}
-        ) as tmps_tbl
-        -- Now that we have the relevant projects and timepoints, get the 
-        -- respective cap_factor (and no others) from 
-        -- inputs_project_variable_generator_profiles through a LEFT OUTER JOIN
-        LEFT OUTER JOIN
-        inputs_project_variable_generator_profiles
-        USING (variable_generator_profile_scenario_id, project, 
-        stage_id, timepoint)
-        -- We also only want timepoints in periods when the project actually 
-        -- exists, so we figure out the operational periods for each of the  
-        -- projects below and INNER JOIN to that
-        INNER JOIN
-            (SELECT project, period
-            FROM (
-                -- Get the operational periods for each 'existing' and 
-                -- 'new' project
-                SELECT project, period
-                FROM inputs_project_specified_capacity
-                WHERE project_specified_capacity_scenario_id = {}
-                UNION
-                SELECT project, period
-                FROM inputs_project_new_cost
-                WHERE project_new_cost_scenario_id = {}
-                ) as all_operational_project_periods
-            -- Only use the periods in temporal_scenario_id via an INNER JOIN
-            INNER JOIN (
-                SELECT period
-                FROM inputs_temporal_periods
-                WHERE temporal_scenario_id = {}
-                ) as relevant_periods_tbl
-            USING (period)
-            ) as relevant_op_periods_tbl
-        USING (project, period);
-        """.format(
-            subscenarios.PROJECT_PORTFOLIO_SCENARIO_ID,
-            subscenarios.PROJECT_OPERATIONAL_CHARS_SCENARIO_ID,
-            subscenarios.TEMPORAL_SCENARIO_ID,
-            subproblem,
-            stage,
-            subscenarios.PROJECT_SPECIFIED_CAPACITY_SCENARIO_ID,
-            subscenarios.PROJECT_NEW_COST_SCENARIO_ID,
-            subscenarios.TEMPORAL_SCENARIO_ID
-        )
+    return get_var_profile_inputs_from_database(
+        subscenarios, subproblem, stage, conn, "gen_var"
     )
-
-    return variable_profiles
 
 
 def write_module_specific_model_inputs(
@@ -609,33 +526,10 @@ def write_module_specific_model_inputs(
     :param conn: database connection
     :return:
     """
-    variable_profiles = get_module_specific_inputs_from_database(
-        subscenarios, subproblem, stage, conn)
 
-    # If variable_generator_profiles.tab file already exists, append rows to it
-    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
-                                   "variable_generator_profiles.tab")
-                      ):
-        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
-                               "variable_generator_profiles.tab"), "a") as \
-                variable_profiles_tab_file:
-            writer = csv.writer(variable_profiles_tab_file, delimiter="\t", lineterminator="\n")
-            for row in variable_profiles:
-                writer.writerow(row)
-    # If variable_generator_profiles.tab does not exist, write header first,
-    # then add profiles data
-    else:
-        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
-                               "variable_generator_profiles.tab"), "w", newline="") as \
-                variable_profiles_tab_file:
-            writer = csv.writer(variable_profiles_tab_file, delimiter="\t", lineterminator="\n")
-
-            # Write header
-            writer.writerow(
-                ["project", "timepoint", "cap_factor"]
-            )
-            for row in variable_profiles:
-                writer.writerow(row)
+    write_var_profile_model_inputs(
+        scenario_directory, subscenarios, subproblem, stage, conn, "gen_var"
+    )
 
 
 def import_module_specific_results_to_database(

--- a/gridpath/project/operations/operational_types/gen_var_must_take.py
+++ b/gridpath/project/operations/operational_types/gen_var_must_take.py
@@ -21,7 +21,8 @@ from gridpath.auxiliary.dynamic_components import headroom_variables, \
 from gridpath.project.common_functions import \
     check_if_linear_horizon_first_timepoint
 from gridpath.project.operations.operational_types.common_functions import \
-    load_var_op_type_profiles
+    load_var_profile_inputs, get_var_profile_inputs_from_database, \
+    write_var_profile_model_inputs
 
 
 def add_module_specific_components(m, d):
@@ -285,8 +286,6 @@ def power_delta_rule(mod, g, tmp):
 def load_module_specific_data(mod, data_portal,
                               scenario_directory, subproblem, stage):
     """
-    Capacity factors vary by horizon and stage, so get inputs from appropriate
-    directory
     :param mod:
     :param data_portal:
     :param scenario_directory:
@@ -295,9 +294,9 @@ def load_module_specific_data(mod, data_portal,
     :return:
     """
 
-    load_var_op_type_profiles(
-        mod, data_portal, scenario_directory, subproblem, stage,
-        "gen_var_must_take")
+    load_var_profile_inputs(
+        data_portal, scenario_directory, subproblem, stage, "gen_var_must_take"
+    )
 
 
 # Database
@@ -313,89 +312,9 @@ def get_module_specific_inputs_from_database(
     :param conn: database connection
     :return:
     """
-    c = conn.cursor()
-    # Select only profiles of projects in the portfolio
-    # Select only profiles of projects with 'gen_var_must_take'
-    # operational type
-    # Select only profiles for timepoints from the correct timepoint
-    # scenario
-    # Select only timepoints on periods when the project is operational
-    # (periods with existing project capacity for existing projects or
-    # with costs specified for new projects)
-    variable_profiles = c.execute("""
-        SELECT project, timepoint, cap_factor
-        FROM (
-        -- Select only projects from the relevant portfolio
-        SELECT project
-        FROM inputs_project_portfolios
-        WHERE project_portfolio_scenario_id = {}
-        ) as portfolio_tbl
-        -- Of the projects in the portfolio, select only those that are in 
-        -- this project_operational_chars_scenario_id and have 'gen_var_must_take' as 
-        -- their operational_type
-        INNER JOIN
-        (SELECT project, variable_generator_profile_scenario_id
-        FROM inputs_project_operational_chars
-        WHERE project_operational_chars_scenario_id = {}
-        AND operational_type = 'gen_var_must_take'
-        ) AS op_char
-        USING (project)
-        -- Cross join to the timepoints in the relevant 
-        -- temporal_scenario_id, subproblem_id, and stage_id
-        -- Get the period since we'll need that to get only the operational 
-        -- timepoints for a project via an INNER JOIN below
-        CROSS JOIN
-        (SELECT stage_id, timepoint, period
-        FROM inputs_temporal_timepoints
-        WHERE temporal_scenario_id = {}
-        AND subproblem_id = {}
-        AND stage_id = {}
-        ) as tmps_tbl
-        -- Now that we have the relevant projects and timepoints, get the 
-        -- respective cap_factor (and no others) from 
-        -- inputs_project_variable_generator_profiles through a LEFT OUTER JOIN
-        LEFT OUTER JOIN
-        inputs_project_variable_generator_profiles
-        USING (variable_generator_profile_scenario_id, project, 
-        stage_id, timepoint)
-        -- We also only want timepoints in periods when the project actually 
-        -- exists, so we figure out the operational periods for each of the  
-        -- projects below and INNER JOIN to that
-        INNER JOIN
-            (SELECT project, period
-            FROM (
-                -- Get the operational periods for each 'existing' and 
-                -- 'new' project
-                SELECT project, period
-                FROM inputs_project_specified_capacity
-                WHERE project_specified_capacity_scenario_id = {}
-                UNION
-                SELECT project, period
-                FROM inputs_project_new_cost
-                WHERE project_new_cost_scenario_id = {}
-                ) as all_operational_project_periods
-            -- Only use the periods in temporal_scenario_id via an INNER JOIN
-            INNER JOIN (
-                SELECT period
-                FROM inputs_temporal_periods
-                WHERE temporal_scenario_id = {}
-                ) as relevant_periods_tbl
-            USING (period)
-            ) as relevant_op_periods_tbl
-        USING (project, period);
-        """.format(
-            subscenarios.PROJECT_PORTFOLIO_SCENARIO_ID,
-            subscenarios.PROJECT_OPERATIONAL_CHARS_SCENARIO_ID,
-            subscenarios.TEMPORAL_SCENARIO_ID,
-            subproblem,
-            stage,
-            subscenarios.PROJECT_SPECIFIED_CAPACITY_SCENARIO_ID,
-            subscenarios.PROJECT_NEW_COST_SCENARIO_ID,
-            subscenarios.TEMPORAL_SCENARIO_ID
-        )
+    return get_var_profile_inputs_from_database(
+        subscenarios, subproblem, stage, conn, "gen_var_must_take"
     )
-
-    return variable_profiles
 
 
 def write_module_specific_model_inputs(
@@ -411,33 +330,11 @@ def write_module_specific_model_inputs(
     :param conn: database connection
     :return:
     """
-    variable_profiles = get_module_specific_inputs_from_database(
-        subscenarios, subproblem, stage, conn)
 
-    # If variable_generator_profiles.tab file already exists, append rows to it
-    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
-                                   "variable_generator_profiles.tab")
-                      ):
-        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
-                               "variable_generator_profiles.tab"), "a") as \
-                variable_profiles_tab_file:
-            writer = csv.writer(variable_profiles_tab_file, delimiter="\t", lineterminator="\n")
-            for row in variable_profiles:
-                writer.writerow(row)
-    # If variable_generator_profiles.tab does not exist, write header first,
-    # then add profiles data
-    else:
-        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
-                               "variable_generator_profiles.tab"), "w", newline="") as \
-                variable_profiles_tab_file:
-            writer = csv.writer(variable_profiles_tab_file, delimiter="\t", lineterminator="\n")
-
-            # Write header
-            writer.writerow(
-                ["project", "timepoint", "cap_factor"]
-            )
-            for row in variable_profiles:
-                writer.writerow(row)
+    write_var_profile_model_inputs(
+        scenario_directory, subscenarios, subproblem, stage, conn,
+        "gen_var_must_take"
+    )
 
 
 # Validation


### PR DESCRIPTION
This way we can re-use the same code rather than having duplicate code
across different operational types.

This also introduces more dataframe operations to do filtering, which
presumably (not tested) is more efficient and could be easier to
follow.

Is this what you had in mind in #536 or is it something even more generalized, @anamileva ? 