### PR TITLE
Pass scenario directory, not input directory, when writing model inputs

### DIFF
--- a/gridpath/common_functions.py
+++ b/gridpath/common_functions.py
@@ -173,7 +173,7 @@ def create_logs_directory_if_not_exists(scenario_directory, subproblem, stage):
     :param stage:
     :return:
     """
-    logs_directory = os.path.join(scenario_directory, subproblem, stage, "logs")
+    logs_directory = os.path.join(scenario_directory, str(subproblem), str(stage), "logs")
     if not os.path.exists(logs_directory):
         os.makedirs(logs_directory)
     return logs_directory

--- a/gridpath/geography/carbon_cap_zones.py
+++ b/gridpath/geography/carbon_cap_zones.py
@@ -31,7 +31,7 @@ def add_model_components(m, d):
 
 def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
 
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "carbon_cap_zones.tab"),
                      index=m.CARBON_CAP_ZONES,
                      param=(m.carbon_cap_allow_violation,
@@ -47,6 +47,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     carbon_cap_zone = c.execute(
         """SELECT carbon_cap_zone, allow_violation, violation_penalty_per_mmt
@@ -75,11 +77,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     carbon_cap_zones.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -90,7 +92,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     carbon_cap_zone = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "carbon_cap_zones.tab"), "w", newline="") as \
             carbon_cap_zones_file:
         writer = csv.writer(carbon_cap_zones_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/frequency_response_balancing_areas.py
+++ b/gridpath/geography/frequency_response_balancing_areas.py
@@ -35,7 +35,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "frequency_response_balancing_areas.tab"),
         select=("balancing_area", "allow_violation",
                 "violation_penalty_per_mw"),
@@ -53,6 +53,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     freq_resp_bas = c.execute(
         """SELECT frequency_response_ba, allow_violation,
@@ -81,11 +83,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     frequency_response_balancing_areas.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -96,7 +98,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     freq_resp_bas = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "frequency_response_balancing_areas.tab"), "w", newline="") as \
             freq_resp_bas_tab_file:
         writer = csv.writer(freq_resp_bas_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/load_following_down_balancing_areas.py
+++ b/gridpath/geography/load_following_down_balancing_areas.py
@@ -35,7 +35,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "load_following_down_balancing_areas.tab"),
         select=("balancing_area", "allow_violation",
                 "violation_penalty_per_mw"),
@@ -53,6 +53,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     lf_down_bas = c.execute(
             """SELECT lf_reserves_down_ba, allow_violation,
@@ -81,11 +83,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     load_following_down_balancing_areas.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -96,7 +98,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     lf_down_bas = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "load_following_down_balancing_areas.tab"), "w", newline="") as \
             lf_down_bas_tab_file:
         writer = csv.writer(lf_down_bas_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/load_following_up_balancing_areas.py
+++ b/gridpath/geography/load_following_up_balancing_areas.py
@@ -35,7 +35,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "load_following_up_balancing_areas.tab"),
         select=("balancing_area", "allow_violation",
                 "violation_penalty_per_mw"),
@@ -53,6 +53,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     lf_up_bas = c.execute(
         """SELECT lf_reserves_up_ba, allow_violation,
@@ -81,11 +83,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     load_following_up_balancing_areas.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -96,7 +98,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     lf_up_bas = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "load_following_up_balancing_areas.tab"), "w", newline="") as \
             lf_up_bas_tab_file:
         writer = csv.writer(lf_up_bas_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/load_zones.py
+++ b/gridpath/geography/load_zones.py
@@ -44,7 +44,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :param stage:
     :return:
     """
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "load_zones.tab"),
                      index=m.LOAD_ZONES,
                      param=(
@@ -63,6 +63,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     load_zones = c.execute("""
         SELECT load_zone, allow_overgeneration, overgeneration_penalty_per_mw, 
@@ -90,11 +92,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     load_zones.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -105,7 +107,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     load_zones = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "load_zones.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "load_zones.tab"),
               "w", newline="") as \
             load_zones_tab_file:
         writer = csv.writer(load_zones_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/local_capacity_zones.py
+++ b/gridpath/geography/local_capacity_zones.py
@@ -40,7 +40,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :param stage:
     :return:
     """
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs",
                                            "local_capacity_zones.tab"),
                      index=m.LOCAL_CAPACITY_ZONES,
@@ -57,6 +57,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     local_capacity_zones = c.execute(
         """SELECT local_capacity_zone, allow_violation,
@@ -86,11 +88,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     local_capacity_zones.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -101,7 +103,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     local_capacity_zones = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "local_capacity_zones.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "local_capacity_zones.tab"),
               "w", newline="") as \
             local_capacity_zones_file:
         writer = csv.writer(local_capacity_zones_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/prm_zones.py
+++ b/gridpath/geography/prm_zones.py
@@ -40,7 +40,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :param stage: 
     :return: 
     """
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "prm_zones.tab"),
                      index=m.PRM_ZONES,
                      param=(m.prm_allow_violation,
@@ -56,6 +56,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     prm_zones = c.execute(
         """SELECT prm_zone, allow_violation, violation_penalty_per_mw
@@ -84,11 +86,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     prm_zones.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -99,7 +101,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     prm_zones = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "prm_zones.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "prm_zones.tab"),
               "w", newline="") as \
             prm_zones_tab_file:
         writer = csv.writer(prm_zones_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/regulation_down_balancing_areas.py
+++ b/gridpath/geography/regulation_down_balancing_areas.py
@@ -35,7 +35,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "regulation_down_balancing_areas.tab"),
         select=("balancing_area", "allow_violation",
                 "violation_penalty_per_mw"),
@@ -53,6 +53,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     reg_down_bas = c.execute(
         """SELECT regulation_down_ba, allow_violation,
@@ -81,11 +83,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     regulation_down_balancing_areas.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -96,7 +98,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     reg_down_bas = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "regulation_down_balancing_areas.tab"), "w", newline="") as \
             reg_down_bas_tab_file:
         writer = csv.writer(reg_down_bas_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/regulation_up_balancing_areas.py
+++ b/gridpath/geography/regulation_up_balancing_areas.py
@@ -35,7 +35,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "regulation_up_balancing_areas.tab"),
         select=("balancing_area", "allow_violation",
                 "violation_penalty_per_mw"),
@@ -53,6 +53,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     reg_up_bas = c.execute(
         """SELECT regulation_up_ba, allow_violation,
@@ -80,11 +82,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     regulation_up_balancing_areas.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -95,7 +97,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     reg_up_bas = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "regulation_up_balancing_areas.tab"), "w", newline="") as \
             reg_up_bas_tab_file:
         writer = csv.writer(reg_up_bas_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/rps_zones.py
+++ b/gridpath/geography/rps_zones.py
@@ -31,7 +31,7 @@ def add_model_components(m, d):
 
 def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
 
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "rps_zones.tab"),
                      index=m.RPS_ZONES,
                      param=(m.rps_allow_violation,
@@ -47,6 +47,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     rps_zones = c.execute(
         """SELECT rps_zone, allow_violation, violation_penalty_per_mwh
@@ -74,11 +76,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     rps_zones.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -89,7 +91,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     rps_zones = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "rps_zones.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "rps_zones.tab"),
               "w", newline="") as \
             rps_zones_tab_file:
         writer = csv.writer(rps_zones_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/geography/spinning_reserves_balancing_areas.py
+++ b/gridpath/geography/spinning_reserves_balancing_areas.py
@@ -35,7 +35,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "spinning_reserves_balancing_areas.tab"),
         select=("balancing_area", "allow_violation",
                 "violation_penalty_per_mw"),
@@ -53,6 +53,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     spinning_reserves_bas = c.execute(
         """SELECT spinning_reserves_ba, allow_violation,
@@ -81,11 +83,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     spinning_reserves_balancing_areas.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -96,7 +98,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     spinning_reserves_bas = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "spinning_reserves_balancing_areas.tab"), "w", newline="") as \
             spinning_reserve_bas_tab_file:
         writer = csv.writer(spinning_reserve_bas_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/get_scenario_inputs.py
+++ b/gridpath/get_scenario_inputs.py
@@ -59,21 +59,17 @@ def write_model_inputs(scenario_directory, subproblems, loaded_modules,
         for stage in stages:
             # if there are subproblems/stages, input directory will be nested
             if len(subproblems_list) > 1 and len(stages) > 1:
-                inputs_directory = os.path.join(scenario_directory,
-                                                str(subproblem),
-                                                str(stage),
-                                                "inputs")
+                pass
             elif len(subproblems.SUBPROBLEMS) > 1:
-                inputs_directory = os.path.join(scenario_directory,
-                                                str(subproblem),
-                                                "inputs")
+                stage = ""
             elif len(stages) > 1:
-                inputs_directory = os.path.join(scenario_directory,
-                                                str(stage),
-                                                "inputs")
+                subproblem = ""
             else:
-                inputs_directory = os.path.join(scenario_directory,
-                                                "inputs")
+                subproblem = ""
+                stage = ""
+            inputs_directory = os.path.join(
+                scenario_directory, str(subproblem), str(stage), "inputs"
+            )
             if not os.path.exists(inputs_directory):
                 os.makedirs(inputs_directory)
 
@@ -91,7 +87,7 @@ def write_model_inputs(scenario_directory, subproblems, loaded_modules,
             for m in loaded_modules:
                 if hasattr(m, "write_model_inputs"):
                     m.write_model_inputs(
-                        inputs_directory=inputs_directory,
+                        scenario_directory=scenario_directory,
                         subscenarios=subscenarios,
                         subproblem=subproblem,
                         stage=stage,

--- a/gridpath/objective/system/reliability/prm/dynamic_elcc_tuning_penalties.py
+++ b/gridpath/objective/system/reliability/prm/dynamic_elcc_tuning_penalties.py
@@ -83,6 +83,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     dynamic_elcc_tuning_cost = c.execute(
         """SELECT dynamic_elcc_tuning_cost_per_mw
@@ -110,11 +112,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     tuning_params.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -127,8 +129,8 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
     # If tuning params file exists, add column to file, else create file and
     #  writer header and tuning param value
-    if os.path.isfile(os.path.join(inputs_directory, "tuning_params.tab")):
-        with open(os.path.join(inputs_directory, "tuning_params.tab"), "r"
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab")):
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab"), "r"
                   ) as tuning_params_file_in:
             reader = csv.reader(tuning_params_file_in, delimiter="\t", lineterminator="\n")
 
@@ -144,14 +146,14 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             param_value.append(dynamic_elcc_tuning_cost)
             new_rows.append(param_value)
 
-        with open(os.path.join(inputs_directory, "tuning_params.tab"),
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab"),
                   "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t", lineterminator="\n")
             writer.writerows(new_rows)
 
     else:
-        with open(os.path.join(inputs_directory, "tuning_params.tab"),
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab"),
                   "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t", lineterminator="\n")

--- a/gridpath/objective/transmission/carbon_imports_tuning_costs.py
+++ b/gridpath/objective/transmission/carbon_imports_tuning_costs.py
@@ -87,6 +87,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     import_carbon_tuning_cost = c.execute(
         """SELECT import_carbon_tuning_cost_per_ton
@@ -114,11 +116,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     tuning_params.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -131,8 +133,8 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
     # If tuning params file exists, add column to file, else create file and
     #  writer header and tuning param value
-    if os.path.isfile(os.path.join(inputs_directory, "tuning_params.tab")):
-        with open(os.path.join(inputs_directory, "tuning_params.tab"), "r"
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab")):
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab"), "r"
                   ) as projects_file_in:
             reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -148,14 +150,14 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             param_value.append(import_carbon_tuning_cost)
             new_rows.append(param_value)
 
-        with open(os.path.join(inputs_directory, "tuning_params.tab"),
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab"),
                   "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t", lineterminator="\n")
             writer.writerows(new_rows)
 
     else:
-        with open(os.path.join(inputs_directory, "tuning_params.tab"),
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab"),
                   "w", newline="") as \
                 tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/__init__.py
+++ b/gridpath/project/__init__.py
@@ -51,7 +51,7 @@ def determine_dynamic_components(d, scenario_directory, subproblem, stage):
     """
 
     project_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "projects.tab"),
         sep="\t"
     )
@@ -179,7 +179,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     """
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "projects.tab"),
         index=m.PROJECTS,
         select=("project", "load_zone", "capacity_type",
@@ -191,14 +191,14 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
 
     # Technology column is optional (default param value is 'unspecified')
     header = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "projects.tab"),
         sep="\t", header=None, nrows=1
     ).values[0]
 
     if "technology" in header:
         data_portal.load(
-            filename=os.path.join(scenario_directory, subproblem, stage,
+            filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                   "inputs", "projects.tab"),
             select=("project", "technology"),
             param=m.technology
@@ -216,6 +216,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
 
     projects = c.execute(
@@ -260,11 +262,11 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     return projects
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -278,10 +280,10 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     #   of the tab files. If going this route, would need to make sure database
     #   columns and tab file column names are the same everywhere
     #   projects.fillna(".", inplace=True)
-    #   filename = os.path.join(inputs_directory, "projects.tab")
+    #   filename = os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab")
     #   projects.to_csv(filename, sep="\t", mode="w", newline="")
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w",
               newline="") as projects_tab_file:
         writer = csv.writer(projects_tab_file,
                             delimiter="\t",

--- a/gridpath/project/availability/availability.py
+++ b/gridpath/project/availability/availability.py
@@ -47,10 +47,10 @@ def add_model_components(m, d):
 
 
 def write_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -74,7 +74,7 @@ def write_model_inputs(
                    "write_module_specific_model_inputs"):
             imported_availability_type_modules[op_m].\
                 write_module_specific_model_inputs(
-                    inputs_directory, subscenarios, subproblem, stage, conn)
+                    scenario_directory, subscenarios, subproblem, stage, conn)
         else:
             pass
 

--- a/gridpath/project/availability/availability_types/binary.py
+++ b/gridpath/project/availability/availability_types/binary.py
@@ -332,7 +332,7 @@ def load_module_specific_data(
     avl_bin_min_unavl_hrs_per_event_dict = {}
     avl_bin_min_avl_hrs_between_events_dict = {}
 
-    with open(os.path.join(scenario_directory, subproblem, stage,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage),
                            "inputs", "project_availability_endogenous.tab"),
               "r") as f:
         reader = csv.reader(f, delimiter="\t", lineterminator="\n")
@@ -364,7 +364,7 @@ def export_module_specific_results(
     :return: Nothing
     """
 
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "project_availability_endogenous_binary.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)
@@ -437,11 +437,11 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
 
-    :param inputs_directory:
+    :param scenario_directory:
     :param subscenarios:
     :param subproblem:
     :param stage:
@@ -457,7 +457,8 @@ def write_module_specific_model_inputs(
     # Check if project_availability_endogenous.tab exists; only write header
     # if the file wasn't already created
     availability_file = os.path.join(
-        inputs_directory, "project_availability_endogenous.tab"
+        scenario_directory, subproblem, stage, "inputs",
+        "project_availability_endogenous.tab"
     )
 
     if not os.path.exists(availability_file):

--- a/gridpath/project/availability/availability_types/continuous.py
+++ b/gridpath/project/availability/availability_types/continuous.py
@@ -330,7 +330,7 @@ def load_module_specific_data(
     avl_cont_min_unavl_hrs_per_event_dict = {}
     avl_cont_min_avl_hrs_between_events_dict = {}
 
-    with open(os.path.join(scenario_directory, subproblem, stage,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage),
                            "inputs", "project_availability_endogenous.tab"),
               "r") as f:
         reader = csv.reader(f, delimiter="\t", lineterminator="\n")
@@ -363,7 +363,7 @@ def export_module_specific_results(
     :return: Nothing
     """
 
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "project_availability_endogenous_continuous.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)
@@ -436,11 +436,11 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
 
-    :param inputs_directory:
+    :param scenario_directory:
     :param subscenarios:
     :param subproblem:
     :param stage:
@@ -456,7 +456,8 @@ def write_module_specific_model_inputs(
     # Check if project_availability_endogenous.tab exists; only write header
     # if the file wasn't already created
     availability_file = os.path.join(
-        inputs_directory, "project_availability_endogenous.tab"
+        scenario_directory, subproblem, stage,
+        "project_availability_endogenous.tab"
     )
 
     if not os.path.exists(availability_file):

--- a/gridpath/project/availability/availability_types/exogenous.py
+++ b/gridpath/project/availability/availability_types/exogenous.py
@@ -143,6 +143,8 @@ def get_inputs_from_database(
     :param conn:
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
 
     c = conn.cursor()
     availabilities = c.execute("""
@@ -227,10 +229,10 @@ def get_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
-    :param inputs_directory:
+    :param scenario_directory:
     :param subscenarios:
     :param subproblem:
     :param stage:
@@ -242,7 +244,7 @@ def write_module_specific_model_inputs(
     ).fetchall()
 
     if availabilities:
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "project_availability_exogenous.tab"),
                   "w", newline="") as availability_tab_file:
             writer = csv.writer(availability_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/capacity/capacity.py
+++ b/gridpath/project/capacity/capacity.py
@@ -249,7 +249,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     """
 
     # Total capacity for all projects
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "capacity_all.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period",
@@ -307,7 +307,7 @@ def summarize_results(d, scenario_directory, subproblem, stage):
 
     # Get the results CSV as dataframe
     capacity_results_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "results",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                      "capacity_all.csv")
     )
 

--- a/gridpath/project/capacity/capacity_types/__init__.py
+++ b/gridpath/project/capacity/capacity_types/__init__.py
@@ -89,10 +89,10 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
             pass
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input .tab files
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -113,7 +113,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                    "write_module_specific_model_inputs"):
             imported_capacity_type_modules[op_m].\
                 write_module_specific_model_inputs(
-                    inputs_directory, subscenarios, subproblem, stage, conn)
+                    scenario_directory, subscenarios, subproblem, stage, conn)
         else:
             pass
 

--- a/gridpath/project/capacity/capacity_types/dr_new.py
+++ b/gridpath/project/capacity/capacity_types/dr_new.py
@@ -342,7 +342,7 @@ def load_module_specific_data(
         max_fraction = dict()
 
         df = pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage,
+            os.path.join(scenario_directory, str(subproblem), str(stage),
                          "inputs", "projects.tab"),
             sep="\t",
             usecols=["project", "capacity_type", "minimum_duration_hours"]
@@ -391,7 +391,7 @@ def export_module_specific_results(
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "capacity_dr_new.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "technology", "load_zone",
@@ -421,7 +421,7 @@ def summarize_module_specific_results(
 
     # Get the results CSV as dataframe
     capacity_results_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "results", "capacity_dr_new.csv")
     )
 
@@ -536,7 +536,7 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
@@ -546,7 +546,7 @@ def write_module_specific_model_inputs(
     Max potential is required for this module, so
     PROJECT_NEW_POTENTIAL_SCENARIO_ID can't be NULL
 
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -558,7 +558,7 @@ def write_module_specific_model_inputs(
         get_module_specific_inputs_from_database(
             subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "new_shiftable_load_supply_curve_potential.tab"),
               "w", newline="") as potentials_tab_file:
         writer = csv.writer(potentials_tab_file, delimiter="\t", lineterminator="\n")
@@ -575,7 +575,7 @@ def write_module_specific_model_inputs(
     # Supply curve
     # No supply curve periods for now, so check that we have only specified
     # a single supply curve for all periods in inputs_project_new_cost
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "new_shiftable_load_supply_curve.tab"),
               "w", newline="") as supply_curve_tab_file:
         writer = csv.writer(supply_curve_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/capacity/capacity_types/gen_new_bin.py
+++ b/gridpath/project/capacity/capacity_types/gen_new_bin.py
@@ -331,7 +331,7 @@ def load_module_specific_data(
     """
 
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "new_binary_build_generator_vintage_costs.tab"),
         index=m.GEN_NEW_BIN_VNTS,
         select=("project", "vintage", "lifetime_yrs",
@@ -341,7 +341,7 @@ def load_module_specific_data(
     )
 
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "new_binary_build_generator_size.tab"),
         index=m.GEN_NEW_BIN,
         select=("project", "binary_build_size_mw"),
@@ -359,7 +359,7 @@ def export_module_specific_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "capacity_gen_new_bin.csv"),
               "w", newline="") as f:
 
@@ -391,7 +391,7 @@ def summarize_module_specific_results(
 
     # Get the results CSV as dataframe
     capacity_results_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "results", "capacity_gen_new_bin.csv")
     )
 
@@ -483,13 +483,13 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     new_binary_build_generator_vintage_costs.tab file and the
     new_binary_build_generator_size.tab file
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -500,7 +500,7 @@ def write_module_specific_model_inputs(
     new_gen_costs, new_gen_build_size = get_module_specific_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "new_binary_build_generator_vintage_costs.tab"),
               "w", newline="") as new_gen_costs_tab_file:
         writer = csv.writer(new_gen_costs_tab_file, delimiter="\t", lineterminator="\n")
@@ -515,7 +515,7 @@ def write_module_specific_model_inputs(
             replace_nulls = ["." if i is None else i for i in row]
             writer.writerow(replace_nulls)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "new_binary_build_generator_size.tab"),
               "w", newline="") as new_build_size_tab_file:
         writer = csv.writer(new_build_size_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/capacity/capacity_types/gen_new_lin.py
+++ b/gridpath/project/capacity/capacity_types/gen_new_lin.py
@@ -414,7 +414,7 @@ def load_module_specific_data(
     # TODO: throw an error when a generator of the 'gen_new_lin' capacity
     #   type is not found in new_build_option_vintage_costs.tab
     data_portal.load(filename=
-                     os.path.join(scenario_directory, subproblem, stage,
+                     os.path.join(scenario_directory, str(subproblem), str(stage),
                                   "inputs",
                                   "new_build_generator_vintage_costs.tab"),
                      index=m.GEN_NEW_LIN_VNTS,
@@ -431,7 +431,7 @@ def load_module_specific_data(
     max_cumulative_mw = dict()
 
     header = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "new_build_generator_vintage_costs.tab"),
         sep="\t", header=None, nrows=1
     ).values[0]
@@ -441,7 +441,7 @@ def load_module_specific_data(
     used_columns = [c for c in optional_columns if c in header]
 
     df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "new_build_generator_vintage_costs.tab"),
         sep="\t", usecols=["project", "vintage"] + used_columns
     )
@@ -508,7 +508,7 @@ def export_module_specific_results(
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "capacity_gen_new_lin.csv"), "w", newline="") as f:
 
         writer = csv.writer(f)
@@ -538,7 +538,7 @@ def summarize_module_specific_results(
 
     # Get the results CSV as dataframe
     capacity_results_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "results", "capacity_gen_new_lin.csv")
     )
 
@@ -628,12 +628,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     new_build_generator_vintage_costs.tab file
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -644,7 +644,7 @@ def write_module_specific_model_inputs(
     new_gen_costs = get_module_specific_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "new_build_generator_vintage_costs.tab"), "w", newline="") as \
             new_gen_costs_tab_file:
         writer = csv.writer(new_gen_costs_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/capacity/capacity_types/gen_ret_bin.py
+++ b/gridpath/project/capacity/capacity_types/gen_ret_bin.py
@@ -231,7 +231,7 @@ def load_module_specific_data(
         gen_ret_bin_projects = list()
 
         df = pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage, "inputs",
+            os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                          "projects.tab"),
             sep="\t",
             usecols=["project", "capacity_type"]
@@ -251,7 +251,7 @@ def load_module_specific_data(
         gen_ret_bin_capacity_mw_dict = dict()
         gen_ret_bin_fixed_cost_per_mw_yr_dict = dict()
         df = pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage, "inputs",
+            os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                          "specified_generation_period_params.tab"),
             sep="\t"
         )
@@ -294,7 +294,7 @@ def export_module_specific_results(
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "capacity_gen_ret_bin.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)
@@ -326,7 +326,7 @@ def summarize_module_specific_results(
 
     # Get the results CSV as dataframe
     capacity_results_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "results",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                      "capacity_gen_ret_bin.csv")
     )
 
@@ -406,12 +406,12 @@ def get_module_specific_inputs_from_database(
 
 # TODO: untested
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     specified_generation_period_params.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -424,10 +424,10 @@ def write_module_specific_model_inputs(
 
     # If specified_generation_period_params.tab file already exists, append
     # rows to it
-    if os.path.isfile(os.path.join(inputs_directory,
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                    "specified_generation_period_params.tab")
                       ):
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "specified_generation_period_params.tab"),
                   "a") as existing_project_capacity_tab_file:
             writer = csv.writer(existing_project_capacity_tab_file,
@@ -437,7 +437,7 @@ def write_module_specific_model_inputs(
     # If specified_generation_period_params.tab file does not exist,
     # write header first, then add input data
     else:
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "specified_generation_period_params.tab"),
                   "w", newline="") as existing_project_capacity_tab_file:
             writer = csv.writer(existing_project_capacity_tab_file,

--- a/gridpath/project/capacity/capacity_types/gen_ret_lin.py
+++ b/gridpath/project/capacity/capacity_types/gen_ret_lin.py
@@ -269,7 +269,7 @@ def load_module_specific_data(
         gen_ret_lin_projects = list()
 
         df = pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage, "inputs",
+            os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                          "projects.tab"),
             sep="\t",
             usecols=["project", "capacity_type"]
@@ -289,7 +289,7 @@ def load_module_specific_data(
         gen_ret_lin_capacity_mw_dict = dict()
         gen_ret_lin_fixed_cost_per_mw_yr_dict = dict()
         df = pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage, "inputs",
+            os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                          "specified_generation_period_params.tab"),
             sep="\t"
         )
@@ -332,7 +332,7 @@ def export_module_specific_results(
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "capacity_gen_ret_lin"
                            ".csv"), "w", newline="") as f:
         writer = csv.writer(f)
@@ -362,7 +362,7 @@ def summarize_module_specific_results(
 
     # Get the results CSV as dataframe
     capacity_results_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "results",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                      "capacity_gen_ret_lin.csv")
     )
 
@@ -439,12 +439,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     specified_generation_period_params.tab file
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -457,10 +457,10 @@ def write_module_specific_model_inputs(
 
     # If specified_generation_period_params.tab file already exists, append
     # rows to it
-    if os.path.isfile(os.path.join(inputs_directory,
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                    "specified_generation_period_params.tab")
                       ):
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "specified_generation_period_params.tab"),
                   "a") as existing_project_capacity_tab_file:
             writer = csv.writer(existing_project_capacity_tab_file,
@@ -470,7 +470,7 @@ def write_module_specific_model_inputs(
     # If specified_generation_period_params.tab file does not exist,
     # write header first, then add input data
     else:
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "specified_generation_period_params.tab"),
                   "w", newline="") as existing_project_capacity_tab_file:
             writer = csv.writer(existing_project_capacity_tab_file,

--- a/gridpath/project/capacity/capacity_types/gen_spec.py
+++ b/gridpath/project/capacity/capacity_types/gen_spec.py
@@ -139,7 +139,7 @@ def load_module_specific_data(
         gen_spec_projects = list()
 
         df = pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage, "inputs",
+            os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                          "projects.tab"),
             sep="\t",
             usecols=["project", "capacity_type"]
@@ -160,7 +160,7 @@ def load_module_specific_data(
         gen_spec_capacity_mw_dict = dict()
         gen_spec_fixed_cost_per_mw_yr_dict = dict()
         df = pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage, "inputs",
+            os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                          "specified_generation_period_params.tab"),
             sep="\t"
         )
@@ -238,12 +238,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     specified_generation_period_params.tab file
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -256,10 +256,10 @@ def write_module_specific_model_inputs(
 
     # If specified_generation_period_params.tab file already exists, append
     # rows to it
-    if os.path.isfile(os.path.join(inputs_directory,
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                    "specified_generation_period_params.tab")
                       ):
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "specified_generation_period_params.tab"),
                   "a") as existing_project_capacity_tab_file:
             writer = csv.writer(existing_project_capacity_tab_file,
@@ -269,7 +269,7 @@ def write_module_specific_model_inputs(
     # If specified_generation_period_params.tab file does not exist,
     # write header first, then add input data
     else:
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "specified_generation_period_params.tab"),
                   "w", newline="") as existing_project_capacity_tab_file:
             writer = csv.writer(existing_project_capacity_tab_file,

--- a/gridpath/project/capacity/capacity_types/stor_new_bin.py
+++ b/gridpath/project/capacity/capacity_types/stor_new_bin.py
@@ -378,7 +378,7 @@ def load_module_specific_data(m, data_portal,
     #   because binary storage and generator use same build size param name
     #   in the columns.
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "new_binary_build_storage_vintage_costs.tab"),
         index=m.STOR_NEW_BIN_VNTS,
         select=("project", "vintage", "lifetime_yrs",
@@ -390,7 +390,7 @@ def load_module_specific_data(m, data_portal,
     )
 
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "new_binary_build_storage_size.tab"),
         index=m.STOR_NEW_BIN,
         select=("project", "binary_build_size_mw", "binary_build_size_mwh"),
@@ -408,7 +408,7 @@ def export_module_specific_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "capacity_stor_new_bin.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "technology", "load_zone",
@@ -441,7 +441,7 @@ def summarize_module_specific_results(
 
     # Get the results CSV as dataframe
     capacity_results_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "results", "capacity_stor_new_bin.csv")
     )
 
@@ -536,13 +536,13 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     new_binary_build_storage_vintage_costs.tab file and the
     new_binary_build_storage_size.tab file
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -554,7 +554,7 @@ def write_module_specific_model_inputs(
         get_module_specific_inputs_from_database(
             subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "new_binary_build_storage_vintage_costs.tab"),
               "w", newline="") as new_storage_costs_tab_file:
         writer = csv.writer(new_storage_costs_tab_file, delimiter="\t", lineterminator="\n")
@@ -570,7 +570,7 @@ def write_module_specific_model_inputs(
             replace_nulls = ["." if i is None else i for i in row]
             writer.writerow(replace_nulls)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "new_binary_build_storage_size.tab"),
               "w", newline="") as new_build_size_tab_file:
         writer = csv.writer(new_build_size_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/capacity/capacity_types/stor_new_lin.py
+++ b/gridpath/project/capacity/capacity_types/stor_new_lin.py
@@ -657,7 +657,7 @@ def load_module_specific_data(
         stor_max_duration = dict()
 
         _df = pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage,
+            os.path.join(scenario_directory, str(subproblem), str(stage),
                          "inputs", "projects.tab"),
             sep="\t",
             usecols=["project", "capacity_type",
@@ -688,7 +688,7 @@ def load_module_specific_data(
     # TODO: throw an error when a project of the 'stor_new_lin' capacity
     #   type is not found in new_build_storage_vintage_costs.tab
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "new_build_storage_vintage_costs.tab"),
         index=m.STOR_NEW_LIN_VNTS,
         select=("project", "vintage", "lifetime_yrs",
@@ -710,7 +710,7 @@ def load_module_specific_data(
     max_cumulative_mwh = dict()
 
     header = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "new_build_storage_vintage_costs.tab"),
         sep="\t", header=None, nrows=1
     ).values[0]
@@ -722,7 +722,7 @@ def load_module_specific_data(
     used_columns = [c for c in dynamic_columns if c in header]
 
     df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "new_build_storage_vintage_costs.tab"),
         sep="\t",
         usecols=["project", "vintage"] + used_columns
@@ -832,7 +832,7 @@ def export_module_specific_results(
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "capacity_stor_new_lin.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "technology", "load_zone",
@@ -862,7 +862,7 @@ def summarize_module_specific_results(
 
     # Get the results CSV as dataframe
     capacity_results_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "results", "capacity_stor_new_lin.csv")
     )
 
@@ -954,12 +954,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     new_build_storage_vintage_costs.tab file
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -970,7 +970,7 @@ def write_module_specific_model_inputs(
     new_stor_costs = get_module_specific_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "new_build_storage_vintage_costs.tab"),
               "w", newline="") as new_storage_costs_tab_file:
         writer = csv.writer(new_storage_costs_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/capacity/capacity_types/stor_spec.py
+++ b/gridpath/project/capacity/capacity_types/stor_spec.py
@@ -163,7 +163,7 @@ def load_module_specific_data(
         m, data_portal, scenario_directory, subproblem, stage
 ):
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "storage_specified_capacities.tab"),
         index=m.STOR_SPEC_OPR_PRDS,
         select=("project", "period",
@@ -227,12 +227,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     storage_specified_capacities.tab file
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -243,7 +243,7 @@ def write_module_specific_model_inputs(
     stor_capacities = get_module_specific_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "storage_specified_capacities.tab"),
               "w", newline="") as f:
         writer = csv.writer(f, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/capacity/costs.py
+++ b/gridpath/project/capacity/costs.py
@@ -76,7 +76,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "costs_capacity_all_projects.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)

--- a/gridpath/project/common_functions.py
+++ b/gridpath/project/common_functions.py
@@ -29,7 +29,7 @@ def determine_project_subset(
 
     dynamic_components = \
         pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage, "inputs",
+            os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                          "projects.tab"),
             sep="\t", usecols=["project", column]
         )

--- a/gridpath/project/fuels.py
+++ b/gridpath/project/fuels.py
@@ -80,6 +80,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c1 = conn.cursor()
     fuels = c1.execute(
         """SELECT DISTINCT fuel, co2_intensity_tons_per_mmbtu
@@ -331,11 +333,11 @@ def validate_fuel_prices(fuels_df, fuel_prices_df, periods_months):
     return results
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     fuels.tab and fuel_prices.tab files.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -346,7 +348,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     fuels, fuel_prices = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "fuels.tab"), "w", newline="") as \
             fuels_tab_file:
         writer = csv.writer(fuels_tab_file, delimiter="\t", lineterminator="\n")
@@ -359,7 +361,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         for row in fuels:
             writer.writerow(row)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "fuel_prices.tab"), "w", newline="") as \
             fuel_prices_tab_file:
         writer = csv.writer(fuel_prices_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/operations/carbon_emissions.py
+++ b/gridpath/project/operations/carbon_emissions.py
@@ -147,7 +147,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "projects.tab"),
         select=("project", "carbon_cap_zone"),
         param=(m.carbon_cap_zone,)
@@ -168,7 +168,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "carbon_emissions_by_project.csv"),
               "w", newline="") as carbon_emissions_results_file:
         writer = csv.writer(carbon_emissions_results_file)
@@ -200,6 +200,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     project_zones = c.execute(
         """SELECT project, carbon_cap_zone
@@ -233,12 +235,12 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     return project_zones
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage,
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage,
                        conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -253,7 +255,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage,
     for (prj, zone) in project_zones:
         prj_zone_dict[str(prj)] = "." if zone is None else str(zone)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t",
                             lineterminator="\n")
@@ -276,7 +278,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage,
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w",
               newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t",

--- a/gridpath/project/operations/costs.py
+++ b/gridpath/project/operations/costs.py
@@ -149,7 +149,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     Nothing
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "costs_operations.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(

--- a/gridpath/project/operations/fix_commitment.py
+++ b/gridpath/project/operations/fix_commitment.py
@@ -191,7 +191,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
         """
         fnl_commit_prjs = list()
         df = read_csv(
-            os.path.join(scenario_directory, subproblem, stage,
+            os.path.join(scenario_directory, str(subproblem), str(stage),
                          "inputs", "projects.tab"),
             sep="\t",
             usecols=["project", "last_commitment_stage"],
@@ -249,7 +249,7 @@ def export_pass_through_inputs(scenario_directory, subproblem, stage, m, d):
     """
 
     df = read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "projects.tab"),
         sep="\t",
         usecols=["project", "last_commitment_stage"]

--- a/gridpath/project/operations/fuel_burn.py
+++ b/gridpath/project/operations/fuel_burn.py
@@ -133,7 +133,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     Nothing
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
               "fuel_burn.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(

--- a/gridpath/project/operations/operational_types/__init__.py
+++ b/gridpath/project/operations/operational_types/__init__.py
@@ -166,10 +166,10 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
             pass
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input .tab files
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -190,7 +190,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                    "write_module_specific_model_inputs"):
             imported_operational_modules[op_m].\
                 write_module_specific_model_inputs(
-                    inputs_directory, subscenarios, subproblem, stage, conn)
+                    scenario_directory, subscenarios, subproblem, stage, conn)
         else:
             pass
 

--- a/gridpath/project/operations/operational_types/common_functions.py
+++ b/gridpath/project/operations/operational_types/common_functions.py
@@ -218,7 +218,7 @@ def get_optype_inputs_as_df(
     # Read in the appropriate columns for the operational type from
     # projects.tab
     df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "projects.tab"),
         sep="\t",
         usecols=["project", "operational_type"]

--- a/gridpath/project/operations/operational_types/gen_commit_bin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_bin.py
@@ -1901,7 +1901,7 @@ def load_module_specific_data(mod, data_portal,
     #  gen_commit_bin and gen_commit_lin
     # Startup characteristics
     df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "startup_chars.tab"),
         sep="\t"
     )
@@ -1959,7 +1959,7 @@ def export_module_specific_results(mod, d,
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "dispatch_binary_commit.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)
@@ -2062,12 +2062,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     startup_chars.tab files.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -2078,8 +2078,8 @@ def write_module_specific_model_inputs(
         subscenarios, subproblem, stage, conn)
 
     # If startup_chars.tab file already exists, append rows to it
-    if os.path.isfile(os.path.join(inputs_directory, "startup_chars.tab")):
-        with open(os.path.join(inputs_directory, "startup_chars.tab"),
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "startup_chars.tab")):
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "startup_chars.tab"),
                   "a") as startup_chars_file:
             writer = csv.writer(startup_chars_file,
                                 delimiter="\t", lineterminator="\n")
@@ -2088,7 +2088,7 @@ def write_module_specific_model_inputs(
                 writer.writerow(replace_nulls)
     # If startup_chars.tab does not exist, write header first, then add data
     else:
-        with open(os.path.join(inputs_directory, "startup_chars.tab"),
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "startup_chars.tab"),
                   "w", newline="") as startup_chars_file:
             writer = csv.writer(startup_chars_file,
                                 delimiter="\t", lineterminator="\n")

--- a/gridpath/project/operations/operational_types/gen_commit_cap.py
+++ b/gridpath/project/operations/operational_types/gen_commit_cap.py
@@ -1342,7 +1342,7 @@ def export_module_specific_results(
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "dispatch_capacity_commit.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)

--- a/gridpath/project/operations/operational_types/gen_commit_lin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_lin.py
@@ -1877,7 +1877,7 @@ def load_module_specific_data(mod, data_portal,
 
     # Startup characteristics
     df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "startup_chars.tab"),
         sep="\t"
     )
@@ -1935,7 +1935,7 @@ def export_module_specific_results(mod, d,
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "dispatch_continuous_commit.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)
@@ -2038,12 +2038,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     startup_chars.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -2054,8 +2054,8 @@ def write_module_specific_model_inputs(
         subscenarios, subproblem, stage, conn)
 
     # If startup_chars.tab file already exists, append rows to it
-    if os.path.isfile(os.path.join(inputs_directory, "startup_chars.tab")):
-        with open(os.path.join(inputs_directory, "startup_chars.tab"),
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "startup_chars.tab")):
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "startup_chars.tab"),
                   "a") as startup_chars_file:
             writer = csv.writer(startup_chars_file,
                                 delimiter="\t", lineterminator="\n")
@@ -2064,7 +2064,7 @@ def write_module_specific_model_inputs(
                 writer.writerow(replace_nulls)
     # If startup_chars.tab does not exist, write header first, then add data
     else:
-        with open(os.path.join(inputs_directory, "startup_chars.tab"),
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "startup_chars.tab"),
                   "w", newline="") as startup_chars_file:
             writer = csv.writer(startup_chars_file,
                                 delimiter="\t", lineterminator="\n")

--- a/gridpath/project/operations/operational_types/gen_hydro.py
+++ b/gridpath/project/operations/operational_types/gen_hydro.py
@@ -582,7 +582,7 @@ def load_module_specific_data(m, data_portal,
     max = dict()
 
     prj_hor_opchar_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "hydro_conventional_horizon_params.tab"),
         sep="\t",
         usecols=["project", "horizon", "hydro_average_power_fraction",
@@ -619,7 +619,7 @@ def export_module_specific_results(mod, d,
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "dispatch_gen_hydro.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)
@@ -659,6 +659,9 @@ def get_module_specific_inputs_from_database(
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
+
     c = conn.cursor()
     # Select only budgets/min/max of projects in the portfolio
     # Select only budgets/min/max of projects with 'gen_hydro'
@@ -725,12 +728,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     hydro_conventional_horizon_params.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -742,10 +745,10 @@ def write_module_specific_model_inputs(
 
     # If hydro_conventional_horizon_params.tab file already exists,
     # append rows to it
-    if os.path.isfile(os.path.join(inputs_directory,
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                    "hydro_conventional_horizon_params.tab")
                       ):
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "hydro_conventional_horizon_params.tab"),
                   "a") as \
                 hydro_chars_tab_file:
@@ -755,7 +758,7 @@ def write_module_specific_model_inputs(
     # If hydro_conventional_horizon_params.tab does not exist, write header
     # first, then add inputs data
     else:
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "hydro_conventional_horizon_params.tab"),
                   "w", newline="") as \
                 hydro_chars_tab_file:

--- a/gridpath/project/operations/operational_types/gen_hydro_must_take.py
+++ b/gridpath/project/operations/operational_types/gen_hydro_must_take.py
@@ -563,7 +563,7 @@ def load_module_specific_data(m, data_portal,
     max = dict()
 
     prj_hor_opchar_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "hydro_conventional_horizon_params.tab"),
         sep="\t",
         usecols=["project", "horizon", "hydro_average_power_fraction",
@@ -603,6 +603,9 @@ def get_module_specific_inputs_from_database(
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
+
     c = conn.cursor()
     # Select only budgets/min/max of projects in the portfolio
     # Select only budgets/min/max of projects with 'gen_hydro_must_take'
@@ -669,12 +672,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     hydro_conventional_horizon_params.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -686,10 +689,10 @@ def write_module_specific_model_inputs(
 
     # If hydro_conventional_horizon_params.tab file already exists,
     # append rows to it
-    if os.path.isfile(os.path.join(inputs_directory,
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                    "hydro_conventional_horizon_params.tab")
                       ):
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "hydro_conventional_horizon_params.tab"),
                   "a") as hydro_chars_tab_file:
             writer = csv.writer(hydro_chars_tab_file, delimiter="\t", lineterminator="\n")
@@ -698,7 +701,7 @@ def write_module_specific_model_inputs(
     # If hydro_conventional_horizon_params.tab does not exist, write header
     # first, then add inputs data
     else:
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "hydro_conventional_horizon_params.tab"),
                   "w", newline="") as hydro_chars_tab_file:
             writer = csv.writer(hydro_chars_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/operations/operational_types/gen_var.py
+++ b/gridpath/project/operations/operational_types/gen_var.py
@@ -457,7 +457,7 @@ def load_module_specific_data(mod, data_portal,
     var_must_take_prjs = list()
 
     prj_op_type_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "projects.tab"),
         sep="\t",
         usecols=["project", "operational_type"]
@@ -476,7 +476,7 @@ def load_module_specific_data(mod, data_portal,
     cap_factor = dict()
 
     prj_tmp_cf_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "variable_generator_profiles.tab"),
         sep="\t",
         usecols=["project", "timepoint", "cap_factor"]
@@ -513,7 +513,7 @@ def export_module_specific_results(mod, d,
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "dispatch_variable.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "balancing_type_project",
@@ -558,6 +558,9 @@ def get_module_specific_inputs_from_database(
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
+
     c = conn.cursor()
     # Select only profiles of projects in the portfolio
     # Select only profiles of projects with 'gen_var'
@@ -644,12 +647,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     variable_generator_profiles.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -660,10 +663,10 @@ def write_module_specific_model_inputs(
         subscenarios, subproblem, stage, conn)
 
     # If variable_generator_profiles.tab file already exists, append rows to it
-    if os.path.isfile(os.path.join(inputs_directory,
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                    "variable_generator_profiles.tab")
                       ):
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "variable_generator_profiles.tab"), "a") as \
                 variable_profiles_tab_file:
             writer = csv.writer(variable_profiles_tab_file, delimiter="\t", lineterminator="\n")
@@ -672,7 +675,7 @@ def write_module_specific_model_inputs(
     # If variable_generator_profiles.tab does not exist, write header first,
     # then add profiles data
     else:
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "variable_generator_profiles.tab"), "w", newline="") as \
                 variable_profiles_tab_file:
             writer = csv.writer(variable_profiles_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/operations/operational_types/gen_var_must_take.py
+++ b/gridpath/project/operations/operational_types/gen_var_must_take.py
@@ -302,7 +302,7 @@ def load_module_specific_data(mod, data_portal,
     var_proj = list()
 
     prj_op_type_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "projects.tab"),
         sep="\t",
         usecols=["project", "operational_type"]
@@ -321,7 +321,7 @@ def load_module_specific_data(mod, data_portal,
     cap_factor = dict()
 
     prj_tmp_cf_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "variable_generator_profiles.tab"),
         sep="\t",
         usecols=["project", "timepoint", "cap_factor"]
@@ -448,12 +448,12 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     variable_generator_profiles.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -464,10 +464,10 @@ def write_module_specific_model_inputs(
         subscenarios, subproblem, stage, conn)
 
     # If variable_generator_profiles.tab file already exists, append rows to it
-    if os.path.isfile(os.path.join(inputs_directory,
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                    "variable_generator_profiles.tab")
                       ):
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "variable_generator_profiles.tab"), "a") as \
                 variable_profiles_tab_file:
             writer = csv.writer(variable_profiles_tab_file, delimiter="\t", lineterminator="\n")
@@ -476,7 +476,7 @@ def write_module_specific_model_inputs(
     # If variable_generator_profiles.tab does not exist, write header first,
     # then add profiles data
     else:
-        with open(os.path.join(inputs_directory,
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                "variable_generator_profiles.tab"), "w", newline="") as \
                 variable_profiles_tab_file:
             writer = csv.writer(variable_profiles_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/operations/operational_types/stor.py
+++ b/gridpath/project/operations/operational_types/stor.py
@@ -603,7 +603,7 @@ def export_module_specific_results(mod, d,
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "dispatch_stor.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "balancing_type_project",

--- a/gridpath/project/operations/power.py
+++ b/gridpath/project/operations/power.py
@@ -92,7 +92,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     """
 
     # First power
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "dispatch_all.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["project", "period", "horizon", "timepoint",
@@ -142,7 +142,7 @@ def summarize_results(d, scenario_directory, subproblem, stage):
 
     # Get the results CSV as dataframe
     operational_results_df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "results", "dispatch_all.csv")
     )
 

--- a/gridpath/project/operations/recs.py
+++ b/gridpath/project/operations/recs.py
@@ -208,7 +208,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "projects.tab"),
         select=("project", "rps_zone"),
         param=(m.rps_zone,)
@@ -229,7 +229,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "rps_by_project.csv"),
               "w", newline="") as rps_results_file:
         writer = csv.writer(rps_results_file)
@@ -258,7 +258,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
             ])
 
     # Export list of RPS projects and their zones for later use
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "rps_project_zones.csv"),
               "w", newline="") as rps_project_zones_file:
         writer = csv.writer(rps_project_zones_file)
@@ -278,6 +278,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
 
     # Get the RPS zones for project in our portfolio and with zones in our
@@ -314,12 +316,12 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     return project_zones
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage,
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage,
                        conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -334,7 +336,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage,
     for (prj, zone) in project_zones:
         prj_zone_dict[str(prj)] = "." if zone is None else str(zone)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t",
                             lineterminator="\n")
@@ -357,7 +359,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage,
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w",
               newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t",

--- a/gridpath/project/operations/reserves/frequency_response.py
+++ b/gridpath/project/operations/reserves/frequency_response.py
@@ -139,7 +139,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     project_fr_partial_list = list()
     projects = \
         pd.read_csv(
-            os.path.join(scenario_directory, subproblem, stage, "inputs",
+            os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                          "projects.tab"),
             sep="\t"
         )
@@ -177,7 +177,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
         else:
             partial_proj[prj] = 0
 
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "reserves_provision_frequency_response.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)
@@ -208,6 +208,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     # Get project BA
     _, prj_derates = generic_get_inputs_from_database(
         subscenarios=subscenarios,
@@ -270,11 +272,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -297,7 +299,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         prj_derate_dict[str(prj)] = "." if derate is None else str(derate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -333,7 +335,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/lf_reserves_down.py
+++ b/gridpath/project/operations/reserves/lf_reserves_down.py
@@ -152,6 +152,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     # Get project BA
     project_bas, prj_derates = generic_get_inputs_from_database(
         subscenarios=subscenarios,
@@ -184,11 +186,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -209,7 +211,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         prj_derate_dict[str(prj)] = "." if derate is None else str(derate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -240,7 +242,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/lf_reserves_up.py
+++ b/gridpath/project/operations/reserves/lf_reserves_up.py
@@ -152,6 +152,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
 
     # Get project BAs
     project_bas, prj_derates = generic_get_inputs_from_database(
@@ -185,11 +187,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -210,7 +212,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         prj_derate_dict[str(prj)] = "." if derate is None else str(derate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -241,7 +243,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/frequency_response.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/frequency_response.py
@@ -85,6 +85,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
 
     # Get frequency_response ramp rate limit
     c = conn.cursor()
@@ -115,11 +117,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -136,7 +138,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             "." if ramp_rate is None else str(ramp_rate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -159,7 +161,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/lf_reserves_down.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/lf_reserves_down.py
@@ -85,6 +85,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     # Get lf_reserves_down ramp rate limit
     prj_ramp_rates = c.execute(
@@ -114,11 +116,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -135,7 +137,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             "." if ramp_rate is None else str(ramp_rate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -158,7 +160,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/lf_reserves_up.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/lf_reserves_up.py
@@ -85,6 +85,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     # Get lf_reserves_up ramp rate limit
     prj_ramp_rates = c.execute(
@@ -114,11 +116,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -135,7 +137,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             "." if ramp_rate is None else str(ramp_rate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -158,7 +160,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/regulation_down.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/regulation_down.py
@@ -85,6 +85,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     # Get regulation_down ramp rate limit
     prj_ramp_rates = c.execute(
@@ -114,11 +116,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -135,7 +137,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             "." if ramp_rate is None else str(ramp_rate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -158,7 +160,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/regulation_up.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/regulation_up.py
@@ -85,6 +85,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     # Get regulation_up ramp rate limit
     prj_ramp_rates = c.execute(
@@ -114,11 +116,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -135,7 +137,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             "." if ramp_rate is None else str(ramp_rate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -158,7 +160,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/op_type_dependent/reserve_limits_by_op_type.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/reserve_limits_by_op_type.py
@@ -100,7 +100,7 @@ def generic_load_model_data(
     columns_to_import = ("project",)
     params_to_import = ()
     projects_file_header = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "projects.tab"),
         sep="\t", header=None, nrows=1
     ).values[0]

--- a/gridpath/project/operations/reserves/op_type_dependent/spinning_reserves.py
+++ b/gridpath/project/operations/reserves/op_type_dependent/spinning_reserves.py
@@ -85,6 +85,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     # Get spinning_reserves ramp rate limit
     prj_ramp_rates = c.execute(
@@ -114,11 +116,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -135,7 +137,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             "." if ramp_rate is None else str(ramp_rate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -158,7 +160,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/regulation_down.py
+++ b/gridpath/project/operations/reserves/regulation_down.py
@@ -151,6 +151,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
 
     # Get project BA
     project_bas, prj_derates = generic_get_inputs_from_database(
@@ -184,11 +186,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -209,7 +211,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         prj_derate_dict[str(prj)] = "." if derate is None else str(derate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -240,7 +242,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/regulation_up.py
+++ b/gridpath/project/operations/reserves/regulation_up.py
@@ -155,6 +155,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
 
     # Get project BA
     project_bas, prj_derates = generic_get_inputs_from_database(
@@ -188,11 +190,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -213,7 +215,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         prj_derate_dict[str(prj)] = "." if derate is None else str(derate)
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -244,7 +246,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/reserves/reserve_provision.py
+++ b/gridpath/project/operations/reserves/reserve_provision.py
@@ -122,7 +122,7 @@ def generic_determine_dynamic_components(
     # 'ba_column_name'); add the variable name for the current reserve type
     # to the list of variables in the headroom/footroom dictionary for the
     # project
-    with open(os.path.join(scenario_directory, subproblem, stage, "inputs", "projects.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"),
               "r") as projects_file:
         projects_file_reader = csv.reader(projects_file, delimiter="\t", lineterminator="\n")
         headers = next(projects_file_reader)
@@ -271,7 +271,7 @@ def generic_load_model_data(
     columns_to_import = ("project", ba_column_name,)
     params_to_import = (getattr(m, reserve_balancing_area_param),)
     projects_file_header = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "projects.tab"),
         sep="\t", header=None, nrows=1
     ).values[0]
@@ -286,7 +286,7 @@ def generic_load_model_data(
         pass
 
     # Load the needed data
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "projects.tab"),
                      select=columns_to_import,
                      param=params_to_import
@@ -300,14 +300,14 @@ def generic_load_model_data(
     # state of charge adjustment or delivered variable RPS energy adjustment)
     # if specified; otherwise it will default to 0
     ba_file_header = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      reserve_balancing_areas_input_file),
         sep="\t", header=None, nrows=1
     ).values[0]
 
     if "reserve_to_energy_adjustment" in ba_file_header:
         data_portal.load(
-            filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+            filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                                   reserve_balancing_areas_input_file),
             select=("balancing_area",
                     "reserve_to_energy_adjustment"),
@@ -334,7 +334,7 @@ def generic_export_module_specific_results(
     :param reserve_ba_param_name:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "reserves_provision_" + module_name + ".csv"),
               "w", newline="") as f:
         writer = csv.writer(f)

--- a/gridpath/project/operations/reserves/spinning_reserves.py
+++ b/gridpath/project/operations/reserves/spinning_reserves.py
@@ -152,6 +152,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     # Get project BA
     project_bas, prj_derates = generic_get_inputs_from_database(
         subscenarios=subscenarios,
@@ -184,11 +186,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -210,7 +212,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
 
     # Add params to projects file
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -241,7 +243,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             # Add resulting row to new_rows list
             new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/operations/tuning_costs.py
+++ b/gridpath/project/operations/tuning_costs.py
@@ -228,6 +228,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     ramp_tuning_cost = c.execute(
         """SELECT ramp_tuning_cost_per_mw
@@ -241,11 +243,11 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     return ramp_tuning_cost
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     tuning_params.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -257,8 +259,8 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
     # If tuning params file exists, add column to file, else create file and
     #  writer header and tuning param value
-    if os.path.isfile(os.path.join(inputs_directory, "tuning_params.tab")):
-        with open(os.path.join(inputs_directory, "tuning_params.tab"),
+    if os.path.isfile(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab")):
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab"),
                   "r") as projects_file_in:
             reader = csv.reader(projects_file_in, delimiter="\t",
                                 lineterminator="\n")
@@ -275,14 +277,14 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
             param_value.append(ramp_tuning_cost)
             new_rows.append(param_value)
 
-        with open(os.path.join(inputs_directory, "tuning_params.tab"),
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab"),
                   "w", newline="") as tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t",
                                 lineterminator="\n")
             writer.writerows(new_rows)
 
     else:
-        with open(os.path.join(inputs_directory, "tuning_params.tab"),
+        with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "tuning_params.tab"),
                   "w", newline="") as tuning_params_file_out:
             writer = csv.writer(tuning_params_file_out, delimiter="\t",
                                 lineterminator="\n")

--- a/gridpath/project/reliability/local_capacity/__init__.py
+++ b/gridpath/project/reliability/local_capacity/__init__.py
@@ -117,11 +117,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -133,7 +133,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
     prj_zones_dict = {p: "." if z is None else z for (p, z) in project_zones}
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -155,7 +155,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/reliability/local_capacity/local_capacity_contribution.py
+++ b/gridpath/project/reliability/local_capacity/local_capacity_contribution.py
@@ -72,7 +72,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "project_local_capacity_contribution.csv"),
               "w", newline="") as \
             results_file:
@@ -104,6 +104,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     project_frac = c.execute(
         """SELECT project, local_capacity_fraction
@@ -140,11 +142,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -156,7 +158,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
 
     prj_frac_dict = {p: "." if f is None else f for (p, f) in project_frac}
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -178,7 +180,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/reliability/prm/__init__.py
+++ b/gridpath/project/reliability/prm/__init__.py
@@ -51,7 +51,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :param stage:
     :return:
     """
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "projects.tab"),
                      select=("project", "prm_zone", "prm_type"),
                      param=(m.prm_zone, m.prm_type)
@@ -70,6 +70,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     project_zones = c.execute(
         """SELECT project, prm_zone, prm_type
@@ -123,11 +125,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -145,7 +147,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         prj_zone_type_dict[str(prj)] = \
             (".", ".") if zone is None else (str(zone), str(prm_type))
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -173,7 +175,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                     row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/reliability/prm/elcc_surface.py
+++ b/gridpath/project/reliability/prm/elcc_surface.py
@@ -119,7 +119,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "prm_project_elcc_surface_contribution.csv"),
               "w", newline="") as \
             results_file:
@@ -152,6 +152,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c1 = conn.cursor()
     # Which projects will contribute to the surface
     project_contr = c1.execute(
@@ -207,12 +209,12 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab (to be precise, amend it) and
     project_elcc_surface_coefficients.tab files.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -227,7 +229,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     for (prj, zone) in project_contr:
         prj_contr_dict[str(prj)] = "." if zone is None else str(zone)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -249,12 +251,12 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "project_elcc_surface_coefficients.tab"), "w", newline="") as \
             coefficients_file:
         writer = csv.writer(coefficients_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/reliability/prm/prm_simple.py
+++ b/gridpath/project/reliability/prm/prm_simple.py
@@ -73,7 +73,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "prm_project_elcc_simple_contribution.csv"),
               "w", newline="") as \
             results_file:
@@ -106,6 +106,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     project_zones = c.execute(
         """SELECT project, elcc_simple_fraction
@@ -142,11 +144,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -161,7 +163,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     for (prj, zone) in project_zones:
         prj_frac_dict[str(prj)] = "." if zone is None else str(zone)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -183,7 +185,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/project/reliability/prm/prm_types/__init__.py
+++ b/gridpath/project/reliability/prm/prm_types/__init__.py
@@ -26,7 +26,7 @@ def determine_dynamic_components(d, scenario_directory, subproblem, stage):
     """
 
     project_dynamic_data = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage,
+        os.path.join(scenario_directory, str(subproblem), str(stage),
                      "inputs", "projects.tab"),
         sep="\t",
         usecols=["project", "prm_type"]
@@ -197,10 +197,10 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
             pass
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input .tab files.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -226,7 +226,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                    "write_module_specific_model_inputs"):
             imported_prm_modules[prm_m]. \
                 write_module_specific_model_inputs(
-                    inputs_directory, subscenarios, subproblem, stage, conn)
+                    scenario_directory, subscenarios, subproblem, stage, conn)
         else:
             pass
 

--- a/gridpath/project/reliability/prm/prm_types/energy_only_allowed.py
+++ b/gridpath/project/reliability/prm/prm_types/energy_only_allowed.py
@@ -323,7 +323,7 @@ def export_module_specific_results(m, d, scenario_directory, subproblem, stage,)
             ])
 
     # Total capacity for all projects in group
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "deliverability_group_capacity_and_costs.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow([
@@ -422,13 +422,13 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     deliverability_group_params.tab and
     deliverability_group_projects.tab files.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -442,7 +442,7 @@ def write_module_specific_model_inputs(
 
     if group_threshold_costs:
         with open(os.path.join(
-                inputs_directory,
+                scenario_directory, subproblem, stage,
                 "deliverability_group_params.tab"), "w", newline="") as \
                 elcc_eligibility_thresholds_file:
             writer = csv.writer(elcc_eligibility_thresholds_file,
@@ -461,7 +461,7 @@ def write_module_specific_model_inputs(
                 writer.writerow(row)
 
         with open(os.path.join(
-                inputs_directory,
+                scenario_directory, subproblem, stage,
                 "deliverability_group_projects.tab"), "w"
         ) as group_projects_file:
             writer = csv.writer(group_projects_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/project/reliability/prm/prm_types/fully_deliverable_energy_limited.py
+++ b/gridpath/project/reliability/prm/prm_types/fully_deliverable_energy_limited.py
@@ -109,7 +109,7 @@ def load_module_specific_data(
     :param stage:
     :return:
     """
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "projects.tab"),
                      select=("project",
                              "minimum_duration_for_full_capacity_credit_hours"
@@ -165,12 +165,12 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     projects.tab file (to be precise, amend it).
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -189,7 +189,7 @@ def write_module_specific_model_inputs(
         prj_zone_dur_dict[str(prj)] = \
             "." if zone is None else min_dur
 
-    with open(os.path.join(inputs_directory, "projects.tab"), "r"
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "r"
               ) as projects_file_in:
         reader = csv.reader(projects_file_in, delimiter="\t", lineterminator="\n")
 
@@ -210,7 +210,7 @@ def write_module_specific_model_inputs(
             else:
                 row.append(".")
                 new_rows.append(row)
-    with open(os.path.join(inputs_directory, "projects.tab"), "w", newline="") as \
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "projects.tab"), "w", newline="") as \
             projects_file_out:
         writer = csv.writer(projects_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/run_scenario.py
+++ b/gridpath/run_scenario.py
@@ -384,7 +384,7 @@ def save_results(scenario_directory, subproblem, stage,
         print("Saving results...")
 
     # TODO: how best to handle non-empty results directories?
-    results_directory = os.path.join(scenario_directory, subproblem, stage,
+    results_directory = os.path.join(scenario_directory, str(subproblem), str(stage),
                                      "results")
     if not os.path.exists(results_directory):
         os.makedirs(results_directory)

--- a/gridpath/system/load_balance/aggregate_transmission_power.py
+++ b/gridpath/system/load_balance/aggregate_transmission_power.py
@@ -81,7 +81,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :return:
     """
 
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "imports_exports.csv"), "w", newline="") as imp_exp_file:
         writer = csv.writer(imp_exp_file)
         writer.writerow(

--- a/gridpath/system/load_balance/load_balance.py
+++ b/gridpath/system/load_balance/load_balance.py
@@ -119,7 +119,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "load_balance.csv"), "w", newline="") as results_file:
         writer = csv.writer(results_file)
         writer.writerow(["zone", "period", "timepoint",

--- a/gridpath/system/load_balance/static_load_requirement.py
+++ b/gridpath/system/load_balance/static_load_requirement.py
@@ -59,6 +59,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     # Select only profiles for timepoints form the correct temporal
     # scenario and the correct subproblem
@@ -110,11 +112,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     load_mw.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -125,7 +127,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     loads = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "load_mw.tab"), "w", newline="") as \
             load_tab_file:
         writer = csv.writer(load_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/system/policy/carbon_cap/aggregate_project_carbon_emissions.py
+++ b/gridpath/system/policy/carbon_cap/aggregate_project_carbon_emissions.py
@@ -66,7 +66,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "carbon_cap_total_project.csv"), "w", newline="") as \
             rps_results_file:
         writer = csv.writer(rps_results_file)

--- a/gridpath/system/policy/carbon_cap/aggregate_transmission_carbon_emissions.py
+++ b/gridpath/system/policy/carbon_cap/aggregate_transmission_carbon_emissions.py
@@ -90,7 +90,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "carbon_cap_total_transmission.csv"), "w", newline="") as \
             rps_results_file:
         writer = csv.writer(rps_results_file)

--- a/gridpath/system/policy/carbon_cap/carbon_balance.py
+++ b/gridpath/system/policy/carbon_cap/carbon_balance.py
@@ -75,7 +75,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "carbon_cap.csv"), "w", newline="") as carbon_cap_results_file:
         writer = csv.writer(carbon_cap_results_file)
         writer.writerow(["carbon_cap_zone", "period",

--- a/gridpath/system/policy/carbon_cap/carbon_cap.py
+++ b/gridpath/system/policy/carbon_cap/carbon_cap.py
@@ -38,7 +38,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :param stage:
     :return:
     """
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "carbon_cap.tab"),
                      index=m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP,
                      param=m.carbon_cap_target_mmt,
@@ -55,6 +55,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     carbon_cap_targets = c.execute(
         """SELECT carbon_cap_zone, period, carbon_cap_mmt
@@ -99,11 +101,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     carbon_cap.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -114,7 +116,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     carbon_cap_targets = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "carbon_cap.tab"), "w", newline="") as \
             carbon_cap_file:
         writer = csv.writer(carbon_cap_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/system/policy/rps/rps_balance.py
+++ b/gridpath/system/policy/rps/rps_balance.py
@@ -64,7 +64,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "rps.csv"), "w", newline="") as rps_results_file:
         writer = csv.writer(rps_results_file)
         writer.writerow(["rps_zone", "period",
@@ -130,13 +130,13 @@ def summarize_results(d, scenario_directory, subproblem, stage):
 
     # Get the main RPS results file
     rps_df = \
-        pd.read_csv(os.path.join(scenario_directory, subproblem, stage, "results",
+        pd.read_csv(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                                  "rps.csv")
                     )
 
     # Get the RPS dual results
     rps_duals_df = \
-        pd.read_csv(os.path.join(scenario_directory, subproblem, stage, "results",
+        pd.read_csv(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                                  "RPS_Target_Constraint.csv")
                     )
 

--- a/gridpath/system/policy/rps/rps_requirement.py
+++ b/gridpath/system/policy/rps/rps_requirement.py
@@ -38,7 +38,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "rps_targets.tab"),
         index=m.RPS_ZONE_PERIODS_WITH_RPS,
         param=m.rps_target_mwh,
@@ -54,6 +54,9 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
+
     c = conn.cursor()
     rps_targets = c.execute(
         """SELECT rps_zone, period, rps_target_mwh
@@ -98,11 +101,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     rps_targets.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -113,7 +116,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     rps_targets = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "rps_targets.tab"), "w", newline="") as \
             rps_targets_tab_file:
         writer = csv.writer(rps_targets_tab_file,

--- a/gridpath/system/reliability/local_capacity/aggregate_local_capacity_contribution.py
+++ b/gridpath/system/reliability/local_capacity/aggregate_local_capacity_contribution.py
@@ -62,7 +62,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "local_capacity_contribution.csv"), "w", newline="") as \
             results_file:
         writer = csv.writer(results_file)

--- a/gridpath/system/reliability/local_capacity/local_capacity_balance.py
+++ b/gridpath/system/reliability/local_capacity/local_capacity_balance.py
@@ -77,7 +77,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "local_capacity.csv"), "w", newline="") as rps_results_file:
         writer = csv.writer(rps_results_file)
         writer.writerow(["local_capacity_zone", "period",

--- a/gridpath/system/reliability/local_capacity/local_capacity_requirement.py
+++ b/gridpath/system/reliability/local_capacity/local_capacity_requirement.py
@@ -37,7 +37,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :param stage:
     :return:
     """
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs",
                                            "local_capacity_requirement.tab"),
                      index=m.LOCAL_CAPACITY_ZONE_PERIODS_WITH_REQUIREMENT,
@@ -95,11 +95,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     local_capacity_requirement.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -110,7 +110,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     local_capacity_requirement = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "local_capacity_requirement.tab"), "w", newline="") as \
             local_capacity_requirement_tab_file:
         writer = csv.writer(local_capacity_requirement_tab_file,

--- a/gridpath/system/reliability/prm/aggregate_project_simple_prm_contribution.py
+++ b/gridpath/system/reliability/prm/aggregate_project_simple_prm_contribution.py
@@ -60,7 +60,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "prm_elcc_simple.csv"), "w", newline="") as \
             results_file:
         writer = csv.writer(results_file)

--- a/gridpath/system/reliability/prm/elcc_surface.py
+++ b/gridpath/system/reliability/prm/elcc_surface.py
@@ -106,7 +106,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "prm_elcc_surface.csv"), "w", newline="") as \
             results_file:
         writer = csv.writer(results_file)
@@ -165,11 +165,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     # do stuff here to validate inputs
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     prm_zone_surface_facets_and_intercept.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -180,7 +180,8 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     with open(os.path.join(
-            inputs_directory, "prm_zone_surface_facets_and_intercept.tab"
+            scenario_directory, subproblem, stage,
+            "prm_zone_surface_facets_and_intercept.tab"
     ), "w", newline="") as intercepts_file:
         writer = csv.writer(intercepts_file, delimiter="\t", lineterminator="\n")
 

--- a/gridpath/system/reliability/prm/prm_balance.py
+++ b/gridpath/system/reliability/prm/prm_balance.py
@@ -73,7 +73,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "prm.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["prm_zone", "period",

--- a/gridpath/system/reliability/prm/prm_requirement.py
+++ b/gridpath/system/reliability/prm/prm_requirement.py
@@ -37,7 +37,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :param stage:
     :return:
     """
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "prm_requirement.tab"),
                      index=m.PRM_ZONE_PERIODS_WITH_REQUIREMENT,
                      param=m.prm_requirement_mw,
@@ -54,6 +54,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     prm_requirement = c.execute(
         """SELECT prm_zone, period, prm_requirement_mw
@@ -94,11 +96,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     prm_requirement.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -109,7 +111,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     prm_requirement = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "prm_requirement.tab"), "w", newline="") as \
             prm_requirement_tab_file:
         writer = csv.writer(prm_requirement_tab_file,

--- a/gridpath/system/reserves/balance/reserve_balance.py
+++ b/gridpath/system/reserves/balance/reserve_balance.py
@@ -86,7 +86,7 @@ def generic_export_results(scenario_directory, subproblem, stage, m, d,
     :param reserve_violation_expression:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            filename), "w", newline="") \
             as results_file:
         writer = csv.writer(results_file)

--- a/gridpath/system/reserves/requirement/frequency_response.py
+++ b/gridpath/system/reserves/requirement/frequency_response.py
@@ -67,6 +67,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     frequency_response = c.execute(
         """SELECT frequency_response_ba, timepoint, 
@@ -114,11 +116,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     frequency_response_requirement.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -129,7 +131,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     frequency_response = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "frequency_response_requirement.tab"), "w", newline="") as \
             frequency_response_tab_file:
         writer = csv.writer(frequency_response_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/system/reserves/requirement/lf_reserves_down.py
+++ b/gridpath/system/reserves/requirement/lf_reserves_down.py
@@ -44,6 +44,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     lf_reserves_down = c.execute(
         """SELECT lf_reserves_down_ba, timepoint, lf_reserves_down_mw
@@ -90,11 +92,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     lf_reserves_down_requirement.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -105,7 +107,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     lf_reserves_down = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "lf_reserves_down_requirement.tab"), "w", newline="") as \
             lf_reserves_down_tab_file:
         writer = csv.writer(lf_reserves_down_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/system/reserves/requirement/lf_reserves_up.py
+++ b/gridpath/system/reserves/requirement/lf_reserves_up.py
@@ -44,6 +44,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     lf_reserves_up = c.execute(
         """SELECT lf_reserves_up_ba, timepoint, lf_reserves_up_mw
@@ -90,11 +92,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     lf_reserves_up_requirement.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -105,7 +107,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     lf_reserves_up = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "lf_reserves_up_requirement.tab"), "w", newline="") as \
             lf_reserves_up_tab_file:
         writer = csv.writer(lf_reserves_up_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/system/reserves/requirement/regulation_down.py
+++ b/gridpath/system/reserves/requirement/regulation_down.py
@@ -44,6 +44,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     regulation_down = c.execute(
         """SELECT regulation_down_ba, timepoint, regulation_down_mw
@@ -90,11 +92,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     regulation_down_requirement.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -105,7 +107,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     regulation_down = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "regulation_down_requirement.tab"), "w", newline="") as \
             regulation_down_tab_file:
         writer = csv.writer(regulation_down_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/system/reserves/requirement/regulation_up.py
+++ b/gridpath/system/reserves/requirement/regulation_up.py
@@ -44,6 +44,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     regulation_up = c.execute(
         """SELECT regulation_up_ba, timepoint, regulation_up_mw
@@ -90,11 +92,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     regulation_up_requirement.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -105,7 +107,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     regulation_up = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "regulation_up_requirement.tab"), "w", newline="") as \
             regulation_up_tab_file:
         writer = csv.writer(regulation_up_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/system/reserves/requirement/reserve_requirements.py
+++ b/gridpath/system/reserves/requirement/reserve_requirements.py
@@ -58,7 +58,7 @@ def generic_load_model_data(m, d, data_portal,
     :param reserve_requirement_param:
     :return:
     """
-    data_portal.load(filename=os.path.join(scenario_directory, subproblem, stage,
+    data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs",
                                            requirement_filename),
                      index=getattr(m, reserve_zone_timepoint_set),

--- a/gridpath/system/reserves/requirement/spinning_reserves.py
+++ b/gridpath/system/reserves/requirement/spinning_reserves.py
@@ -44,6 +44,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     spinning_reserves = c.execute(
         """SELECT spinning_reserves_ba, timepoint, spinning_reserves_mw
@@ -90,11 +92,11 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     #     subscenarios, subproblem, stage, conn)
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     spinning_reserves_requirement.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -106,7 +108,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         subscenarios, subproblem, stage, conn)
 
     # spinning_reserves_requirement.tab
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "spinning_reserves_requirement.tab"), "w", newline="") as \
             spinning_reserves_tab_file:
         writer = csv.writer(spinning_reserves_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/temporal/investment/periods.py
+++ b/gridpath/temporal/investment/periods.py
@@ -170,7 +170,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     """
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "periods.tab"),
         select=("period", "discount_factor", "number_years_represented"),
         index=m.PERIODS,
@@ -178,7 +178,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     )
 
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "timepoints.tab"),
         select=("timepoint", "period"),
         index=m.TMPS,
@@ -197,6 +197,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     periods = c.execute(
         """SELECT period, discount_factor, number_years_represented
@@ -209,11 +211,11 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     return periods
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     periods.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -224,7 +226,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     periods = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "periods.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "periods.tab"),
               "w", newline="") as periods_tab_file:
         writer = csv.writer(periods_tab_file, delimiter="\t",
                             lineterminator="\n")

--- a/gridpath/temporal/operations/horizons.py
+++ b/gridpath/temporal/operations/horizons.py
@@ -318,14 +318,14 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     """
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "horizons.tab"),
         select=("balancing_type_horizon", "horizon", "boundary"),
         index=m.BLN_TYPE_HRZS,
         param=m.boundary
     )
 
-    with open(os.path.join(scenario_directory, subproblem, stage,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage),
                            "inputs", "horizon_timepoints.tab")
               ) as f:
         reader = csv.reader(f, delimiter="\t", lineterminator="\n")
@@ -355,6 +355,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c1 = conn.cursor()
     horizons = c1.execute(
         """SELECT horizon, balancing_type_horizon, boundary
@@ -386,11 +388,11 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     return horizons, timepoint_horizons
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     horizons.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -401,7 +403,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     horizons, timepoint_horizons = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "horizons.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "horizons.tab"),
               "w", newline="") as horizons_tab_file:
         hwriter = csv.writer(horizons_tab_file, delimiter="\t",
                              lineterminator="\n")
@@ -412,7 +414,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
         for row in horizons:
             hwriter.writerow(row)
 
-    with open(os.path.join(inputs_directory, "horizon_timepoints.tab"), "w",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "horizon_timepoints.tab"), "w",
               newline="") as timepoint_horizons_tab_file:
         thwriter = csv.writer(timepoint_horizons_tab_file, delimiter="\t",
                               lineterminator="\n")

--- a/gridpath/temporal/operations/timepoints.py
+++ b/gridpath/temporal/operations/timepoints.py
@@ -143,7 +143,7 @@ def add_model_components(m, d):
 
 def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "timepoints.tab"),
         index=m.TMPS,
         param=(m.tmp_weight,
@@ -169,6 +169,9 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
+
     c = conn.cursor()
     timepoints = c.execute(
         """SELECT timepoint, period, timepoint_weight,
@@ -186,11 +189,11 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     return timepoints
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     timepoints.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -201,7 +204,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     timepoints = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "timepoints.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "timepoints.tab"),
               "w", newline="") as timepoints_tab_file:
         writer = csv.writer(timepoints_tab_file, delimiter="\t",
                             lineterminator="\n")

--- a/gridpath/transmission/__init__.py
+++ b/gridpath/transmission/__init__.py
@@ -32,7 +32,7 @@ def determine_dynamic_components(d, scenario_directory, subproblem, stage):
 
     # Get the capacity and operational type of each transmission line
     df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "transmission_lines.tab"),
         sep="\t",
         usecols=["TRANSMISSION_LINES", "tx_capacity_type",
@@ -155,6 +155,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
 
     # TODO: we might want to get the reactance in the tx_dcopf
     #  tx_operational_type rather than here (see also comment in project/init)
@@ -187,11 +189,11 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     return transmission_lines
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     transmission_lines.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -202,7 +204,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
     transmission_lines = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "transmission_lines.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "transmission_lines.tab"),
               "w", newline="") as \
             transmission_lines_tab_file:
         writer = csv.writer(transmission_lines_tab_file, delimiter="\t", lineterminator="\n")

--- a/gridpath/transmission/capacity/capacity.py
+++ b/gridpath/transmission/capacity/capacity.py
@@ -288,7 +288,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
             pass
 
     # Export transmission capacity
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "transmission_capacity.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["tx_line", "period", "load_zone_from", "load_zone_to",
@@ -305,7 +305,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
             ])
 
     # Export transmission capacity costs
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
               "costs_transmission_capacity.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(

--- a/gridpath/transmission/capacity/capacity_types/__init__.py
+++ b/gridpath/transmission/capacity/capacity_types/__init__.py
@@ -86,10 +86,10 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
             pass
 
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input .tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -108,7 +108,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                    "write_module_specific_model_inputs"):
             imported_capacity_type_modules[op_m]. \
                 write_module_specific_model_inputs(
-                    inputs_directory, subscenarios, subproblem, stage, conn
+                    scenario_directory, subscenarios, subproblem, stage, conn
             )
         else:
             pass

--- a/gridpath/transmission/capacity/capacity_types/tx_new_lin.py
+++ b/gridpath/transmission/capacity/capacity_types/tx_new_lin.py
@@ -286,7 +286,7 @@ def load_module_specific_data(
     # TODO: throw an error when a line of the 'tx_new_lin' capacity
     #   type is not found in new_build_transmission_vintage_costs.tab
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "new_build_transmission_vintage_costs.tab"),
         index=m.TX_NEW_LIN_VNTS,
         select=("transmission_line", "vintage",
@@ -312,7 +312,7 @@ def export_module_specific_results(
     """
 
     # Export transmission capacity
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "transmission_new_capacity.csv"),
               "w", newline="") as f:
         writer = csv.writer(f)
@@ -369,10 +369,10 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn):
+        scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input .tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -383,7 +383,7 @@ def write_module_specific_model_inputs(
     tx_cost = get_module_specific_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "new_build_transmission_vintage_costs.tab"),
               "w", newline="") as existing_tx_capacity_tab_file:
         writer = csv.writer(existing_tx_capacity_tab_file,

--- a/gridpath/transmission/capacity/capacity_types/tx_spec.py
+++ b/gridpath/transmission/capacity/capacity_types/tx_spec.py
@@ -111,7 +111,7 @@ def tx_capacity_cost_rule(mod, g, p):
 def load_module_specific_data(m, data_portal, scenario_directory,
                               subproblem, stage):
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "specified_transmission_line_capacities.tab"),
         select=("transmission_line", "period",
                 "specified_tx_min_mw", "specified_tx_max_mw"),
@@ -157,11 +157,11 @@ def get_module_specific_inputs_from_database(
 
 
 def write_module_specific_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn):
+        scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and write out the model input
     specified_transmission_line_capacities.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -172,7 +172,7 @@ def write_module_specific_model_inputs(
     tx_capacities = get_module_specific_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "specified_transmission_line_capacities.tab"),
               "w", newline="") as existing_tx_capacity_tab_file:
         writer = csv.writer(existing_tx_capacity_tab_file,

--- a/gridpath/transmission/operations/carbon_emissions.py
+++ b/gridpath/transmission/operations/carbon_emissions.py
@@ -238,7 +238,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     """
 
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage,
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                               "inputs", "transmission_lines.tab"),
         select=("TRANSMISSION_LINES", "carbon_cap_zone",
                 "carbon_cap_zone_import_direction",
@@ -263,7 +263,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "carbon_emission_imports_by_tx_line.csv"),
               "w", newline="") as carbon_emission_imports__results_file:
         writer = csv.writer(carbon_emission_imports__results_file)
@@ -294,6 +294,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     transmission_zones = c.execute(
         """SELECT transmission_line, carbon_cap_zone, import_direction,
@@ -308,12 +310,12 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
 
 
 def write_model_inputs(
-    inputs_directory, subscenarios, subproblem, stage, conn
+    scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     transmission_lines.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -331,7 +333,7 @@ def write_model_inputs(
             (".", ".", ".") if zone is None \
             else (str(zone), str(direction), intensity)
 
-    with open(os.path.join(inputs_directory, "transmission_lines.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "transmission_lines.tab"),
               "r") as tx_file_in:
         reader = csv.reader(tx_file_in, delimiter="\t", lineterminator="\n")
 
@@ -359,7 +361,7 @@ def write_model_inputs(
                 row.append(".")
                 new_rows.append(row)
 
-    with open(os.path.join(inputs_directory, "transmission_lines.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "transmission_lines.tab"),
               "w", newline="") as tx_file_out:
         writer = csv.writer(tx_file_out, delimiter="\t", lineterminator="\n")
         writer.writerows(new_rows)

--- a/gridpath/transmission/operations/costs.py
+++ b/gridpath/transmission/operations/costs.py
@@ -185,7 +185,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "transmission_hurdle_rates.tab"),
         select=("transmission_line", "period",
                 "hurdle_rate_positive_direction_per_mwh",
@@ -205,7 +205,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d: Dynamic components
     :return: Nothing
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
               "costs_transmission_hurdle.csv"), "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
@@ -239,6 +239,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c = conn.cursor()
     hurdle_rates = c.execute(
         """SELECT transmission_line, period, 
@@ -261,12 +263,12 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
 
 
 def write_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     transmission_hurdle_rates.tab file.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -277,7 +279,7 @@ def write_model_inputs(
     hurdle_rates = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    with open(os.path.join(inputs_directory, "transmission_hurdle_rates.tab"),
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs", "transmission_hurdle_rates.tab"),
               "w", newline="") as sim_flows_file:
         writer = csv.writer(sim_flows_file, delimiter="\t", lineterminator="\n")
 

--- a/gridpath/transmission/operations/operational_types/__init__.py
+++ b/gridpath/transmission/operations/operational_types/__init__.py
@@ -112,12 +112,12 @@ def get_required_tx_opchar_modules(scenario_id, c):
 # Database
 ###############################################################################
 
-def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
+def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn):
     """
     Go through each relevant operational type and write the model inputs
     for that operational type based on the database.
 
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -138,7 +138,7 @@ def write_model_inputs(inputs_directory, subscenarios, subproblem, stage, conn):
                    "write_module_specific_model_inputs"):
             imported_tx_operational_modules[op_m].\
                 write_module_specific_model_inputs(
-                    inputs_directory, subscenarios, subproblem, stage, conn)
+                    scenario_directory, subscenarios, subproblem, stage, conn)
         else:
             pass
 

--- a/gridpath/transmission/operations/operational_types/tx_dcopf.py
+++ b/gridpath/transmission/operations/operational_types/tx_dcopf.py
@@ -524,7 +524,7 @@ def load_module_specific_data(m, data_portal, scenario_directory,
 
     # Get the DC OPF lines
     df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "transmission_lines.tab"),
         sep="\t",
         usecols=["TRANSMISSION_LINES", "load_zone_from", "load_zone_to",

--- a/gridpath/transmission/operations/operational_types/tx_simple.py
+++ b/gridpath/transmission/operations/operational_types/tx_simple.py
@@ -357,7 +357,7 @@ def load_module_specific_data(m, data_portal, scenario_directory,
 
     # Get the simple transport model lines
     df = pd.read_csv(
-        os.path.join(scenario_directory, subproblem, stage, "inputs",
+        os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                      "transmission_lines.tab"),
         sep="\t",
         usecols=["TRANSMISSION_LINES", "tx_operational_type",

--- a/gridpath/transmission/operations/operations.py
+++ b/gridpath/transmission/operations/operations.py
@@ -112,7 +112,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     """
 
     # Transmission flows for all lines
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "transmission_operations.csv"), "w", newline="") as \
             tx_op_results_file:
         writer = csv.writer(tx_op_results_file)

--- a/gridpath/transmission/operations/simultaneous_flow_limits.py
+++ b/gridpath/transmission/operations/simultaneous_flow_limits.py
@@ -203,7 +203,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     :return:
     """
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "transmission_simultaneous_flow_limits.tab"),
         select=("simultaneous_flow_limit", "period",
                 "simultaneous_flow_limit_mw"),
@@ -212,7 +212,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     )
 
     data_portal.load(
-        filename=os.path.join(scenario_directory, subproblem, stage, "inputs",
+        filename=os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                               "transmission_simultaneous_flow_limit_lines.tab"),
         select=("simultaneous_flow_limit", "transmission_line",
                 "simultaneous_flow_direction"),
@@ -231,7 +231,7 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, subproblem, stage, "results",
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
                            "transmission_simultaneous_flow_limits.csv"),
               "w", newline="") as tx_op_results_file:
         writer = csv.writer(tx_op_results_file)
@@ -263,6 +263,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+    subproblem = 1 if subproblem == "" else subproblem
+    stage = 1 if stage == "" else stage
     c1 = conn.cursor()
     flow_limits = c1.execute(
         """SELECT transmission_simultaneous_flow_limit, period, max_flow_mw
@@ -308,13 +310,13 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
 
 
 def write_model_inputs(
-        inputs_directory, subscenarios, subproblem, stage, conn
+        scenario_directory, subscenarios, subproblem, stage, conn
 ):
     """
     Get inputs from database and write out the model input
     transmission_simultaneous_flow_limits.tab and
     transmission_simultaneous_flow_limit_lines files.
-    :param inputs_directory: local directory where .tab files will be saved
+    :param scenario_directory: string, the scenario directory
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -326,7 +328,7 @@ def write_model_inputs(
         subscenarios, subproblem, stage, conn)
 
     # transmission_simultaneous_flow_limits.tab
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "transmission_simultaneous_flow_limits.tab"),
               "w", newline="") as sim_flows_file:
         writer = csv.writer(sim_flows_file, delimiter="\t", lineterminator="\n")
@@ -340,7 +342,7 @@ def write_model_inputs(
             writer.writerow(row)
 
     # transmission_simultaneous_flow_limit_lines.tab
-    with open(os.path.join(inputs_directory,
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "inputs",
                            "transmission_simultaneous_flow_limit_lines.tab"),
               "w", newline="") as sim_flow_limit_lines_file:
         writer = csv.writer(sim_flow_limit_lines_file,


### PR DESCRIPTION
In preparation for linking the subproblems, I'd like to pass the information for what the scenario directory is when writing model inputs. We currently pass the final inputs directory (that depends on subproblem and stage) and what the scenario directory is would need to be reversed engineered every time in `write_model_inputs`. Instead, I'd like to change things to pass the scenario directory directly instead and determine the inputs directory based on the subproblem and stage arguments, which are already being passed to `write_model_inputs` (this also re-standardizes with the treatment in the other module methods, which figure out the correct inputs directory). The "reverse engineering" now happens in the `get_inputs_from_database` functions, which use `1` for the subproblem and stage whenever those are empty strings.