### PR TITLE
Fix dataframe float formatting when printing

### DIFF
--- a/examples/2horizons/results/summary_results.txt
+++ b/examples/2horizons/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          9             14
-                 Gas                          27             44
-                 Nuclear                      24             39
-                 Wind                          2              3
+Zone1     2020   Coal                       8.53          13.91
+                 Gas                       26.80          43.70
+                 Nuclear                   24.00          39.13
+                 Wind                       2.00           3.26

--- a/examples/2horizons_w_hydro/results/summary_results.txt
+++ b/examples/2horizons_w_hydro/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          0              0
-                 Gas                          20             34
-                 Hydro                        12             20
-                 Nuclear                      24             40
-                 Wind                          4              6
+Zone1     2020   Coal                       0.00           0.00
+                 Gas                       20.27          33.78
+                 Hydro                     12.00          20.00
+                 Nuclear                   24.00          40.00
+                 Wind                       3.73           6.22

--- a/examples/2horizons_w_hydro_and_nuclear_binary_availability/results/summary_results.txt
+++ b/examples/2horizons_w_hydro_and_nuclear_binary_availability/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          0              0
-                 Gas                          25             42
-                 Hydro                        12             20
-                 Nuclear                      18             30
-                 Wind                          5              8
+Zone1     2020   Coal                       0.00           0.00
+                 Gas                       25.47          42.44
+                 Hydro                     12.00          20.00
+                 Nuclear                   18.00          30.00
+                 Wind                       4.53           7.56

--- a/examples/2horizons_w_hydro_w_balancing_types/results/summary_results.txt
+++ b/examples/2horizons_w_hydro_w_balancing_types/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          0              0
-                 Gas                          20             33
-                 Hydro                        12             20
-                 Nuclear                      24             40
-                 Wind                          4              7
+Zone1     2020   Coal                       0.00           0.00
+                 Gas                       20.00          33.33
+                 Hydro                     12.00          20.00
+                 Nuclear                   24.00          40.00
+                 Wind                       4.00           6.67

--- a/examples/2periods/results/summary_results.txt
+++ b/examples/2periods/results/summary_results.txt
@@ -7,11 +7,11 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
-          2030   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26
+          2030   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/2periods_gen_bin_econ_retirement/results/summary_results.txt
+++ b/examples/2periods_gen_bin_econ_retirement/results/summary_results.txt
@@ -5,19 +5,19 @@
 --> Retired Capacity <--
                              Retired Capacity (MW)
 load_zone technology period                       
-Zone1     Coal       2020                       10
-                     2030                       10
+Zone1     Coal       2020                    10.00
+                     2030                    10.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
-          2030   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26
+          2030   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/2periods_gen_lin_econ_retirement/results/summary_results.txt
+++ b/examples/2periods_gen_lin_econ_retirement/results/summary_results.txt
@@ -5,19 +5,19 @@
 --> Retired Capacity <--
                              Retired Capacity (MW)
 load_zone technology period                       
-Zone1     Coal       2020                       10
-                     2030                       10
+Zone1     Coal       2020                    10.00
+                     2030                    10.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
-          2030   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26
+          2030   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/2periods_new_build/results/summary_results.txt
+++ b/examples/2periods_new_build/results/summary_results.txt
@@ -5,19 +5,19 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   26
-                     2030                    3
+Zone1     Gas        2020                26.20
+                     2030                 2.80
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          5              6
-                 Gas                          70             78
-                 Nuclear                      12             13
-                 Wind                          3              3
-          2030   Coal                          4              4
-                 Gas                          71             79
-                 Nuclear                      12             13
-                 Wind                          3              3
+Zone1     2020   Coal                       5.00           5.56
+                 Gas                       70.20          78.00
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11
+          2030   Coal                       4.00           4.44
+                 Gas                       71.20          79.11
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11

--- a/examples/2periods_new_build_2zones/results/summary_results.txt
+++ b/examples/2periods_new_build_2zones/results/summary_results.txt
@@ -5,29 +5,29 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   26
-                     2030                    3
-Zone2     Gas        2020                   26
-                     2030                    3
+Zone1     Gas        2020                26.20
+                     2030                 2.80
+Zone2     Gas        2020                26.20
+                     2030                 2.80
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          5              6
-                 Gas                          70             78
-                 Nuclear                      12             13
-                 Wind                          3              3
-          2030   Coal                          4              4
-                 Gas                          71             79
-                 Nuclear                      12             13
-                 Wind                          3              3
-Zone2     2020   Coal                          5              6
-                 Gas                          70             78
-                 Nuclear                      12             13
-                 Wind                          3              3
-          2030   Coal                          4              4
-                 Gas                          71             79
-                 Nuclear                      12             13
-                 Wind                          3              3
+Zone1     2020   Coal                       5.00           5.56
+                 Gas                       70.20          78.00
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11
+          2030   Coal                       4.00           4.44
+                 Gas                       71.20          79.11
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11
+Zone2     2020   Coal                       5.00           5.56
+                 Gas                       70.20          78.00
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11
+          2030   Coal                       4.00           4.44
+                 Gas                       71.20          79.11
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11

--- a/examples/2periods_new_build_2zones_new_build_transmission/results/summary_results.txt
+++ b/examples/2periods_new_build_2zones_new_build_transmission/results/summary_results.txt
@@ -5,27 +5,27 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   52
-                     2030                    5
+Zone1     Gas        2020                52.40
+                     2030                 4.80
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          5              4
-                 Gas                         115             85
-                 Nuclear                      12              9
-                 Wind                          3              2
-          2030   Coal                          4              3
-                 Gas                         121             87
-                 Nuclear                      12              9
-                 Wind                          3              2
-Zone2     2020   Coal                          9             20
-                 Gas                          22             48
-                 Nuclear                      12             26
-                 Wind                          3              6
-          2030   Coal                          4             11
-                 Gas                          21             53
-                 Nuclear                      12             30
-                 Wind                          3              7
+Zone1     2020   Coal                       5.00           3.72
+                 Gas                      114.60          85.27
+                 Nuclear                   12.00           8.93
+                 Wind                       2.80           2.08
+          2030   Coal                       4.00           2.86
+                 Gas                      120.93          86.55
+                 Nuclear                   12.00           8.59
+                 Wind                       2.80           2.00
+Zone2     2020   Coal                       9.00          19.74
+                 Gas                       21.80          47.81
+                 Nuclear                   12.00          26.32
+                 Wind                       2.80           6.14
+          2030   Coal                       4.27          10.60
+                 Gas                       21.20          52.65
+                 Nuclear                   12.00          29.80
+                 Wind                       2.80           6.95

--- a/examples/2periods_new_build_2zones_singleBA/results/summary_results.txt
+++ b/examples/2periods_new_build_2zones_singleBA/results/summary_results.txt
@@ -5,28 +5,28 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   25
-Zone2     Gas        2020                   27
-                     2030                    6
+Zone1     Gas        2020                25.40
+Zone2     Gas        2020                27.00
+                     2030                 5.60
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          5              5
-                 Gas                          70             78
-                 Nuclear                      12             13
-                 Wind                          3              3
-          2030   Coal                          6              6
-                 Gas                          70             77
-                 Nuclear                      12             13
-                 Wind                          3              3
-Zone2     2020   Coal                          5              6
-                 Gas                          70             78
-                 Nuclear                      12             13
-                 Wind                          3              3
-          2030   Coal                          2              3
-                 Gas                          73             81
-                 Nuclear                      12             13
-                 Wind                          3              3
+Zone1     2020   Coal                       4.80           5.33
+                 Gas                       70.40          78.22
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11
+          2030   Coal                       5.60           6.22
+                 Gas                       69.60          77.33
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11
+Zone2     2020   Coal                       5.20           5.78
+                 Gas                       70.00          77.78
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11
+          2030   Coal                       2.40           2.67
+                 Gas                       72.80          80.89
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11

--- a/examples/2periods_new_build_2zones_transmission/results/summary_results.txt
+++ b/examples/2periods_new_build_2zones_transmission/results/summary_results.txt
@@ -5,27 +5,27 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   36
-                     2030                    3
+Zone1     Gas        2020                36.20
+                     2030                 2.80
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          5              5
-                 Gas                          90             82
-                 Nuclear                      12             11
-                 Wind                          3              3
-          2030   Coal                          4              4
-                 Gas                          91             83
-                 Nuclear                      12             11
-                 Wind                          3              3
-Zone2     2020   Coal                          9             20
-                 Gas                          22             48
-                 Nuclear                      12             26
-                 Wind                          3              6
-          2030   Coal                          9             20
-                 Gas                          22             48
-                 Nuclear                      12             26
-                 Wind                          3              6
+Zone1     2020   Coal                       5.00           4.55
+                 Gas                       90.20          82.00
+                 Nuclear                   12.00          10.91
+                 Wind                       2.80           2.55
+          2030   Coal                       4.00           3.64
+                 Gas                       91.20          82.91
+                 Nuclear                   12.00          10.91
+                 Wind                       2.80           2.55
+Zone2     2020   Coal                       9.00          19.74
+                 Gas                       21.80          47.81
+                 Nuclear                   12.00          26.32
+                 Wind                       2.80           6.14
+          2030   Coal                       9.00          19.74
+                 Gas                       21.80          47.81
+                 Nuclear                   12.00          26.32
+                 Wind                       2.80           6.14

--- a/examples/2periods_new_build_2zones_transmission_w_losses/results/summary_results.txt
+++ b/examples/2periods_new_build_2zones_transmission_w_losses/results/summary_results.txt
@@ -5,27 +5,27 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   36
-                     2030                    3
+Zone1     Gas        2020                36.20
+                     2030                 2.80
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          5              5
-                 Gas                          90             82
-                 Nuclear                      12             11
-                 Wind                          3              3
-          2030   Coal                          4              4
-                 Gas                          91             83
-                 Nuclear                      12             11
-                 Wind                          3              3
-Zone2     2020   Coal                          9             20
-                 Gas                          22             48
-                 Nuclear                      12             26
-                 Wind                          3              6
-          2030   Coal                          9             20
-                 Gas                          22             48
-                 Nuclear                      12             26
-                 Wind                          3              6
+Zone1     2020   Coal                       5.00           4.55
+                 Gas                       90.20          82.00
+                 Nuclear                   12.00          10.91
+                 Wind                       2.80           2.55
+          2030   Coal                       4.00           3.64
+                 Gas                       91.20          82.91
+                 Nuclear                   12.00          10.91
+                 Wind                       2.80           2.55
+Zone2     2020   Coal                       9.00          19.74
+                 Gas                       21.80          47.81
+                 Nuclear                   12.00          26.32
+                 Wind                       2.80           6.14
+          2030   Coal                       9.00          19.74
+                 Gas                       21.80          47.81
+                 Nuclear                   12.00          26.32
+                 Wind                       2.80           6.14

--- a/examples/2periods_new_build_2zones_transmission_w_losses_opp_dir/results/summary_results.txt
+++ b/examples/2periods_new_build_2zones_transmission_w_losses_opp_dir/results/summary_results.txt
@@ -5,27 +5,27 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   36
-                     2030                    3
+Zone1     Gas        2020                36.20
+                     2030                 2.80
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          5              5
-                 Gas                          90             82
-                 Nuclear                      12             11
-                 Wind                          3              3
-          2030   Coal                          4              4
-                 Gas                          91             83
-                 Nuclear                      12             11
-                 Wind                          3              3
-Zone2     2020   Coal                          9             20
-                 Gas                          22             48
-                 Nuclear                      12             26
-                 Wind                          3              6
-          2030   Coal                          9             20
-                 Gas                          22             48
-                 Nuclear                      12             26
-                 Wind                          3              6
+Zone1     2020   Coal                       5.00           4.55
+                 Gas                       90.20          82.00
+                 Nuclear                   12.00          10.91
+                 Wind                       2.80           2.55
+          2030   Coal                       4.00           3.64
+                 Gas                       91.20          82.91
+                 Nuclear                   12.00          10.91
+                 Wind                       2.80           2.55
+Zone2     2020   Coal                       9.00          19.74
+                 Gas                       21.80          47.81
+                 Nuclear                   12.00          26.32
+                 Wind                       2.80           6.14
+          2030   Coal                       9.00          19.74
+                 Gas                       21.80          47.81
+                 Nuclear                   12.00          26.32
+                 Wind                       2.80           6.14

--- a/examples/2periods_new_build_cumulative_min_max/results/summary_results.txt
+++ b/examples/2periods_new_build_cumulative_min_max/results/summary_results.txt
@@ -5,19 +5,19 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   20
-                     2030                   10
+Zone1     Gas        2020                20.00
+                     2030                10.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          8             10
-                 Gas                          61             73
-                 Nuclear                      12             14
-                 Wind                          3              3
-          2030   Coal                          3              3
-                 Gas                          72             80
-                 Nuclear                      12             13
-                 Wind                          3              3
+Zone1     2020   Coal                       8.00           9.55
+                 Gas                       61.00          72.79
+                 Nuclear                   12.00          14.32
+                 Wind                       2.80           3.34
+          2030   Coal                       3.00           3.33
+                 Gas                       72.20          80.22
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11

--- a/examples/2periods_new_build_local_capacity/results/summary_results.txt
+++ b/examples/2periods_new_build_local_capacity/results/summary_results.txt
@@ -5,19 +5,19 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   26
-                     2030                    3
+Zone1     Gas        2020                26.20
+                     2030                 2.80
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          5              6
-                 Gas                          70             78
-                 Nuclear                      12             13
-                 Wind                          3              3
-          2030   Coal                          4              4
-                 Gas                          71             79
-                 Nuclear                      12             13
-                 Wind                          3              3
+Zone1     2020   Coal                       5.00           5.56
+                 Gas                       70.20          78.00
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11
+          2030   Coal                       4.00           4.44
+                 Gas                       71.20          79.11
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11

--- a/examples/2periods_new_build_rps/results/summary_results.txt
+++ b/examples/2periods_new_build_rps/results/summary_results.txt
@@ -5,26 +5,26 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                    1
-          Wind       2020                   37
-                     2030                   22
+Zone1     Gas        2020                 1.33
+          Wind       2020                37.26
+                     2030                22.07
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4              5
-                 Gas                          14             17
-                 Nuclear                      12             15
-                 Wind                         50             63
-          2030   Coal                          4              5
-                 Gas                          14             17
-                 Nuclear                      12             15
-                 Wind                         50             63
+Zone1     2020   Coal                       4.00           5.00
+                 Gas                       14.00          17.50
+                 Nuclear                   12.00          15.00
+                 Wind                      50.00          62.50
+          2030   Coal                       4.00           5.00
+                 Gas                       14.00          17.50
+                 Nuclear                   12.00          15.00
+                 Wind                      50.00          62.50
 
 ### RPS RESULTS ###
-                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed       dual  rps_marginal_cost_per_mwh
-rps_zone period                                                                                                                             
-RPSZone1 2020                50                        50                         5                  9 11,106,674                  1,110,667
-         2030                50                        50                        36                 42 19,995,563                  1,999,556
+                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed          dual  rps_marginal_cost_per_mwh
+rps_zone period                                                                                                                                
+RPSZone1 2020             50.00                     50.00                      4.96               9.03 11,106,674.00               1,110,667.40
+         2030             50.00                     50.00                     35.87              41.77 19,995,563.00               1,999,556.30

--- a/examples/2periods_new_build_rps_variable_reserves/results/summary_results.txt
+++ b/examples/2periods_new_build_rps_variable_reserves/results/summary_results.txt
@@ -5,26 +5,26 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2030                    4
-          Wind       2020                   34
-                     2030                   16
+Zone1     Gas        2030                 4.00
+          Wind       2020                33.71
+                     2030                16.29
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          1              1
-                 Gas                          17             21
-                 Nuclear                      12             15
-                 Wind                         50             62
-          2030   Coal                          4              5
-                 Gas                          14             18
-                 Nuclear                      12             15
-                 Wind                         50             62
+Zone1     2020   Coal                       1.12           1.40
+                 Gas                       16.88          21.10
+                 Nuclear                   12.00          15.00
+                 Wind                      50.00          62.50
+          2030   Coal                       4.00           5.00
+                 Gas                       14.00          17.50
+                 Nuclear                   12.00          15.00
+                 Wind                      50.00          62.50
 
 ### RPS RESULTS ###
-                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed       dual  rps_marginal_cost_per_mwh
-rps_zone period                                                                                                                             
-RPSZone1 2020                50                        50                         0                  0  7,128,256                    712,826
-         2030                50                        50                        23                 31 18,595,563                  1,859,556
+                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed          dual  rps_marginal_cost_per_mwh
+rps_zone period                                                                                                                                
+RPSZone1 2020             50.00                     50.00                      0.00               0.00  7,128,255.50                 712,825.55
+         2030             50.00                     50.00                     22.80              31.32 18,595,563.00               1,859,556.30

--- a/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/results/summary_results.txt
+++ b/examples/2periods_new_build_rps_variable_reserves_subhourly_adj/results/summary_results.txt
@@ -5,26 +5,26 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2030                    4
-          Wind       2020                   34
-                     2030                   16
+Zone1     Gas        2030                 4.00
+          Wind       2020                33.80
+                     2030                16.20
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          3              4
-                 Gas                          15             19
-                 Nuclear                      12             15
-                 Wind                         50             63
-          2030   Coal                          4              5
-                 Gas                          14             18
-                 Nuclear                      12             15
-                 Wind                         50             62
+Zone1     2020   Coal                       2.88           3.60
+                 Gas                       15.00          18.75
+                 Nuclear                   12.00          15.00
+                 Wind                      50.12          62.65
+          2030   Coal                       4.00           5.00
+                 Gas                       14.00          17.50
+                 Nuclear                   12.00          15.00
+                 Wind                      50.00          62.50
 
 ### RPS RESULTS ###
-                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed       dual  rps_marginal_cost_per_mwh
-rps_zone period                                                                                                                             
-RPSZone1 2020                50                        50                         0                  0  7,199,750                    719,975
-         2030                50                        50                        23                 31 18,595,563                  1,859,556
+                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed          dual  rps_marginal_cost_per_mwh
+rps_zone period                                                                                                                                
+RPSZone1 2020             50.00                     50.00                      0.12               0.23  7,199,750.20                 719,975.02
+         2030             50.00                     50.00                     22.80              31.32 18,595,563.00               1,859,556.30

--- a/examples/2periods_new_build_rps_w_rps_eligible_storage/results/summary_results.txt
+++ b/examples/2periods_new_build_rps_w_rps_eligible_storage/results/summary_results.txt
@@ -5,27 +5,27 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                    1
-          Wind       2020                   34
-                     2030                   25
+Zone1     Gas        2020                 1.33
+          Wind       2020                34.18
+                     2030                25.15
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4              5
-                 Gas                          14             17
-                 Nuclear                      12             15
-                 Storage                      -1             -1
-                 Wind                         51             63
-          2030   Coal                          4              5
-                 Gas                          14             17
-                 Nuclear                      12             15
-                 Wind                         50             63
+Zone1     2020   Coal                       4.00           5.00
+                 Gas                       14.00          17.50
+                 Nuclear                   12.00          15.00
+                 Storage                   -0.65          -0.81
+                 Wind                      50.65          63.31
+          2030   Coal                       4.00           5.00
+                 Gas                       14.00          17.50
+                 Nuclear                   12.00          15.00
+                 Wind                      50.00          62.50
 
 ### RPS RESULTS ###
-                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed       dual  rps_marginal_cost_per_mwh
-rps_zone period                                                                                                                             
-RPSZone1 2020                50                        50                        -0                 -0  7,658,399                    765,840
-         2030                50                        50                        36                 42 19,995,563                  1,999,556
+                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed          dual  rps_marginal_cost_per_mwh
+rps_zone period                                                                                                                                
+RPSZone1 2020             50.00                     50.00                     -0.00              -0.00  7,658,398.60                 765,839.86
+         2030             50.00                     50.00                     35.87              41.77 19,995,563.00               1,999,556.30

--- a/examples/2periods_new_build_rps_w_rps_ineligible_storage/results/summary_results.txt
+++ b/examples/2periods_new_build_rps_w_rps_ineligible_storage/results/summary_results.txt
@@ -5,27 +5,27 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                    1
-          Wind       2020                   34
-                     2030                   26
+Zone1     Gas        2020                 1.33
+          Wind       2020                33.71
+                     2030                25.62
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4              5
-                 Gas                          15             18
-                 Nuclear                      12             15
-                 Storage                      -1             -1
-                 Wind                         50             63
-          2030   Coal                          4              5
-                 Gas                          14             17
-                 Nuclear                      12             15
-                 Wind                         50             63
+Zone1     2020   Coal                       4.00           5.00
+                 Gas                       14.61          18.26
+                 Nuclear                   12.00          15.00
+                 Storage                   -0.61          -0.76
+                 Wind                      50.00          62.50
+          2030   Coal                       4.00           5.00
+                 Gas                       14.00          17.50
+                 Nuclear                   12.00          15.00
+                 Wind                      50.00          62.50
 
 ### RPS RESULTS ###
-                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed       dual  rps_marginal_cost_per_mwh
-rps_zone period                                                                                                                             
-RPSZone1 2020                50                        50                         0                  0  7,138,722                    713,872
-         2030                50                        50                        36                 42 19,995,563                  1,999,556
+                 rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed          dual  rps_marginal_cost_per_mwh
+rps_zone period                                                                                                                                
+RPSZone1 2020             50.00                     50.00                      0.00               0.00  7,138,721.50                 713,872.15
+         2030             50.00                     50.00                     35.87              41.77 19,995,563.00               1,999,556.30

--- a/examples/2periods_new_build_simple_prm/results/summary_results.txt
+++ b/examples/2periods_new_build_simple_prm/results/summary_results.txt
@@ -5,18 +5,18 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Gas        2020                   49
+Zone1     Gas        2020                49.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          0              0
-                 Gas                          75             84
-                 Nuclear                      12             13
-                 Wind                          3              3
-          2030   Coal                          0              0
-                 Gas                          75             84
-                 Nuclear                      12             13
-                 Wind                          3              3
+Zone1     2020   Coal                       0.00           0.00
+                 Gas                       75.20          83.56
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11
+          2030   Coal                       0.00           0.00
+                 Gas                       75.20          83.56
+                 Nuclear                   12.00          13.33
+                 Wind                       2.80           3.11

--- a/examples/multi_stage_prod_cost/1/1/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/1/1/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/multi_stage_prod_cost/1/2/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/1/2/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/multi_stage_prod_cost/1/3/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/1/3/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/multi_stage_prod_cost/2/1/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/2/1/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/multi_stage_prod_cost/2/2/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/2/2/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/multi_stage_prod_cost/2/3/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/2/3/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/multi_stage_prod_cost/3/1/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/3/1/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/multi_stage_prod_cost/3/2/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/3/2/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/multi_stage_prod_cost/3/3/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost/3/3/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/multi_stage_prod_cost_w_hydro/1/1/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/1/1/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                           8             27
-                 Hydro                         6             19
-                 Nuclear                      12             38
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.47
+                 Gas                        8.40          26.53
+                 Hydro                      6.00          18.95
+                 Nuclear                   12.00          37.89
+                 Wind                       1.00           3.16

--- a/examples/multi_stage_prod_cost_w_hydro/1/2/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/1/2/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                           8             27
-                 Hydro                         6             19
-                 Nuclear                      12             38
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.47
+                 Gas                        8.40          26.53
+                 Hydro                      6.00          18.95
+                 Nuclear                   12.00          37.89
+                 Wind                       1.00           3.16

--- a/examples/multi_stage_prod_cost_w_hydro/1/3/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/1/3/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                           8             27
-                 Hydro                         6             19
-                 Nuclear                      12             38
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.47
+                 Gas                        8.40          26.53
+                 Hydro                      6.00          18.95
+                 Nuclear                   12.00          37.89
+                 Wind                       1.00           3.16

--- a/examples/multi_stage_prod_cost_w_hydro/2/1/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/2/1/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                           8             27
-                 Hydro                         6             19
-                 Nuclear                      12             38
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.47
+                 Gas                        8.40          26.53
+                 Hydro                      6.00          18.95
+                 Nuclear                   12.00          37.89
+                 Wind                       1.00           3.16

--- a/examples/multi_stage_prod_cost_w_hydro/2/2/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/2/2/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                           8             27
-                 Hydro                         6             19
-                 Nuclear                      12             38
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.47
+                 Gas                        8.40          26.53
+                 Hydro                      6.00          18.95
+                 Nuclear                   12.00          37.89
+                 Wind                       1.00           3.16

--- a/examples/multi_stage_prod_cost_w_hydro/2/3/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/2/3/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                           8             27
-                 Hydro                         6             19
-                 Nuclear                      12             38
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.47
+                 Gas                        8.40          26.53
+                 Hydro                      6.00          18.95
+                 Nuclear                   12.00          37.89
+                 Wind                       1.00           3.16

--- a/examples/multi_stage_prod_cost_w_hydro/3/1/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/3/1/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                           8             27
-                 Hydro                         6             19
-                 Nuclear                      12             38
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.47
+                 Gas                        8.40          26.53
+                 Hydro                      6.00          18.95
+                 Nuclear                   12.00          37.89
+                 Wind                       1.00           3.16

--- a/examples/multi_stage_prod_cost_w_hydro/3/2/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/3/2/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                           8             27
-                 Hydro                         6             19
-                 Nuclear                      12             38
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.47
+                 Gas                        8.40          26.53
+                 Hydro                      6.00          18.95
+                 Nuclear                   12.00          37.89
+                 Wind                       1.00           3.16

--- a/examples/multi_stage_prod_cost_w_hydro/3/3/results/summary_results.txt
+++ b/examples/multi_stage_prod_cost_w_hydro/3/3/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                           8             27
-                 Hydro                         6             19
-                 Nuclear                      12             38
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.47
+                 Gas                        8.40          26.53
+                 Hydro                      6.00          18.95
+                 Nuclear                   12.00          37.89
+                 Wind                       1.00           3.16

--- a/examples/single_stage_prod_cost/1/results/summary_results.txt
+++ b/examples/single_stage_prod_cost/1/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/single_stage_prod_cost/2/results/summary_results.txt
+++ b/examples/single_stage_prod_cost/2/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/single_stage_prod_cost/3/results/summary_results.txt
+++ b/examples/single_stage_prod_cost/3/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/test/results/summary_results.txt
+++ b/examples/test/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/test_aux_cons/results/summary_results.txt
+++ b/examples/test_aux_cons/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                          13             44
-                 Nuclear                      12             40
-                 Wind                          1              3
+Zone1     2020   Coal                       3.99          13.13
+                 Gas                       13.38          44.06
+                 Nuclear                   12.00          39.52
+                 Wind                       1.00           3.29

--- a/examples/test_new_binary_build_storage/results/summary_results.txt
+++ b/examples/test_new_binary_build_storage/results/summary_results.txt
@@ -5,21 +5,21 @@
 --> New Binary Storage Capacity <--
                              New Binary Storage Power Capacity (MW)  New Binary Storage Energy Capacity (MWh)
 load_zone technology period                                                                                  
-Zone1     Storage    2020                                        10                                        40
-                     2030                                        10                                        40
+Zone1     Storage    2020                                     10.00                                     40.00
+                     2030                                     10.00                                     40.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          0              0
-                 Gas                          17             55
-                 Nuclear                      12             40
-                 Storage                      -1             -5
-                 Wind                          3              9
-          2030   Coal                          0              0
-                 Gas                          17             55
-                 Nuclear                      12             40
-                 Storage                      -1             -5
-                 Wind                          3              9
+Zone1     2020   Coal                       0.00           0.00
+                 Gas                       16.57          55.23
+                 Nuclear                   12.00          40.00
+                 Storage                   -1.37          -4.56
+                 Wind                       2.80           9.33
+          2030   Coal                       0.00           0.00
+                 Gas                       16.57          55.23
+                 Nuclear                   12.00          40.00
+                 Storage                   -1.37          -4.56
+                 Wind                       2.80           9.33

--- a/examples/test_new_binary_solar/results/summary_results.txt
+++ b/examples/test_new_binary_solar/results/summary_results.txt
@@ -5,15 +5,15 @@
 --> New Binary Build Generation Capacity <--
                              New Binary Build Capacity (MW)
 load_zone technology period                                
-Zone1     Solar      2020                                10
+Zone1     Solar      2020                             10.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                           8             27
-                 Nuclear                      12             39
-                 Solar                         6             20
-                 Wind                          0              0
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                        8.40          27.39
+                 Nuclear                   12.00          39.13
+                 Solar                      6.00          19.57
+                 Wind                       0.00           0.00

--- a/examples/test_new_build_storage/results/summary_results.txt
+++ b/examples/test_new_build_storage/results/summary_results.txt
@@ -5,21 +5,21 @@
 --> New Storage Capacity <--
                              New Storage Power Capacity (MW)  New Storage Energy Capacity (MWh)
 load_zone technology period                                                                    
-Zone1     Storage    2020                                  6                                 10
-                     2030                                  6                                 10
+Zone1     Storage    2020                               6.43                               9.64
+                     2030                               6.43                               9.64
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          0              0
-                 Gas                          17             55
-                 Nuclear                      12             40
-                 Storage                      -1             -5
-                 Wind                          3              9
-          2030   Coal                          0              0
-                 Gas                          17             55
-                 Nuclear                      12             40
-                 Storage                      -1             -5
-                 Wind                          3              9
+Zone1     2020   Coal                       0.00           0.00
+                 Gas                       16.57          55.23
+                 Nuclear                   12.00          40.00
+                 Storage                   -1.37          -4.56
+                 Wind                       2.80           9.33
+          2030   Coal                       0.00           0.00
+                 Gas                       16.57          55.23
+                 Nuclear                   12.00          40.00
+                 Storage                   -1.37          -4.56
+                 Wind                       2.80           9.33

--- a/examples/test_new_build_storage_cumulative_min_max/results/summary_results.txt
+++ b/examples/test_new_build_storage_cumulative_min_max/results/summary_results.txt
@@ -5,21 +5,21 @@
 --> New Storage Capacity <--
                              New Storage Power Capacity (MW)  New Storage Energy Capacity (MWh)
 load_zone technology period                                                                    
-Zone1     Storage    2020                                  4                                  7
-                     2030                                 10                                 15
+Zone1     Storage    2020                               4.32                               7.00
+                     2030                              10.00                              15.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          1              2
-                 Gas                          15             49
-                 Nuclear                      12             40
-                 Storage                      -0             -1
-                 Wind                          3              9
-          2030   Coal                          0              0
-                 Gas                          17             55
-                 Nuclear                      12             40
-                 Storage                      -1             -5
-                 Wind                          3              9
+Zone1     2020   Coal                       0.68           2.27
+                 Gas                       14.70          49.00
+                 Nuclear                   12.00          40.00
+                 Storage                   -0.18          -0.60
+                 Wind                       2.80           9.33
+          2030   Coal                       0.00           0.00
+                 Gas                       16.57          55.23
+                 Nuclear                   12.00          40.00
+                 Storage                   -1.37          -4.56
+                 Wind                       2.80           9.33

--- a/examples/test_new_solar/results/summary_results.txt
+++ b/examples/test_new_solar/results/summary_results.txt
@@ -5,15 +5,15 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Solar      2020                    4
+Zone1     Solar      2020                 4.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                           9             31
-                 Nuclear                      12             39
-                 Solar                         4             13
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                        9.40          30.65
+                 Nuclear                   12.00          39.13
+                 Solar                      4.00          13.04
+                 Wind                       1.00           3.26

--- a/examples/test_new_solar_carbon_cap/results/summary_results.txt
+++ b/examples/test_new_solar_carbon_cap/results/summary_results.txt
@@ -5,15 +5,15 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Solar      2020                    2
+Zone1     Solar      2020                 2.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          1              5
-                 Gas                          14             45
-                 Nuclear                      12             40
-                 Solar                         2              7
-                 Wind                          1              3
+Zone1     2020   Coal                       1.41           4.70
+                 Gas                       13.59          45.30
+                 Nuclear                   12.00          40.00
+                 Solar                      2.00           6.67
+                 Wind                       1.00           3.33

--- a/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/results/summary_results.txt
+++ b/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/results/summary_results.txt
@@ -5,16 +5,16 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Solar      2020                    2
+Zone1     Solar      2020                 2.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          1              5
-                 Gas                          12             38
-                 Nuclear                      12             40
-                 Solar                         2              7
-                 Wind                          3              9
-Zone2     2020   Gas                          20            100
+Zone1     2020   Coal                       1.49           4.98
+                 Gas                       11.51          38.49
+                 Nuclear                   12.00          40.13
+                 Solar                      2.10           7.02
+                 Wind                       2.80           9.36
+Zone2     2020   Gas                       20.10         100.00

--- a/examples/test_new_solar_carbon_cap_2zones_tx/results/summary_results.txt
+++ b/examples/test_new_solar_carbon_cap_2zones_tx/results/summary_results.txt
@@ -5,16 +5,16 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Solar      2020                    2
+Zone1     Solar      2020                 2.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          1              5
-                 Gas                          12             39
-                 Nuclear                      12             40
-                 Solar                         2              7
-                 Wind                          3              9
-Zone2     2020   Gas                          20            100
+Zone1     2020   Coal                       1.48           4.95
+                 Gas                       11.52          38.53
+                 Nuclear                   12.00          40.13
+                 Solar                      2.10           7.02
+                 Wind                       2.80           9.36
+Zone2     2020   Gas                       20.10         100.00

--- a/examples/test_no_fuels/results/summary_results.txt
+++ b/examples/test_no_fuels/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          5             17
-                 Gas                          13             41
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       5.07          16.52
+                 Gas                       12.60          41.09
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/test_no_overgen_allowed/results/summary_results.txt
+++ b/examples/test_no_overgen_allowed/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                          13             43
-                 Nuclear                      12             40
-                 Wind                          1              3
+Zone1     2020   Coal                       4.00          13.33
+                 Gas                       13.00          43.33
+                 Nuclear                   12.00          40.00
+                 Wind                       1.00           3.33

--- a/examples/test_no_reserves/results/summary_results.txt
+++ b/examples/test_no_reserves/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          1              3
-                 Gas                          14             47
-                 Nuclear                      12             40
-                 Wind                          3              9
+Zone1     2020   Coal                       1.00           3.33
+                 Gas                       14.20          47.33
+                 Nuclear                   12.00          40.00
+                 Wind                       2.80           9.33

--- a/examples/test_ramp_up_and_down_constraints/results/summary_results.txt
+++ b/examples/test_ramp_up_and_down_constraints/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          6             20
-                 Gas                          13             41
-                 Nuclear                      12             37
-                 Wind                          1              3
+Zone1     2020   Coal                       6.40          19.51
+                 Gas                       13.40          40.85
+                 Nuclear                   12.00          36.59
+                 Wind                       1.00           3.05

--- a/examples/test_ramp_up_constraints/results/summary_results.txt
+++ b/examples/test_ramp_up_constraints/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/test_startup_shutdown_rates/results/summary_results.txt
+++ b/examples/test_startup_shutdown_rates/results/summary_results.txt
@@ -7,5 +7,5 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Gas                          16             18
-                 Nuclear                      72             82
+Zone1     2020   Gas                       16.32          18.48
+                 Nuclear                   72.00          81.52

--- a/examples/test_tx_dcopf/results/summary_results.txt
+++ b/examples/test_tx_dcopf/results/summary_results.txt
@@ -5,17 +5,17 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Solar      2020                    2
+Zone1     Solar      2020                 2.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          1              4
-                 Gas                          10             36
-                 Nuclear                      12             43
-                 Solar                         2              7
-                 Wind                          3             10
-Zone2     2020   Gas                          16            100
-Zone3     2020   Gas                          66            100
+Zone1     2020   Coal                       1.13           4.04
+                 Gas                       10.00          35.67
+                 Nuclear                   12.00          42.81
+                 Solar                      2.10           7.49
+                 Wind                       2.80           9.99
+Zone2     2020   Gas                       16.02         100.00
+Zone3     2020   Gas                       65.95         100.00

--- a/examples/test_tx_simple/results/summary_results.txt
+++ b/examples/test_tx_simple/results/summary_results.txt
@@ -5,17 +5,17 @@
 --> New Generation Capacity <--
                              New Capacity (MW)
 load_zone technology period                   
-Zone1     Solar      2020                    2
+Zone1     Solar      2020                 2.00
 
 ### OPERATIONAL RESULTS ###
 
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          1              4
-                 Gas                          10             36
-                 Nuclear                      12             43
-                 Solar                         2              7
-                 Wind                          3             10
-Zone2     2020   Gas                          12            100
-Zone3     2020   Gas                          70            100
+Zone1     2020   Coal                       1.13           4.04
+                 Gas                       10.00          35.67
+                 Nuclear                   12.00          42.81
+                 Solar                      2.10           7.49
+                 Wind                       2.80           9.99
+Zone2     2020   Gas                       11.97         100.00
+Zone3     2020   Gas                       70.00         100.00

--- a/examples/test_variable_gen_reserves/results/summary_results.txt
+++ b/examples/test_variable_gen_reserves/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             13
-                 Gas                          13             43
-                 Nuclear                      12             40
-                 Wind                          1              3
+Zone1     2020   Coal                       4.00          13.30
+                 Gas                       13.07          43.46
+                 Nuclear                   12.00          39.91
+                 Wind                       1.00           3.33

--- a/examples/test_variable_om_curves/results/summary_results.txt
+++ b/examples/test_variable_om_curves/results/summary_results.txt
@@ -7,7 +7,7 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          4             14
-                 Gas                          13             44
-                 Nuclear                      12             39
-                 Wind                          1              3
+Zone1     2020   Coal                       4.27          13.91
+                 Gas                       13.40          43.70
+                 Nuclear                   12.00          39.13
+                 Wind                       1.00           3.26

--- a/examples/test_w_hydro/results/summary_results.txt
+++ b/examples/test_w_hydro/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          0              0
-                 Gas                          10             33
-                 Hydro                         6             20
-                 Nuclear                      12             40
-                 Wind                          2              7
+Zone1     2020   Coal                       0.00           0.00
+                 Gas                       10.00          33.33
+                 Hydro                      6.00          20.00
+                 Nuclear                   12.00          40.00
+                 Wind                       2.00           6.67

--- a/examples/test_w_storage/results/summary_results.txt
+++ b/examples/test_w_storage/results/summary_results.txt
@@ -7,8 +7,8 @@
 --> Energy Production <--
                              Annual Energy (MWh)  % Total Power
 load_zone period technology                                    
-Zone1     2020   Coal                          1              3
-                 Gas                          14             47
-                 Nuclear                      12             40
-                 Storage                       0              0
-                 Wind                          3              9
+Zone1     2020   Coal                       1.00           3.33
+                 Gas                       14.20          47.33
+                 Nuclear                   12.00          40.00
+                 Storage                    0.00           0.00
+                 Wind                       2.80           9.33

--- a/gridpath/project/capacity/capacity_types/dr_new.py
+++ b/gridpath/project/capacity/capacity_types/dr_new.py
@@ -445,7 +445,7 @@ def summarize_module_specific_results(
         if new_build_df.empty:
             outfile.write("No new DR was built.\n")
         else:
-            new_build_df.to_string(outfile, float_format="{:,.0f}".format)
+            new_build_df.to_string(outfile, float_format="{:,.2f}".format)
             outfile.write("\n")
 
 

--- a/gridpath/project/capacity/capacity_types/gen_new_bin.py
+++ b/gridpath/project/capacity/capacity_types/gen_new_bin.py
@@ -414,7 +414,7 @@ def summarize_module_specific_results(
         if new_build_df.empty:
             outfile.write("No new generation was built.\n")
         else:
-            new_build_df.to_string(outfile, float_format="{:,.0f}".format)
+            new_build_df.to_string(outfile, float_format="{:,.2f}".format)
             outfile.write("\n")
 
 

--- a/gridpath/project/capacity/capacity_types/gen_new_lin.py
+++ b/gridpath/project/capacity/capacity_types/gen_new_lin.py
@@ -562,7 +562,7 @@ def summarize_module_specific_results(
         if new_build_df.empty:
             outfile.write("No new generation was built.\n")
         else:
-            new_build_df.to_string(outfile, float_format="{:,.0f}".format)
+            new_build_df.to_string(outfile, float_format="{:,.2f}".format)
             outfile.write("\n")
 
 

--- a/gridpath/project/capacity/capacity_types/gen_ret_bin.py
+++ b/gridpath/project/capacity/capacity_types/gen_ret_bin.py
@@ -349,7 +349,7 @@ def summarize_module_specific_results(
         if bin_retirement_df.empty:
             outfile.write("No retirements.\n")
         else:
-            bin_retirement_df.to_string(outfile, float_format="{:,.0f}".format)
+            bin_retirement_df.to_string(outfile, float_format="{:,.2f}".format)
             outfile.write("\n")
 
 

--- a/gridpath/project/capacity/capacity_types/gen_ret_lin.py
+++ b/gridpath/project/capacity/capacity_types/gen_ret_lin.py
@@ -385,7 +385,7 @@ def summarize_module_specific_results(
         if lin_retirement_df.empty:
             outfile.write("No retirements.\n")
         else:
-            lin_retirement_df.to_string(outfile, float_format="{:,.0f}".format)
+            lin_retirement_df.to_string(outfile, float_format="{:,.2f}".format)
             outfile.write("\n")
 
 

--- a/gridpath/project/capacity/capacity_types/stor_new_bin.py
+++ b/gridpath/project/capacity/capacity_types/stor_new_bin.py
@@ -465,7 +465,7 @@ def summarize_module_specific_results(
         if new_build_df.empty:
             outfile.write("No new storage was built.\n")
         else:
-            new_build_df.to_string(outfile, float_format="{:,.0f}".format)
+            new_build_df.to_string(outfile, float_format="{:,.2f}".format)
             outfile.write("\n")
 
 

--- a/gridpath/project/capacity/capacity_types/stor_new_lin.py
+++ b/gridpath/project/capacity/capacity_types/stor_new_lin.py
@@ -886,7 +886,7 @@ def summarize_module_specific_results(
         if new_build_df.empty:
             outfile.write("No new storage was built.\n")
         else:
-            new_build_df.to_string(outfile, float_format="{:,.0f}".format)
+            new_build_df.to_string(outfile, float_format="{:,.2f}".format)
             outfile.write("\n")
 
 

--- a/gridpath/project/operations/power.py
+++ b/gridpath/project/operations/power.py
@@ -195,7 +195,7 @@ def summarize_results(d, scenario_directory, subproblem, stage):
     with open(summary_results_file, "a") as outfile:
         outfile.write("\n--> Energy Production <--\n")
         operational_results_agg_df.to_string(outfile,
-                                             float_format="{:,.0f}".format)
+                                             float_format="{:,.2f}".format)
         outfile.write("\n")
 
 

--- a/gridpath/system/policy/rps/rps_balance.py
+++ b/gridpath/system/policy/rps/rps_balance.py
@@ -197,7 +197,7 @@ def summarize_results(d, scenario_directory, subproblem, stage):
     results_df = results_df[cols]
     results_df.sort_index(inplace=True)
     with open(summary_results_file, "a") as outfile:
-        results_df.to_string(outfile, float_format="{:,.0f}".format)
+        results_df.to_string(outfile, float_format="{:,.2f}".format)
         outfile.write("\n")
 
 


### PR DESCRIPTION
Rather than setting overal pd display settings it seems safer (more
consistent behavior) to set the float formatting when printing the
dataframe.

The format setting was missing in power.py, so if there are
examples without new capacity it's possible the display settings
weren't changed from default, resulting in un-rounded float formats.
This in turn could made the formatting dependent on the order of the
examples (I think).

After this update, all formats in summarry_results.txt should
consistently be rounded.