### PR TITLE
Fix Pandas deprecation warning for default dtype of empty Series

### DIFF
--- a/gridpath/project/operations/power.py
+++ b/gridpath/project/operations/power.py
@@ -174,7 +174,7 @@ def summarize_results(d, scenario_directory, subproblem, stage):
     operational_results_agg_df.columns = ["weighted_power_mwh"]
     # Add a column with the percentage of total power by load zone and tech
     operational_results_agg_df["percent_total_power"] = pd.Series(
-        index=operational_results_agg_df.index
+        index=operational_results_agg_df.index, dtype="float64"
     )
 
     # Calculate the percent of total power for each tech (by load zone

--- a/gridpath/system/policy/rps/rps_balance.py
+++ b/gridpath/system/policy/rps/rps_balance.py
@@ -164,8 +164,12 @@ def summarize_results(d, scenario_directory, subproblem, stage):
     # 2) the marginal RPS cost per MWh based on the RPS constraint duals --
     # to convert back to 'real' dollars, we need to divide by the discount
     # factor and the number of years a period represents
-    results_df["percent_curtailed"] = pd.Series(index=results_df.index)
-    results_df["rps_marginal_cost_per_mwh"] = pd.Series(index=results_df.index)
+    results_df["percent_curtailed"] = pd.Series(
+        index=results_df.index, dtype="float64"
+    )
+    results_df["rps_marginal_cost_per_mwh"] = pd.Series(
+        index=results_df.index, dtype="float64"
+    )
 
     pd.options.mode.chained_assignment = None  # default='warn'
     for indx, row in results_df.iterrows():


### PR DESCRIPTION
Pandas 1.0.3 throws the deprecation warning below, so I've addressed it here.

```DeprecationWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.```