### PR TITLE
Add MANIFEST.in file for setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include gridpath/project/operations/operational_types/opchar_param_requirements.csv


### PR DESCRIPTION
We're now relying on a non-`.py` file to load some inputs for the operational types, so make sure this is packaged up on setup. We were already setting `include_package_data=True` in the setup script.

See https://python-packaging.readthedocs.io/en/latest/non-code-files.html.

Note: it's an open question which non-`.py` files should be included as part of an eventual distribution, i.e. which functionality should be part of the distribution. For now, the database, example, and testing CSV/tab files (the main components that have non-`.py` files) are not part of what we package up.
