### PR TITLE
Fix zero division error

### DIFF
--- a/gridpath/project/operations/operational_types/gen_commit_bin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_bin.py
@@ -1085,13 +1085,36 @@ def synced_constraint_rule(mod, g, tmp):
 
     Synced is 1 if the unit is committed, starting, or stopping and zero
     otherwise.
+
+    Note: This contains a division by the Pmin expression, so cases where Pmin
+    would be zero need to be treated differently to avoid zero-division errors.
     """
+
+    # If specified capacity is zero, synced units is zero
+    if mod.capacity_type[g] in ['gen_spec', 'gen_ret_bin', 'gen_ret_lin']:
+        spec_capacity = getattr(mod, mod.capacity_type[g] + '_capacity_mw')
+        if spec_capacity[g, mod.period[tmp]] == 0:
+            return mod.GenCommitBin_Synced[g, tmp] == 0
+
+    # If exogenous availability is zero, synced units is zero
+    if mod.availability_type[g] == 'exogenous':
+        if mod.avl_exog_derate[g, tmp] == 0:
+            return mod.GenCommitBin_Synced[g, tmp] == 0
+
+    # If min stable level is zero, there will be no trajectories so we drop the
+    # second RHS term which checks for startup/shutdown power
+    if mod.gen_commit_bin_min_stable_level_fraction[g] == 0:
+        startup_shutdown_fraction = 0
+    else:
+        startup_shutdown_fraction = (
+            sum(mod.GenCommitBin_Provide_Power_Startup_MW[g, tmp, s]
+                for s in mod.GEN_COMMIT_BIN_STR_TYPES_BY_PRJ[g])
+            + mod.GenCommitBin_Provide_Power_Shutdown_MW[g, tmp]
+        ) / mod.GenCommitBin_Pmin_MW[g, tmp]
+
     return mod.GenCommitBin_Synced[g, tmp] \
         >= mod.GenCommitBin_Commit[g, tmp] \
-        + (sum(mod.GenCommitBin_Provide_Power_Startup_MW[g, tmp, s]
-               for s in mod.GEN_COMMIT_BIN_STR_TYPES_BY_PRJ[g])
-           + mod.GenCommitBin_Provide_Power_Shutdown_MW[g, tmp]) \
-        / mod.Capacity_MW[g, mod.period[tmp]]
+        + startup_shutdown_fraction
 
 
 # Power


### PR DESCRIPTION
I managed to reproduce the errors mentioned in #555: when the availability is zero or the min stable level is zero, Pmin will be zero, and dividing by Pmin will result in a division by zero error. 

This update fixes this by replacing Pmin with the installed capacity. 

A few notes:
- The min stable level should be > 0 for commitment generators. If not, the concept of starts and stops mean nothing because the unit can simply be committed but running at zero output whenever it needs to shut down. If you really want a unit that can go down to zero all the way, you should use a simpler operational type. 
- This solution might still cause problems when the capacity is zero, e.g. for gen_new_lin/bin capacity types. I did a quick test example to check this using the ipopt non-linear solver and didn't get the division-by-zero error, but the results looked off with synced units being a non-integer number, e.g. 1.5. This seems to be a wider issue with these non-linear solutions, because I had the same weird results when I changed out the capacity for a large number
- An alternative solution is to simply replace the capacity with a very big number. We just need
to make sure that number is larger than Pmin, which can be hard if we have units that are flexible (a user could set the units to W and have units with capacity in the millions). 
- Regardless of the solution, and even in the current case, synced_units in the linearized case will not really have any useful meaning since the synced_units_constraint relies on the binary nature of the synce_units variable. 

Closes #555