### PR TITLE
Standardize carbon emission units

### DIFF
--- a/db/csvs_test_examples/policy/carbon_cap/system_carbon_cap_targets/1_system_carbon_cap_targets_1.csv
+++ b/db/csvs_test_examples/policy/carbon_cap/system_carbon_cap_targets/1_system_carbon_cap_targets_1.csv
@@ -1,3 +1,3 @@
-carbon_cap_zone,period,subproblem_id,stage_id,carbon_cap_mmt
-Zone1,2020,1,1,0.0003
-Zone1,2030,1,1,0.0003
+carbon_cap_zone,period,subproblem_id,stage_id,carbon_cap
+Zone1,2020,1,1,300
+Zone1,2030,1,1,300

--- a/db/csvs_to_db_utilities/load_system_carbon_cap.py
+++ b/db/csvs_to_db_utilities/load_system_carbon_cap.py
@@ -10,7 +10,7 @@ from db.utilities import carbon_cap
 def load_system_carbon_cap_targets(io, c, subscenario_input, data_input):
     """
     System carbon_cap dictionary
-    {carbon_cap_zone: {period: {subproblem: {stage_id: carbon_cap_mmt}}}}
+    {carbon_cap_zone: {period: {subproblem: {stage_id: carbon_cap}}}}
     :param io:
     :param c:
     :param subscenario_input:
@@ -43,7 +43,7 @@ def load_system_carbon_cap_targets(io, c, subscenario_input, data_input):
                         st_id = int(st_id)
                         zone_period_targets[z][p][sub_id][st_id] = dict()
                         zone_period_targets[z][p][sub_id][st_id] = float(zone_period_targets_by_zone_period_subproblem.loc[
-                            zone_period_targets_by_zone_period_subproblem['stage_id'] == st_id, 'carbon_cap_mmt'].iloc[0])
+                            zone_period_targets_by_zone_period_subproblem['stage_id'] == st_id, 'carbon_cap'].iloc[0])
 
         # Load data into GridPath database
         carbon_cap.insert_carbon_cap_targets(

--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -487,7 +487,7 @@ CREATE TABLE inputs_geography_carbon_cap_zones (
 carbon_cap_zone_scenario_id INTEGER,
 carbon_cap_zone VARCHAR(32),
 allow_violation INTEGER DEFAULT 0,  -- constraint is hard by default
-violation_penalty_per_mmt FLOAT DEFAULT 0,
+violation_penalty_per_emission FLOAT DEFAULT 0,
 PRIMARY KEY (carbon_cap_zone_scenario_id, carbon_cap_zone),
 FOREIGN KEY (carbon_cap_zone_scenario_id) REFERENCES
 subscenarios_geography_carbon_cap_zones (carbon_cap_zone_scenario_id)
@@ -1771,7 +1771,7 @@ carbon_cap_zone VARCHAR(32),
 period INTEGER,
 subproblem_id INTEGER,
 stage_id INTEGER,
-carbon_cap_mmt FLOAT,
+carbon_cap FLOAT,
 PRIMARY KEY (carbon_cap_target_scenario_id, carbon_cap_zone, period,
 subproblem_id, stage_id),
 FOREIGN KEY (carbon_cap_target_scenario_id) REFERENCES
@@ -2834,15 +2834,15 @@ subproblem_id INTEGER,
 stage_id INTEGER,
 discount_factor FLOAT,
 number_years_represented FLOAT,
-carbon_cap_mmt FLOAT,
-in_zone_project_emissions_mmt FLOAT,
-import_emissions_mmt FLOAT,
-total_emissions_mmt FLOAT,
-carbon_cap_overage_mmt FLOAT,
-import_emissions_mmt_degen FLOAT,
-total_emissions_mmt_degen FLOAT,
+carbon_cap FLOAT,
+in_zone_project_emissions FLOAT,
+import_emissions FLOAT,
+total_emissions FLOAT,
+carbon_cap_overage FLOAT,
+import_emissions_degen FLOAT,
+total_emissions_degen FLOAT,
 dual FLOAT,
-carbon_cap_marginal_cost_per_mmt FLOAT,
+carbon_cap_marginal_cost_per_emission FLOAT,
 PRIMARY KEY (scenario_id, carbon_cap_zone, subproblem_id, stage_id, period)
 );
 

--- a/db/utilities/carbon_cap.py
+++ b/db/utilities/carbon_cap.py
@@ -51,7 +51,7 @@ def insert_carbon_cap_targets(
         INSERT OR IGNORE INTO inputs_system_carbon_cap_targets
         (carbon_cap_target_scenario_id, carbon_cap_zone, period,
         subproblem_id, stage_id,
-        carbon_cap_mmt)
+        carbon_cap)
         VALUES (?, ?, ?, ?, ?, ?);
         """
     spin_on_database_lock(conn=io, cursor=c, sql=inputs_sql, data=inputs_data)

--- a/db/utilities/geography.py
+++ b/db/utilities/geography.py
@@ -451,7 +451,7 @@ def geography_carbon_cap_zones(
     inputs_sql = """
         INSERT OR IGNORE INTO inputs_geography_carbon_cap_zones
         (carbon_cap_zone_scenario_id, carbon_cap_zone, allow_violation, 
-        violation_penalty_per_mmt)
+        violation_penalty_per_emission)
         VALUES (?, ?, ?, ?);
         """
     spin_on_database_lock(conn=io, cursor=c, sql=inputs_sql, data=inputs_data)

--- a/examples/test_new_solar_carbon_cap/inputs/carbon_cap.tab
+++ b/examples/test_new_solar_carbon_cap/inputs/carbon_cap.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	period	carbon_cap_target_mmt
-Zone1	2020	0.0003
+carbon_cap_zone	period	carbon_cap_target
+Zone1	2020	300.0

--- a/examples/test_new_solar_carbon_cap/inputs/carbon_cap_zones.tab
+++ b/examples/test_new_solar_carbon_cap/inputs/carbon_cap_zones.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	allow_violation	violation_penalty_per_mmt
+carbon_cap_zone	allow_violation	violation_penalty_per_emission
 Zone1	0	0.0

--- a/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/inputs/carbon_cap.tab
+++ b/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/inputs/carbon_cap.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	period	carbon_cap_target_mmt
-Zone1	2020	0.0003
+carbon_cap_zone	period	carbon_cap_target
+Zone1	2020	300.0

--- a/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/inputs/carbon_cap_zones.tab
+++ b/examples/test_new_solar_carbon_cap_2zones_dont_count_tx/inputs/carbon_cap_zones.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	allow_violation	violation_penalty_per_mmt
+carbon_cap_zone	allow_violation	violation_penalty_per_emission
 Zone1	0	0.0

--- a/examples/test_new_solar_carbon_cap_2zones_tx/inputs/carbon_cap.tab
+++ b/examples/test_new_solar_carbon_cap_2zones_tx/inputs/carbon_cap.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	period	carbon_cap_target_mmt
-Zone1	2020	0.0003
+carbon_cap_zone	period	carbon_cap_target
+Zone1	2020	300.0

--- a/examples/test_new_solar_carbon_cap_2zones_tx/inputs/carbon_cap_zones.tab
+++ b/examples/test_new_solar_carbon_cap_2zones_tx/inputs/carbon_cap_zones.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	allow_violation	violation_penalty_per_mmt
+carbon_cap_zone	allow_violation	violation_penalty_per_emission
 Zone1	0	0.0

--- a/examples/test_tx_dcopf/inputs/carbon_cap.tab
+++ b/examples/test_tx_dcopf/inputs/carbon_cap.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	period	carbon_cap_target_mmt
-Zone1	2020	0.0003
+carbon_cap_zone	period	carbon_cap_target
+Zone1	2020	300.0

--- a/examples/test_tx_dcopf/inputs/carbon_cap_zones.tab
+++ b/examples/test_tx_dcopf/inputs/carbon_cap_zones.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	allow_violation	violation_penalty_per_mmt
+carbon_cap_zone	allow_violation	violation_penalty_per_emission
 Zone1	0	0.0

--- a/examples/test_tx_simple/inputs/carbon_cap.tab
+++ b/examples/test_tx_simple/inputs/carbon_cap.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	period	carbon_cap_target_mmt
-Zone1	2020	0.0003
+carbon_cap_zone	period	carbon_cap_target
+Zone1	2020	300.0

--- a/examples/test_tx_simple/inputs/carbon_cap_zones.tab
+++ b/examples/test_tx_simple/inputs/carbon_cap_zones.tab
@@ -1,2 +1,2 @@
-carbon_cap_zone	allow_violation	violation_penalty_per_mmt
+carbon_cap_zone	allow_violation	violation_penalty_per_emission
 Zone1	0	0.0

--- a/gridpath/geography/carbon_cap_zones.py
+++ b/gridpath/geography/carbon_cap_zones.py
@@ -24,7 +24,7 @@ def add_model_components(m, d):
     m.carbon_cap_allow_violation = Param(
         m.CARBON_CAP_ZONES, within=Boolean, default=0
     )
-    m.carbon_cap_violation_penalty_per_mmt = Param(
+    m.carbon_cap_violation_penalty_per_emission = Param(
         m.CARBON_CAP_ZONES, within=NonNegativeReals, default=0
     )
 
@@ -35,7 +35,7 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
                                            "inputs", "carbon_cap_zones.tab"),
                      index=m.CARBON_CAP_ZONES,
                      param=(m.carbon_cap_allow_violation,
-                            m.carbon_cap_violation_penalty_per_mmt)
+                            m.carbon_cap_violation_penalty_per_emission)
                      )
 
 
@@ -51,7 +51,8 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     stage = 1 if stage == "" else stage
     c = conn.cursor()
     carbon_cap_zone = c.execute(
-        """SELECT carbon_cap_zone, allow_violation, violation_penalty_per_mmt
+        """SELECT carbon_cap_zone, allow_violation, 
+        violation_penalty_per_emission
         FROM inputs_geography_carbon_cap_zones
         WHERE carbon_cap_zone_scenario_id = {};
         """.format(
@@ -99,7 +100,7 @@ def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn
 
         # Write header
         writer.writerow(["carbon_cap_zone", "allow_violation",
-                         "violation_penalty_per_mmt"])
+                         "violation_penalty_per_emission"])
 
         for row in carbon_cap_zone:
             writer.writerow(row)

--- a/gridpath/objective/system/policy/aggregate_carbon_cap_violation_penalties.py
+++ b/gridpath/objective/system/policy/aggregate_carbon_cap_violation_penalties.py
@@ -21,8 +21,8 @@ def add_model_components(m, d):
     """
 
     def total_penalty_costs_rule(mod):
-        return sum(mod.Carbon_Cap_Overage_MMt_Expression[z, p]
-                   * mod.carbon_cap_violation_penalty_per_mmt[z]
+        return sum(mod.Carbon_Cap_Overage_Expression[z, p]
+                   * mod.carbon_cap_violation_penalty_per_emission[z]
                    * mod.number_years_represented[p]
                    * mod.discount_factor[p]
                    for (z, p) in mod.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP)

--- a/gridpath/system/policy/carbon_cap/aggregate_project_carbon_emissions.py
+++ b/gridpath/system/policy/carbon_cap/aggregate_project_carbon_emissions.py
@@ -66,22 +66,22 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
-                           "carbon_cap_total_project.csv"), "w", newline="") as \
-            rps_results_file:
-        writer = csv.writer(rps_results_file)
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage),
+                           "results", "carbon_cap_total_project.csv"),
+              "w", newline="") as carbon_results_file:
+        writer = csv.writer(carbon_results_file)
         writer.writerow(["carbon_cap_zone", "period",
                          "discount_factor", "number_years_represented",
-                         "carbon_cap_target_mmt",
-                         "project_carbon_emissions_mmt"])
+                         "carbon_cap_target",
+                         "project_carbon_emissions"])
         for (z, p) in m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP:
             writer.writerow([
                 z,
                 p,
                 m.discount_factor[p],
                 m.number_years_represented[p],
-                float(m.carbon_cap_target_mmt[z, p]),
-                value(m.Total_Carbon_Emissions_Tons[z, p]/10**6)  # MMT
+                float(m.carbon_cap_target[z, p]),
+                value(m.Total_Carbon_Emissions_Tons[z, p])
             ])
 
 
@@ -119,19 +119,19 @@ def import_results_into_database(
         for row in reader:
             carbon_cap_zone = row[0]
             period = row[1]
-            carbon_cap_mmt = row[4]
-            project_carbon_emissions_mmt = row[5]
+            carbon_cap = row[4]
+            project_carbon_emissions = row[5]
             
             results.append(
                 (scenario_id, carbon_cap_zone, period, subproblem, stage,
-                 carbon_cap_mmt, project_carbon_emissions_mmt)
+                 carbon_cap, project_carbon_emissions)
             )
 
     insert_temp_sql = """
         INSERT INTO 
         temp_results_system_carbon_emissions{}
          (scenario_id, carbon_cap_zone, period, subproblem_id, stage_id,
-         carbon_cap_mmt, in_zone_project_emissions_mmt)
+         carbon_cap, in_zone_project_emissions)
          VALUES (?, ?, ?, ?, ?, ?, ?);
          """.format(scenario_id)
     spin_on_database_lock(conn=db, cursor=c, sql=insert_temp_sql, data=results)
@@ -140,10 +140,10 @@ def import_results_into_database(
     insert_sql = """
         INSERT INTO results_system_carbon_emissions
         (scenario_id, carbon_cap_zone, period, subproblem_id, stage_id,
-        carbon_cap_mmt, in_zone_project_emissions_mmt)
+        carbon_cap, in_zone_project_emissions)
         SELECT
         scenario_id, carbon_cap_zone, period, subproblem_id, stage_id,
-        carbon_cap_mmt, in_zone_project_emissions_mmt
+        carbon_cap, in_zone_project_emissions
         FROM temp_results_system_carbon_emissions{}
          ORDER BY scenario_id, carbon_cap_zone, period, subproblem_id, 
         stage_id;

--- a/gridpath/system/policy/carbon_cap/aggregate_transmission_carbon_emissions.py
+++ b/gridpath/system/policy/carbon_cap/aggregate_transmission_carbon_emissions.py
@@ -90,21 +90,20 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
-                           "carbon_cap_total_transmission.csv"), "w", newline="") as \
-            rps_results_file:
-        writer = csv.writer(rps_results_file)
-        writer.writerow(["carbon_cap_zone", "period", "carbon_cap_target_mmt",
-                         "transmission_carbon_emissions_mmt",
-                         "transmission_carbon_emissions_mmt_degen"])
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage),
+                           "results", "carbon_cap_total_transmission.csv"),
+              "w", newline="") as carbon_results_file:
+        writer = csv.writer(carbon_results_file)
+        writer.writerow(["carbon_cap_zone", "period", "carbon_cap_target",
+                         "transmission_carbon_emissions",
+                         "transmission_carbon_emissions_degen"])
         for (z, p) in m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP:
             writer.writerow([
                 z,
                 p,
-                float(m.carbon_cap_target_mmt[z, p]),
-                value(m.Total_Carbon_Emission_Imports_Tons[z, p]/10**6),  # MMT
-                total_carbon_emissions_imports_degen_expr_rule(m, z, p)/10**6
-                # MMT
+                float(m.carbon_cap_target[z, p]),
+                value(m.Total_Carbon_Emission_Imports_Tons[z, p]),
+                total_carbon_emissions_imports_degen_expr_rule(m, z, p)
             ])
 
 
@@ -131,7 +130,7 @@ def import_results_into_database(
     # TODO: why not just clear the results?
     nullify_sql = """
         UPDATE results_system_carbon_emissions
-        SET import_emissions_mmt = NULL
+        SET import_emissions = NULL
         WHERE scenario_id = ?
         AND subproblem_id = ?
         AND stage_id = ?;
@@ -150,20 +149,20 @@ def import_results_into_database(
         for row in reader:
             carbon_cap_zone = row[0]
             period = row[1]
-            tx_carbon_emissions_mmt = row[3]
-            tx_carbon_emissions_mmt_degen = row[4]
+            tx_carbon_emissions = row[3]
+            tx_carbon_emissions_degen = row[4]
             
             results.append(
-                (tx_carbon_emissions_mmt,
-                    tx_carbon_emissions_mmt_degen,
+                (tx_carbon_emissions,
+                    tx_carbon_emissions_degen,
                     scenario_id, carbon_cap_zone, period,
                     subproblem, stage)
             )
 
     imports_sql = """
         UPDATE results_system_carbon_emissions
-        SET import_emissions_mmt = ?,
-        import_emissions_mmt_degen = ?
+        SET import_emissions = ?,
+        import_emissions_degen = ?
         WHERE scenario_id = ?
         AND carbon_cap_zone = ?
         AND period = ?
@@ -175,8 +174,8 @@ def import_results_into_database(
     # Update the total emissions in case of degeneracy
     total_degen_sql = """
         UPDATE results_system_carbon_emissions
-           SET total_emissions_mmt_degen = 
-           in_zone_project_emissions_mmt + import_emissions_mmt_degen
+           SET total_emissions_degen = 
+           in_zone_project_emissions + import_emissions_degen
            WHERE scenario_id = ?
            AND subproblem_id = ?
            AND stage_id = ?;

--- a/gridpath/system/policy/carbon_cap/carbon_balance.py
+++ b/gridpath/system/policy/carbon_cap/carbon_balance.py
@@ -26,15 +26,15 @@ def add_model_components(m, d):
     :return:
     """
 
-    m.Carbon_Cap_Overage_MMt = Var(
+    m.Carbon_Cap_Overage = Var(
         m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP, within=NonNegativeReals
     )
 
     def violation_expression_rule(mod, z, p):
-        return mod.Carbon_Cap_Overage_MMt[z, p] * \
+        return mod.Carbon_Cap_Overage[z, p] * \
                mod.carbon_cap_allow_violation[z]
 
-    m.Carbon_Cap_Overage_MMt_Expression = Expression(
+    m.Carbon_Cap_Overage_Expression = Expression(
         m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP,
         rule=violation_expression_rule
     )
@@ -56,8 +56,8 @@ def add_model_components(m, d):
         :return:
         """
         return mod.Total_Carbon_Emissions_from_All_Sources_Expression[z, p] \
-            - mod.Carbon_Cap_Overage_MMt_Expression[z, p] * 10**6 \
-            <= mod.carbon_cap_target_mmt[z, p] * 10**6  # convert to tons
+            - mod.Carbon_Cap_Overage_Expression[z, p] \
+            <= mod.carbon_cap_target[z, p]
 
     m.Carbon_Cap_Constraint = Constraint(
         m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP,
@@ -75,24 +75,24 @@ def export_results(scenario_directory, subproblem, stage, m, d):
     :param d:
     :return:
     """
-    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
-                           "carbon_cap.csv"), "w", newline="") as carbon_cap_results_file:
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage),
+                           "results", "carbon_cap.csv"),
+              "w", newline="") as carbon_cap_results_file:
         writer = csv.writer(carbon_cap_results_file)
         writer.writerow(["carbon_cap_zone", "period",
                          "discount_factor", "number_years_represented",
-                         "carbon_cap_target_mmt",
-                         "carbon_emissions_mmt",
-                         "carbon_cap_overage_mmt"])
+                         "carbon_cap_target",
+                         "carbon_emissions",
+                         "carbon_cap_overage"])
         for (z, p) in m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP:
             writer.writerow([
                 z,
                 p,
                 m.discount_factor[p],
                 m.number_years_represented[p],
-                float(m.carbon_cap_target_mmt[z, p]),
-                value(m.Total_Carbon_Emissions_from_All_Sources_Expression[z, p]
-                      / 10**6),
-                value(m.Carbon_Cap_Overage_MMt_Expression[z, p])# MMT
+                float(m.carbon_cap_target[z, p]),
+                value(m.Total_Carbon_Emissions_from_All_Sources_Expression[z, p]),
+                value(m.Carbon_Cap_Overage_Expression[z, p])
             ])
 
 
@@ -123,8 +123,8 @@ def import_results_into_database(
     # clearing prior results)
     nullify_sql = """
         UPDATE results_system_carbon_emissions
-        SET total_emissions_mmt = NULL,
-        carbon_cap_overage_mmt = NULL
+        SET total_emissions = NULL,
+        carbon_cap_overage = NULL
         WHERE scenario_id = ?
         AND subproblem_id = ?
         AND stage_id = ?;
@@ -145,19 +145,19 @@ def import_results_into_database(
             period = row[1]
             discount_factor = row[2]
             number_years = row[3]
-            total_emissions_mmt = row[5]
+            total_emissions = row[5]
             overage = row[6]
             
             results.append(
-                (total_emissions_mmt, overage, discount_factor, number_years,
+                (total_emissions, overage, discount_factor, number_years,
                  scenario_id, carbon_cap_zone, period,
                  subproblem, stage)
             )
 
     total_sql = """
         UPDATE results_system_carbon_emissions
-        SET total_emissions_mmt = ?,
-        carbon_cap_overage_mmt = ?,
+        SET total_emissions = ?,
+        carbon_cap_overage = ?,
         discount_factor = ?,
         number_years_represented = ?
         WHERE scenario_id = ?
@@ -190,10 +190,10 @@ def import_results_into_database(
         AND stage_id = ?;"""
     spin_on_database_lock(conn=db, cursor=c, sql=duals_sql, data=duals_results)
 
-    # Calculate marginal carbon cost per MMt
+    # Calculate marginal carbon cost per emission
     mc_sql = """
         UPDATE results_system_carbon_emissions
-        SET carbon_cap_marginal_cost_per_mmt = 
+        SET carbon_cap_marginal_cost_per_emission = 
         dual / (discount_factor * number_years_represented)
         WHERE scenario_id = ?
         AND subproblem_id = ?

--- a/gridpath/system/policy/carbon_cap/carbon_cap.py
+++ b/gridpath/system/policy/carbon_cap/carbon_cap.py
@@ -22,7 +22,7 @@ def add_model_components(m, d):
 
     m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP = \
         Set(dimen=2, within=m.CARBON_CAP_ZONES * m.PERIODS)
-    m.carbon_cap_target_mmt = Param(
+    m.carbon_cap_target = Param(
         m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP,
         within=NonNegativeReals)
 
@@ -41,9 +41,9 @@ def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     data_portal.load(filename=os.path.join(scenario_directory, str(subproblem), str(stage),
                                            "inputs", "carbon_cap.tab"),
                      index=m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP,
-                     param=m.carbon_cap_target_mmt,
+                     param=m.carbon_cap_target,
                      select=("carbon_cap_zone", "period",
-                             "carbon_cap_target_mmt")
+                             "carbon_cap_target")
                      )
 
 
@@ -59,7 +59,7 @@ def get_inputs_from_database(subscenarios, subproblem, stage, conn):
     stage = 1 if stage == "" else stage
     c = conn.cursor()
     carbon_cap_targets = c.execute(
-        """SELECT carbon_cap_zone, period, carbon_cap_mmt
+        """SELECT carbon_cap_zone, period, carbon_cap
         FROM inputs_system_carbon_cap_targets
         JOIN
         (SELECT period
@@ -123,7 +123,7 @@ def write_model_inputs(scenario_directory, subscenarios, subproblem, stage, conn
 
         # Write header
         writer.writerow(
-            ["carbon_cap_zone", "period", "carbon_cap_target_mmt"]
+            ["carbon_cap_zone", "period", "carbon_cap_target"]
         )
 
         for row in carbon_cap_targets:

--- a/tests/geography/test_carbon_cap_zones.py
+++ b/tests/geography/test_carbon_cap_zones.py
@@ -107,7 +107,7 @@ class TestCarbonCapZones(unittest.TestCase):
         )
         actual_penalty = OrderedDict(
             sorted(
-                {z: instance.carbon_cap_violation_penalty_per_mmt[z]
+                {z: instance.carbon_cap_violation_penalty_per_emission[z]
                  for z in instance.CARBON_CAP_ZONES}.items()
             )
         )

--- a/tests/system/policy/carbon_cap/test_carbon_cap.py
+++ b/tests/system/policy/carbon_cap/test_carbon_cap.py
@@ -93,14 +93,14 @@ class TestCarbonCap(unittest.TestCase):
         self.assertListEqual(expected_cc_zone_periods,
                              actual_cc_zone_periods)
 
-        # Param: carbon_cap_target_mmt
+        # Param: carbon_cap_target
         expected_cc_target = OrderedDict(sorted({
             ("Carbon_Cap_Zone1", 2020): 50, ("Carbon_Cap_Zone1", 2030): 50,
             ("Carbon_Cap_Zone2", 2020): 10, ("Carbon_Cap_Zone2", 2030): 10}.items()
                                                  )
                                           )
         actual_cc_target = OrderedDict(sorted({
-            (z, p): instance.carbon_cap_target_mmt[z, p]
+            (z, p): instance.carbon_cap_target[z, p]
             for (z, p) in instance.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP}.items()
                                                )
                                         )

--- a/tests/test_data/inputs/carbon_cap.tab
+++ b/tests/test_data/inputs/carbon_cap.tab
@@ -1,4 +1,4 @@
-carbon_cap_zone	period	carbon_cap_target_mmt
+carbon_cap_zone	period	carbon_cap_target
 Carbon_Cap_Zone1	2020	50
 Carbon_Cap_Zone1	2030	50
 Carbon_Cap_Zone2	2020	10

--- a/viz/carbon_plot.py
+++ b/viz/carbon_plot.py
@@ -75,11 +75,11 @@ def get_plotting_data(conn, scenario_id, carbon_cap_zone, subproblem, stage,
     sql = """
         SELECT 
             period, 
-            carbon_cap_mmt, 
-            in_zone_project_emissions_mmt, 
-            import_emissions_mmt_degen, 
-            total_emissions_mmt_degen,
-            carbon_cap_marginal_cost_per_mmt
+            carbon_cap, 
+            in_zone_project_emissions, 
+            import_emissions_degen, 
+            total_emissions_degen,
+            carbon_cap_marginal_cost_per_emission
         FROM results_system_carbon_emissions
         WHERE scenario_id = ?
         AND carbon_cap_zone = ?
@@ -97,20 +97,20 @@ def get_plotting_data(conn, scenario_id, carbon_cap_zone, subproblem, stage,
     # df = pd.DataFrame(
     #     data=[[2018, 50, 40, 5, 45, 0],
     #           [2020, 20, 15, 5, 20, 100]],
-    #     columns=["period", "carbon_cap_mmt", "in_zone_project_emissions_mmt",
-    #              "import_emissions_mmt_degen", "total_emissions_mmt_degen",
-    #              "carbon_cap_marginal_cost_per_mmt"]
+    #     columns=["period", "carbon_cap", "in_zone_project_emissions",
+    #              "import_emissions_degen", "total_emissions_degen",
+    #              "carbon_cap_marginal_cost_per_emission"]
     # )
 
     # Change period type from int to string (required for categorical bar chart)
     df["period"] = df["period"].map(str)
 
     # Add project/import fractions
-    df["fraction_of_project_emissions"] = df["in_zone_project_emissions_mmt"] \
-        / df["total_emissions_mmt_degen"]
+    df["fraction_of_project_emissions"] = df["in_zone_project_emissions"] \
+        / df["total_emissions_degen"]
 
-    df["fraction_of_import_emissions"] = df["import_emissions_mmt_degen"] \
-        / df["total_emissions_mmt_degen"]
+    df["fraction_of_import_emissions"] = df["import_emissions_degen"] \
+        / df["total_emissions_degen"]
 
     return df
 
@@ -133,9 +133,9 @@ def create_plot(df, title, ylimit=None):
     # Determine column types for plotting, legend and colors
     # Order of stacked_cols will define order of stacked areas in chart
     x_col = "period"
-    line_col = "carbon_cap_mmt"
-    stacked_cols = ["in_zone_project_emissions_mmt",
-                    "import_emissions_mmt_degen"]
+    line_col = "carbon_cap"
+    stacked_cols = ["in_zone_project_emissions",
+                    "import_emissions_degen"]
 
     # Stacked Area Colors
     colors = ['#666666', "#999999"]
@@ -223,7 +223,7 @@ def create_plot(df, title, ylimit=None):
         tooltips=[
             ("Period", "@period"),
             ("Carbon Target", "@%s{0,0} MMT" % line_col),
-            ("Marginal Cost", "@carbon_cap_marginal_cost_per_mmt{0,0} $/MMT")
+            ("Marginal Cost", "@carbon_cap_marginal_cost_per_emission{0,0} $/MMT")
         ],
         renderers=[target_renderer],
         toggleable=False)


### PR DESCRIPTION
Rather than using a mixture of "tonnes" and "MMT", and converting
between the two in the code base as appropriate, we should use the same
unit everywhere so that ultimately users can choose what unit they use,
without causing conversion issues in the code base.

This commit ensures the same units are used everywhere. This is a
pre-requisite for the flexible units update (#565).