### PR TITLE
Write startup type linked inputs only if needed

### DIFF
--- a/gridpath/project/operations/operational_types/gen_commit_bin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_bin.py
@@ -2432,36 +2432,42 @@ def export_linked_subproblem_inputs(
                             )
                     ])
             # Export params by project, timepoint, and startup type
-            with open(os.path.join(
-                    scenario_directory, next_subproblem, stage, "inputs",
-                    "gen_commit_bin_linked_timepoint_str_type_params.tab"
-            ), "w", newline=""
-            ) as f:
-                writer = csv.writer(f, delimiter="\t", lineterminator="\n")
-                writer.writerow(
-                    ["project", "linked_timepoint", "startup_type",
-                     "linked_provide_power_startup",
-                     "linked_startup_ramp_rate_mw_per_tmp"]
-                )
-                for (p, tmp, s) in sorted(
-                        mod.GEN_COMMIT_BIN_OPR_TMPS_STR_TYPES):
-                    if tmp in tmps_to_link:
-                        writer.writerow([
-                            p,
-                            tmp_linked_tmp_dict[tmp],
-                            s,
-                            max(value(
-                                mod.GenCommitBin_Provide_Power_Startup_MW[
-                                    p, tmp, s]),
-                                0
-                                ),
-                            max(value(
-                                mod.
-                                GenCommitBin_Startup_Ramp_Rate_MW_Per_Tmp[
-                                    p, tmp, s]),
-                                0
-                                )
-                        ])
+            # Only write this file if there are data for these results to
+            # avoid throwing an index error when trying to load these inputs
+            # into the next subproblem
+            if mod.GEN_COMMIT_BIN_OPR_TMPS_STR_TYPES:
+                with open(os.path.join(
+                        scenario_directory, next_subproblem, stage, "inputs",
+                        "gen_commit_bin_linked_timepoint_str_type_params.tab"
+                ), "w", newline=""
+                ) as f:
+                    writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+                    writer.writerow(
+                        ["project", "linked_timepoint", "startup_type",
+                         "linked_provide_power_startup",
+                         "linked_startup_ramp_rate_mw_per_tmp"]
+                    )
+                    for (p, tmp, s) in sorted(
+                            mod.GEN_COMMIT_BIN_OPR_TMPS_STR_TYPES):
+                        if tmp in tmps_to_link:
+                            writer.writerow([
+                                p,
+                                tmp_linked_tmp_dict[tmp],
+                                s,
+                                max(value(
+                                    mod.GenCommitBin_Provide_Power_Startup_MW[
+                                        p, tmp, s]),
+                                    0
+                                    ),
+                                max(value(
+                                    mod.
+                                    GenCommitBin_Startup_Ramp_Rate_MW_Per_Tmp[
+                                        p, tmp, s]),
+                                    0
+                                    )
+                            ])
+            else:
+                pass
     else:
         pass
 

--- a/gridpath/project/operations/operational_types/gen_commit_lin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_lin.py
@@ -2415,34 +2415,40 @@ def export_linked_subproblem_inputs(
                             )
                     ])
             # Export params by project, timepoint, and startup type
-            with open(os.path.join(
-                    scenario_directory, next_subproblem, stage, "inputs",
-                    "gen_commit_lin_linked_timepoint_str_type_params.tab"
-            ), "w", newline=""
-            ) as f:
-                writer = csv.writer(f, delimiter="\t", lineterminator="\n")
-                writer.writerow(
-                    ["project", "linked_timepoint", "startup_type",
-                     "linked_provide_power_startup",
-                     "linked_startup_ramp_rate_mw_per_tmp"]
-                )
-                for (p, tmp, s) in sorted(
-                        mod.GEN_COMMIT_LIN_OPR_TMPS_STR_TYPES):
-                    if tmp in tmps_to_link:
-                        writer.writerow([
-                            p,
-                            tmp_linked_tmp_dict[tmp],
-                            s,
-                            value(
-                                mod.GenCommitLin_Provide_Power_Startup_MW[
-                                    p, tmp, s]
-                            ),
-                            value(
-                                mod.
-                                GenCommitLin_Startup_Ramp_Rate_MW_Per_Tmp[
-                                    p, tmp, s]
-                            )
-                        ])
+            # Only write this file if there are data for these results to
+            # avoid throwing an index error when trying to load these inputs
+            # into the next subproblem
+            if mod.GEN_COMMIT_LIN_OPR_TMPS_STR_TYPES:
+                with open(os.path.join(
+                        scenario_directory, next_subproblem, stage, "inputs",
+                        "gen_commit_lin_linked_timepoint_str_type_params.tab"
+                ), "w", newline=""
+                ) as f:
+                    writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+                    writer.writerow(
+                        ["project", "linked_timepoint", "startup_type",
+                         "linked_provide_power_startup",
+                         "linked_startup_ramp_rate_mw_per_tmp"]
+                    )
+                    for (p, tmp, s) in sorted(
+                            mod.GEN_COMMIT_LIN_OPR_TMPS_STR_TYPES):
+                        if tmp in tmps_to_link:
+                            writer.writerow([
+                                p,
+                                tmp_linked_tmp_dict[tmp],
+                                s,
+                                value(
+                                    mod.GenCommitLin_Provide_Power_Startup_MW[
+                                        p, tmp, s]
+                                ),
+                                value(
+                                    mod.
+                                    GenCommitLin_Startup_Ramp_Rate_MW_Per_Tmp[
+                                        p, tmp, s]
+                                )
+                            ])
+            else:
+                pass
     else:
         pass
 


### PR DESCRIPTION
Only write the by-startup-type linked input file if there are data for these results to avoid throwing an index error when trying to load these inputs into the next subproblem.