### PR TITLE
Clear results before import

### DIFF
--- a/gridpath/import_scenario_results.py
+++ b/gridpath/import_scenario_results.py
@@ -22,6 +22,7 @@ from gridpath.auxiliary.auxiliary import get_scenario_id_and_name
 from gridpath.common_functions import determine_scenario_directory, \
     get_db_parser, get_required_e2e_arguments_parser
 from db.common_functions import connect_to_database
+from db.utilities.scenario import delete_scenario_results
 from gridpath.auxiliary.module_list import determine_modules, load_modules
 from gridpath.auxiliary.scenario_chars import SubProblems
 
@@ -149,6 +150,12 @@ def main(args=None):
     scenario_id_saved = int(sc_df.loc["scenario_id", 1])
     if scenario_id_saved != scenario_id:
         raise AssertionError("ERROR: saved scenario_id does not match")
+
+    # Delete all previous results for this scenario_id
+    # Each module also makes sure results are deleted, but this step ensures
+    # that if a scenario_id was run with different modules before, we also
+    # delete previously imported "phantom" results
+    delete_scenario_results(conn=conn, scenario_id=scenario_id)
 
     # Go through modules
     modules_to_use = determine_modules(scenario_directory=scenario_directory)

--- a/ui/server/db_ops/delete_scenario.py
+++ b/ui/server/db_ops/delete_scenario.py
@@ -6,7 +6,7 @@ Clear scenario results/statuses or delete scenario completely based on input
 from the UI client.
 """
 
-from db.utilities.scenario import delete_scenario_results, delete_scenario
+from db.utilities.scenario import delete_scenario_results_and_status, delete_scenario
 from db.common_functions import connect_to_database
 
 
@@ -18,7 +18,7 @@ def clear(db_path, scenario_id):
     :return:
     """
     conn = connect_to_database(db_path=db_path)
-    delete_scenario_results(conn=conn, scenario_id=scenario_id)
+    delete_scenario_results_and_status(conn=conn, scenario_id=scenario_id)
 
 
 def delete(db_path, scenario_id):


### PR DESCRIPTION
This makes sure that all prior results for a scenario_id are deleted before importing new results. While all modules currently delete their own results before importing again, this addition takes care of the situation in which modules were changed for a scenario and perhaps not included in a subsequent run, which could result in phantom results in some tables.

Note that if using the UI, the user is required to clear all results and statuses before re-running a scenario out of abundance of caution, but this addition helps those running scenarios from the command line.