### PR TITLE
Refactor opchar validation

### DIFF
--- a/gridpath/project/operations/operational_types/dr.py
+++ b/gridpath/project/operations/operational_types/dr.py
@@ -18,6 +18,8 @@ from pyomo.environ import Var, Set, Constraint, NonNegativeReals
 from gridpath.auxiliary.auxiliary import generator_subset_init
 from gridpath.project.common_functions import \
     check_if_first_timepoint, check_boundary_type
+from gridpath.project.operations.operational_types.common_functions import \
+    validate_opchars
 
 
 def add_module_specific_components(m, d):
@@ -293,3 +295,20 @@ def power_delta_rule(mod, p, tmp):
                 - mod.DR_Shift_Down_MW[
                  p, mod.prev_tmp[tmp, mod.balancing_type_project[p]]
              ])
+
+
+# Validation
+###############################################################################
+
+def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
+    """
+    Get inputs from database and validate the inputs
+    :param subscenarios: SubScenarios object with all subscenario info
+    :param subproblem:
+    :param stage:
+    :param conn: database connection
+    :return:
+    """
+
+    # Validate operational chars table inputs
+    validate_opchars(subscenarios, subproblem, stage, conn, "dr")

--- a/gridpath/project/operations/operational_types/gen_commit_bin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_bin.py
@@ -51,7 +51,7 @@ from gridpath.project.operations.operational_types.common_functions import \
     determine_relevant_timepoints, update_dispatch_results_table, \
     load_optype_module_specific_data, load_startup_chars, \
     get_startup_chars_inputs_from_database, write_tab_file_model_inputs, \
-    check_for_tmps_to_link
+    check_for_tmps_to_link, validate_opchars
 from gridpath.project.common_functions import \
     check_if_boundary_type_and_first_timepoint, \
     check_if_first_timepoint, check_if_last_timepoint, \
@@ -2543,7 +2543,6 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     """
     Get inputs from database and validate the inputs
 
-    TODO: could add data type checking here
     :param subscenarios: SubScenarios object with all subscenario info
     :param subproblem:
     :param stage:
@@ -2551,58 +2550,26 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     :return:
     """
 
+    # Validate operational chars table inputs
+    opchar_df = validate_opchars(subscenarios, subproblem, stage, conn,
+                                 "gen_commit_bin")
+
+    # Other module specific validations
     validation_results = []
 
     # Get startup chars and project inputs
     startup_chars = get_module_specific_inputs_from_database(
         subscenarios, subproblem, stage, conn)
 
-    c1 = conn.cursor()
-    projects = c1.execute(
-        """SELECT project, operational_type,
-        min_stable_level_fraction, unit_size_mw,
-        shutdown_cost_per_mw,
-        startup_fuel_mmbtu_per_mw,
-        startup_plus_ramp_up_rate,
-        shutdown_plus_ramp_down_rate,
-        min_up_time_hours, min_down_time_hours,
-        charging_efficiency, discharging_efficiency,
-        minimum_duration_hours, maximum_duration_hours
-        FROM inputs_project_portfolios
-        INNER JOIN
-        (SELECT project, operational_type,
-        min_stable_level_fraction, unit_size_mw,
-        shutdown_cost_per_mw,
-        startup_fuel_mmbtu_per_mw,
-        startup_plus_ramp_up_rate,
-        shutdown_plus_ramp_down_rate,
-        min_up_time_hours, min_down_time_hours,
-        charging_efficiency, discharging_efficiency,
-        minimum_duration_hours, maximum_duration_hours
-        FROM inputs_project_operational_chars
-        WHERE project_operational_chars_scenario_id = {}) as prj_chars
-        USING (project)
-        WHERE project_portfolio_scenario_id = {}
-        AND operational_type = '{}'""".format(
-            subscenarios.PROJECT_OPERATIONAL_CHARS_SCENARIO_ID,
-            subscenarios.PROJECT_PORTFOLIO_SCENARIO_ID,
-            "gen_commit_bin"
-        )
-    )
-
     # Convert input data to DataFrame
-    prj_df = pd.DataFrame(
-        data=projects.fetchall(),
-        columns=[s[0] for s in projects.description]
-    )
     su_df = pd.DataFrame(
         data=startup_chars.fetchall(),
         columns=[s[0] for s in startup_chars.description]
     )
 
     # Get the number of hours in the timepoint (take min if it varies)
-    c2 = conn.cursor()
-    tmp_durations = c2.execute(
+    c = conn.cursor()
+    tmp_durations = c.execute(
         """SELECT number_of_hours_in_timepoint
            FROM inputs_temporal_timepoints
            WHERE temporal_scenario_id = {}
@@ -2615,52 +2582,8 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     ).fetchall()
     hrs_in_tmp = min(tmp_durations)
 
-    # Check that min stable level is specified
-    # (not all operational types require this input)
-    req_columns = [
-        "min_stable_level_fraction",
-    ]
-    validation_errors = check_req_prj_columns(prj_df, req_columns, True,
-                                              "gen_commit_bin")
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS",
-             "inputs_project_operational_chars",
-             "High",
-             "Missing inputs",
-             error
-             )
-        )
-
-    # Check that there are no unexpected operational inputs
-    expected_na_columns = [
-        "unit_size_mw",
-        "charging_efficiency", "discharging_efficiency",
-        "minimum_duration_hours", "maximum_duration_hours"
-    ]
-    validation_errors = check_req_prj_columns(prj_df, expected_na_columns,
-                                              False,
-                                              "gen_commit_bin")
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS",
-             "inputs_project_operational_chars",
-             "Low",
-             "Unexpected inputs",
-             error
-             )
-        )
-
     # Check startup shutdown rate inputs
-    validation_errors = validate_startup_shutdown_rate_inputs(prj_df,
+    validation_errors = validate_startup_shutdown_rate_inputs(opchar_df,
                                                               su_df,
                                                               hrs_in_tmp)
     for error in validation_errors:

--- a/gridpath/project/operations/operational_types/gen_hydro.py
+++ b/gridpath/project/operations/operational_types/gen_hydro.py
@@ -30,7 +30,7 @@ from gridpath.project.common_functions import \
 from gridpath.project.operations.operational_types.common_functions import \
     update_dispatch_results_table, load_optype_module_specific_data, \
     load_hydro_opchars, get_hydro_inputs_from_database, \
-    write_tab_file_model_inputs, check_for_tmps_to_link
+    write_tab_file_model_inputs, check_for_tmps_to_link, validate_opchars
 
 
 def add_module_specific_components(m, d):
@@ -937,6 +937,9 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+
+    # Validate operational chars table inputs
+    validate_opchars(subscenarios, subproblem, stage, conn, "gen_hydro")
 
     # hydro_chars = get_module_specific_inputs_from_database(
     #     subscenarios, subproblem, stage, conn)

--- a/gridpath/project/operations/operational_types/gen_hydro_must_take.py
+++ b/gridpath/project/operations/operational_types/gen_hydro_must_take.py
@@ -25,7 +25,7 @@ from gridpath.project.common_functions import \
 from gridpath.project.operations.operational_types.common_functions import \
     load_optype_module_specific_data, load_hydro_opchars, \
     get_hydro_inputs_from_database, write_tab_file_model_inputs, \
-    check_for_tmps_to_link
+    check_for_tmps_to_link, validate_opchars
 
 
 def add_module_specific_components(m, d):
@@ -784,6 +784,10 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+
+    # Validate operational chars table inputs
+    validate_opchars(subscenarios, subproblem, stage, conn,
+                     "gen_hydro_must_take")
 
     # hydro_chars = get_module_specific_inputs_from_database(
     #     subscenarios, subproblem, stage, conn)

--- a/gridpath/project/operations/operational_types/gen_must_run.py
+++ b/gridpath/project/operations/operational_types/gen_must_run.py
@@ -23,11 +23,12 @@ import pandas as pd
 from pyomo.environ import Constraint, Set
 
 from gridpath.auxiliary.auxiliary import generator_subset_init, \
-    write_validation_to_database, check_req_prj_columns, \
-    check_constant_heat_rate, get_projects_by_reserve, \
-    check_projects_for_reserves
+    write_validation_to_database, check_constant_heat_rate, \
+    get_projects_by_reserve, check_projects_for_reserves
 from gridpath.auxiliary.dynamic_components import headroom_variables, \
     footroom_variables
+from gridpath.project.operations.operational_types.common_functions import \
+    validate_opchars
 
 
 def add_module_specific_components(m, d):
@@ -253,48 +254,15 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     :return:
     """
 
+    # Validate operational chars table inputs
+    opchar_df = validate_opchars(subscenarios, subproblem, stage, conn,
+                                 "gen_must_run")
+
+    # Other module specific validations
     validation_results = []
 
-    # Read in inputs to be validated
-    c1 = conn.cursor()
-    projects = c1.execute(
-        """SELECT project, operational_type,
-        fuel, min_stable_level_fraction, unit_size_mw,
-        startup_cost_per_mw, shutdown_cost_per_mw,
-        startup_fuel_mmbtu_per_mw,
-        startup_plus_ramp_up_rate,
-        shutdown_plus_ramp_down_rate,
-        ramp_up_when_on_rate,
-        ramp_down_when_on_rate,
-        min_up_time_hours, min_down_time_hours,
-        charging_efficiency, discharging_efficiency,
-        minimum_duration_hours, maximum_duration_hours
-        FROM inputs_project_portfolios
-        INNER JOIN
-        (SELECT project, operational_type,
-        fuel, min_stable_level_fraction, unit_size_mw,
-        startup_cost_per_mw, shutdown_cost_per_mw,
-        startup_fuel_mmbtu_per_mw,
-        startup_plus_ramp_up_rate,
-        shutdown_plus_ramp_down_rate,
-        ramp_up_when_on_rate,
-        ramp_down_when_on_rate,
-        min_up_time_hours, min_down_time_hours,
-        charging_efficiency, discharging_efficiency,
-        minimum_duration_hours, maximum_duration_hours
-        FROM inputs_project_operational_chars
-        WHERE project_operational_chars_scenario_id = {}) as prj_chars
-        USING (project)
-        WHERE project_portfolio_scenario_id = {}
-        AND operational_type = '{}'""".format(
-            subscenarios.PROJECT_OPERATIONAL_CHARS_SCENARIO_ID,
-            subscenarios.PROJECT_PORTFOLIO_SCENARIO_ID,
-            "gen_must_run"
-        )
-    )
-
-    c2 = conn.cursor()
-    heat_rates = c2.execute(
+    c = conn.cursor()
+    heat_rates = c.execute(
         """
         SELECT project, load_point_fraction
         FROM inputs_project_portfolios
@@ -316,44 +284,10 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     )
 
     # Convert inputs to data frame
-    df = pd.DataFrame(
-        data=projects.fetchall(),
-        columns=[s[0] for s in projects.description]
-    )
     hr_df = pd.DataFrame(
         data=heat_rates.fetchall(),
         columns=[s[0] for s in heat_rates.description]
     )
-
-    # Check that there are no unexpected operational inputs
-    expected_na_columns = [
-        "min_stable_level_fraction",
-        "unit_size_mw",
-        "startup_cost_per_mw", "shutdown_cost_per_mw",
-        "startup_fuel_mmbtu_per_mw",
-        "startup_plus_ramp_up_rate",
-        "shutdown_plus_ramp_down_rate",
-        "ramp_up_when_on_rate",
-        "ramp_down_when_on_rate",
-        "min_up_time_hours", "min_down_time_hours",
-        "charging_efficiency", "discharging_efficiency",
-        "minimum_duration_hours", "maximum_duration_hours"
-    ]
-    validation_errors = check_req_prj_columns(df, expected_na_columns, False,
-                                              "Must_run")
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS",
-             "inputs_project_operational_chars",
-             "Low",
-             "Unexpected inputs",
-             error
-             )
-        )
 
     # Check that there is only one load point (constant heat rate)
     validation_errors = check_constant_heat_rate(hr_df, "Must_run")
@@ -379,7 +313,7 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
         project_ba_id = "project_" + reserve + "_ba_scenario_id"
         table = "inputs_project_" + reserve + "_bas"
         validation_errors = check_projects_for_reserves(
-            projects_op_type=df["project"],
+            projects_op_type=opchar_df["project"],
             projects_w_ba=projects,
             operational_type="gen_must_run",
             reserve=reserve

--- a/gridpath/project/operations/operational_types/gen_var.py
+++ b/gridpath/project/operations/operational_types/gen_var.py
@@ -32,7 +32,8 @@ from gridpath.project.common_functions import \
     check_if_first_timepoint, check_boundary_type
 from gridpath.project.operations.operational_types.common_functions import \
     update_dispatch_results_table, load_var_profile_inputs, \
-    get_var_profile_inputs_from_database, write_tab_file_model_inputs
+    get_var_profile_inputs_from_database, write_tab_file_model_inputs, \
+    validate_opchars
 
 
 def add_module_specific_components(m, d):
@@ -646,6 +647,10 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     :param conn: database connection
     :return:
     """
+
+    # Validate operational chars table inputs
+    validate_opchars(subscenarios, subproblem, stage, conn, "gen_var")
+
 
     # variable_profiles = get_module_specific_inputs_from_database(
     #     subscenarios, subproblem, stage, conn

--- a/gridpath/project/operations/operational_types/gen_var_must_take.py
+++ b/gridpath/project/operations/operational_types/gen_var_must_take.py
@@ -8,8 +8,6 @@ not allowed. Second, because the project's output is not controllable, projects
 of this operational type cannot provide operational reserves .
 """
 
-import csv
-import os.path
 from pyomo.environ import Param, Set, NonNegativeReals, Constraint
 import warnings
 
@@ -22,7 +20,7 @@ from gridpath.project.common_functions import \
     check_if_first_timepoint, check_boundary_type
 from gridpath.project.operations.operational_types.common_functions import \
     load_var_profile_inputs, get_var_profile_inputs_from_database, \
-    write_tab_file_model_inputs
+    write_tab_file_model_inputs, validate_opchars
 
 
 def add_module_specific_components(m, d):
@@ -367,31 +365,17 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     :return:
     """
 
+    # Validate operational chars table inputs
+    opchar_df = validate_opchars(subscenarios, subproblem, stage, conn,
+                                 "gen_var_must_take")
+
+    # Other module specific validations
     validation_results = []
 
     # TODO: validate timepoints: make sure timepoints specified are consistent
     #   with the temporal timepoints (more is okay, less is not)
     # variable_profiles = get_module_specific_inputs_from_database(
     #     subscenarios, subproblem, stage, conn)
-
-    # Get list of gen_var_must_take projects
-    c = conn.cursor()
-    var_projects = c.execute(
-        """SELECT project
-        FROM inputs_project_portfolios
-        INNER JOIN
-        (SELECT project, operational_type
-        FROM inputs_project_operational_chars
-        WHERE project_operational_chars_scenario_id = {}) as prj_chars
-        USING (project)
-        WHERE project_portfolio_scenario_id = {}
-        AND operational_type = '{}'""".format(
-            subscenarios.PROJECT_OPERATIONAL_CHARS_SCENARIO_ID,
-            subscenarios.PROJECT_PORTFOLIO_SCENARIO_ID,
-            "gen_var_must_take"
-        )
-    )
-    var_projects = [p[0] for p in var_projects.fetchall()]
 
     # Check that the project does not show up in any of the
     # inputs_project_reserve_bas tables since gen_var_must_take can't
@@ -401,7 +385,7 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
         project_ba_id = "project_" + reserve + "_ba_scenario_id"
         table = "inputs_project_" + reserve + "_bas"
         validation_errors = check_projects_for_reserves(
-            projects_op_type=var_projects,
+            projects_op_type=opchar_df["project"].tolist(),
             projects_w_ba=projects,
             operational_type="gen_var_must_take",
             reserve=reserve

--- a/gridpath/project/operations/operational_types/stor.py
+++ b/gridpath/project/operations/operational_types/stor.py
@@ -19,12 +19,11 @@ and/or downward reserves.
 Costs for this operational type include variable O&M costs.
 
 """
+
 from __future__ import division
 
-from builtins import zip
 import csv
 import os.path
-import pandas as pd
 from pyomo.environ import Var, Set, Constraint, Param, Expression, \
     NonNegativeReals, PercentFraction, value
 
@@ -34,7 +33,7 @@ from gridpath.auxiliary.dynamic_components import headroom_variables, \
 from gridpath.project.common_functions import \
     check_if_first_timepoint, check_boundary_type
 from gridpath.project.operations.operational_types.common_functions import \
-    load_optype_module_specific_data, check_for_tmps_to_link
+    load_optype_module_specific_data, check_for_tmps_to_link, validate_opchars
 
 
 def add_module_specific_components(m, d):
@@ -773,3 +772,17 @@ def export_module_specific_results(mod, d,
                         max(value(mod.Stor_Discharge_MW[p, tmp]), 0),
                         max(value(mod.Stor_Charge_MW[p, tmp]), 0)
                     ])
+
+
+def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
+    """
+    Get inputs from database and validate the inputs
+    :param subscenarios: SubScenarios object with all subscenario info
+    :param subproblem:
+    :param stage:
+    :param conn: database connection
+    :return:
+    """
+
+    # Validate operational chars table inputs
+    validate_opchars(subscenarios, subproblem, stage, conn, "stor")


### PR DESCRIPTION
This PR refactors some of the input validations for the operational characteristics, namely the checking of required and non-applicable inputs, and the checking of the datatypes. It uses the `opchar_param_requirement.csv` to determine which operating characteristics are resp. required/optional/not required.

This update does raise some questions on the operational characteristics that are not loaded within the individual modules, namely the VOM and fuel (see `#TODO` notes in code). It's a bit awkward/inconsistent on how to deal with these inputs being read in and validated in a separate place. I think ideally we load them in within the individual operational characteristics modules, as discussed in #590. 
Once these are properly aligned, we can consolidate the input validations in project.init into this same validate_opchar function as well, and we might also be able to only hard-code the expected columns in the opchar table once, which will make it easier to maintain this piece of the code (now the expected column names show up in a bunch of SQL queries). 