### PR TITLE
Fix numpy future warning

### DIFF
--- a/gridpath/project/operations/operational_types/common_functions.py
+++ b/gridpath/project/operations/operational_types/common_functions.py
@@ -325,7 +325,8 @@ def get_optype_param_requirements(op_type):
     df = pd.read_csv(
         os.path.join(os.path.dirname(__file__),
                      "opchar_param_requirements.csv"),
-        sep=","
+        sep=",",
+        dtype=str
     )
     # df.set_index('ID').T.to_dict('list')
     required_columns = \


### PR DESCRIPTION
Before, when running the validation I would get the following error
for test example with scenario ID 47:
```
FutureWarning: elementwise comparison failed; returning scalar,
but in the future will perform elementwise comparison
```

I found out it was caused by the gen_must_run column which doesn't
have any entries. That column will therefore not be a string, and
the boolean comparison df['op_type'] == 'op_type' results in the
FutureWarning.

Forcing all columns to be strings seems to fix this issue.

See here for more info:
https://stackoverflow.com/questions/40659212/futurewarning-elementwise-comparison-failed-returning-scalar-but-in-the-futur