### PR TITLE
Refactor write_validation_to_database function

### DIFF
--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -154,12 +154,10 @@ scenario_id INTEGER,
 subproblem_id INTEGER,
 stage_id INTEGER,
 gridpath_module VARCHAR(64),
-related_subscenario VARCHAR(64),
-related_database_table VARCHAR(64),
-issue_severity VARCHAR(32),
-issue_type VARCHAR(32),
-issue_description VARCHAR(64),
-timestamp TEXT,  -- ISO8601 String
+db_table VARCHAR(64),
+severity VARCHAR(32),
+description VARCHAR(64),
+time_stamp TEXT,  -- ISO8601 String
 FOREIGN KEY (scenario_id) REFERENCES scenarios (scenario_id)
 );
 

--- a/gridpath/project/__init__.py
+++ b/gridpath/project/__init__.py
@@ -338,7 +338,6 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     """
 
     c = conn.cursor()
-    validation_results = []
 
     # Get the project inputs
     projects = get_inputs_from_database(subscenarios, subproblem, stage, conn)
@@ -358,57 +357,48 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     )
 
     dtype_errors, error_columns = check_dtypes(df, expected_dtypes)
-    for error in dtype_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS, PROJECT_PORTFOLIO",
-             "inputs_project_operational_chars, inputs_project_portfolios",
-             "High",
-             "Invalid data type",
-             error
-             )
-        )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_operational_chars, inputs_project_portfolios",
+        severity="High",
+        errors=dtype_errors
+    )
 
     # Check valid numeric columns are non-negative
     numeric_columns = [c for c in df.columns if expected_dtypes[c] == "numeric"]
     valid_numeric_columns = set(numeric_columns) - set(error_columns)
-    sign_errors = check_column_sign_positive(df, valid_numeric_columns)
-    for error in sign_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS",
-             "inputs_project_operational_chars",
-             "High",
-             "Invalid numeric sign",
-             error
-             )
-        )
+
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_operational_chars",
+        severity="High",
+        errors=check_column_sign_positive(df, valid_numeric_columns)
+    )
 
     # Check that we're not combining incompatible cap-types and op-types
     invalid_combos = c.execute(
         """SELECT capacity_type, operational_type 
         FROM mod_capacity_and_operational_type_invalid_combos"""
     ).fetchall()
-    validation_errors = validate_op_cap_combos(df, invalid_combos)
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS, PROJECT_PORTFOLIO",
-             "inputs_project_operational_chars, inputs_project_portfolios",
-             "High",
-             "Invalid combination of capacity type and operational type",
-             error
-             )
-        )
+
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_operational_chars, inputs_project_portfolios",
+        severity="High",
+        errors=validate_op_cap_combos(df, invalid_combos)
+    )
 
     # Check that capacity type is valid
     # Note: foreign key already ensures this!
@@ -416,20 +406,17 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
         """SELECT capacity_type from mod_capacity_types"""
     ).fetchall()
     valid_cap_types = [v[0] for v in valid_cap_types]
-    validation_errors = check_prj_column(df, "capacity_type", valid_cap_types)
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_PORTFOLIO",
-             "inputs_project_portfolios",
-             "High",
-             "Invalid capacity type",
-             error
-             )
-        )
+
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_portfolios",
+        severity="High",
+        errors=check_prj_column(df, "capacity_type", valid_cap_types)
+    )
 
     # Check that operational type is valid
     # Note: foreign key already ensures this!
@@ -437,23 +424,17 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
         """SELECT operational_type from mod_operational_types"""
     ).fetchall()
     valid_op_types = [v[0] for v in valid_op_types]
-    validation_errors = check_prj_column(df, "operational_type", valid_op_types)
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS",
-             "inputs_project_operational_chars",
-             "High",
-             "Invalid operational type",
-             error
-             )
-        )
 
-    # Write all input validation errors to database
-    write_validation_to_database(validation_results, conn)
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_portfolios",
+        severity="High",
+        errors=check_prj_column(df, "operational_type", valid_op_types)
+    )
 
 
 def validate_op_cap_combos(df, invalid_combos):

--- a/gridpath/project/fuels.py
+++ b/gridpath/project/fuels.py
@@ -169,8 +169,6 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     :return:
     """
 
-    validation_results = []
-
     # Get the fuel input data
     fuels, fuel_prices = get_inputs_from_database(
         subscenarios, subproblem, stage, conn)
@@ -223,69 +221,52 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     )
 
     dtype_errors, error_columns = check_dtypes(fuels_df, expected_dtypes)
-    for error in dtype_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_FUELS",
-             "inputs_project_fuels",
-             "High,"
-             "Invalid data type",
-             error
-             )
-        )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_fuels",
+        severity="High",
+        errors=dtype_errors
+    )
 
     dtype_errors, error_columns = check_dtypes(fuel_prices_df, expected_dtypes)
-    for error in dtype_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_FUEL_PRICES",
-             "inputs_project_fuel_prices",
-             "High",
-             "Invalid data type",
-             error
-             )
-        )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_fuel_prices",
+        severity="High",
+        errors=dtype_errors
+    )
 
     # Check that fuels specified for projects exist in fuels table
-    validation_errors = validate_fuel_projects(prj_df, fuels_df)
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS",
-             "inputs_project_operational_chars",
-             "High",
-             "Non existent fuel",
-             error)
-        )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_operational_chars",
+        severity="High",
+        errors=validate_fuel_projects(prj_df, fuels_df)
+    )
 
     # Check that fuel prices exist for the period and month
-    validation_errors = validate_fuel_prices(fuels_df, fuel_prices_df,
-                                             periods_months)
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_FUEL_PRICES",
-             "inputs_project_fuel_prices",
-             "High",
-             "Missing fuel price",
-             error
-             )
-        )
-
-    # Write all input validation errors to database
-    write_validation_to_database(validation_results, conn)
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_fuel_prices",
+        severity="High",
+        errors=validate_fuel_prices(fuels_df, fuel_prices_df, periods_months)
+    )
 
 
 def validate_fuel_projects(prj_df, fuels_df):

--- a/gridpath/project/operations/operational_types/common_functions.py
+++ b/gridpath/project/operations/operational_types/common_functions.py
@@ -987,8 +987,6 @@ def validate_opchars(subscenarios, subproblem, stage, conn, op_type):
     # TODO: deal with fuel and variable O&M column, which are nor optional nor
     #  required for any?
 
-    validation_results = []
-
     # Get the opchar inputs for this operational type
     df = get_optype_inputs_from_db(subscenarios, conn, op_type)
 
@@ -999,42 +997,31 @@ def validate_opchars(subscenarios, subproblem, stage, conn, op_type):
     na_cols = other_columns_types.keys()
 
     # Check that required inputs are present
-    req_errors = check_req_prj_columns(df, req_cols, True, op_type)
-    for error in req_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS",
-             "inputs_project_operational_chars",
-             "High",
-             "Missing inputs",
-             error
-             )
-        )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_operational_chars",
+        severity="High",
+        errors=check_req_prj_columns(df, req_cols, True, op_type)
+    )
 
     # Check that other (not required or optional) inputs are not present
-    na_errors = check_req_prj_columns(df, na_cols, False, op_type)
-    for error in na_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS",
-             "inputs_project_operational_chars",
-             "Low",
-             "Unexpected inputs",
-             error
-             )
-        )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_operational_chars",
+        severity="Low",
+        errors=check_req_prj_columns(df, na_cols, False, op_type)
+    )
 
     # TODO: do data-type and numeric non-negativity checking here rather than
     #  in project.init?
 
-    # Write all input validation errors to database
-    write_validation_to_database(validation_results, conn)
-
-    # Return the opchar_df (sometimes used for further validations)
+    # Return the opchar df (sometimes used for further validations)
     return df

--- a/gridpath/project/operations/operational_types/gen_commit_bin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_bin.py
@@ -2555,7 +2555,6 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
                                  "gen_commit_bin")
 
     # Other module specific validations
-    validation_results = []
 
     # Get startup chars and project inputs
     startup_chars = get_module_specific_inputs_from_database(
@@ -2583,22 +2582,17 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     hrs_in_tmp = min(tmp_durations)
 
     # Check startup shutdown rate inputs
-    validation_errors = validate_startup_shutdown_rate_inputs(opchar_df,
-                                                              su_df,
-                                                              hrs_in_tmp)
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS, PROJECT_STARTUP_CHARS",
-             "inputs_project_operational_chars, inputs_project_startup_chars",
-             "High",
-             "Invalid startup/shutdown ramp inputs",
-             error
-             )
-        )
+    su_errors = validate_startup_shutdown_rate_inputs(
+        opchar_df, su_df, hrs_in_tmp
+    )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_operational_chars, inputs_project_startup_chars",
+        severity="High",
+        errors=su_errors
+    )
 
-    # Write all input validation errors to database
-    write_validation_to_database(validation_results, conn)

--- a/gridpath/project/operations/operational_types/gen_commit_lin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_lin.py
@@ -2535,7 +2535,6 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
                                 "gen_commit_lin")
 
     # Other module specific validations
-    validation_results = []
 
     # Get startup chars and project inputs
     startup_chars = get_module_specific_inputs_from_database(
@@ -2563,22 +2562,17 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     hrs_in_tmp = min(tmp_durations)
 
     # Check startup shutdown rate inputs
-    validation_errors = validate_startup_shutdown_rate_inputs(opchar_df,
-                                                              su_df,
-                                                              hrs_in_tmp)
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_OPERATIONAL_CHARS, PROJECT_STARTUP_CHARS",
-             "inputs_project_operational_chars, inputs_project_startup_chars",
-             "High",
-             "Invalid startup/shutdown ramp inputs",
-             error
-             )
-        )
+    su_errors = validate_startup_shutdown_rate_inputs(
+        opchar_df, su_df, hrs_in_tmp
+    )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_operational_chars, inputs_project_startup_chars",
+        severity="High",
+        errors=su_errors
+    )
 
-    # Write all input validation errors to database
-    write_validation_to_database(validation_results, conn)

--- a/gridpath/project/operations/operational_types/gen_must_run.py
+++ b/gridpath/project/operations/operational_types/gen_must_run.py
@@ -290,47 +290,38 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     )
 
     # Check that there is only one load point (constant heat rate)
-    validation_errors = check_constant_heat_rate(hr_df, "Must_run")
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_HEAT_RATE_CURVES",
-             "inputs_project_heat_rate_curves",
-             "Mid",
-             "Too many load points",
-             error
-             )
-        )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_heat_rate_curves",
+        severity="Mid",
+        errors=check_constant_heat_rate(hr_df, "gen_must_run")
+    )
 
     # Check that the project does not show up in any of the
     # inputs_project_reserve_bas tables since gen_must_run can't provide any
     # reserves
     projects_by_reserve = get_projects_by_reserve(subscenarios, conn)
     for reserve, projects in projects_by_reserve.items():
-        project_ba_id = "project_" + reserve + "_ba_scenario_id"
         table = "inputs_project_" + reserve + "_bas"
-        validation_errors = check_projects_for_reserves(
+        reserve_errors = check_projects_for_reserves(
             projects_op_type=opchar_df["project"],
             projects_w_ba=projects,
             operational_type="gen_must_run",
             reserve=reserve
         )
-        for error in validation_errors:
-            validation_results.append(
-                (subscenarios.SCENARIO_ID,
-                 subproblem,
-                 stage,
-                 __name__,
-                 project_ba_id.upper(),
-                 table,
-                 "Mid",
-                 "Invalid {} BA inputs".format(reserve),
-                 error
-                 )
-            )
 
-    # Write all input validation errors to database
-    write_validation_to_database(validation_results, conn)
+        write_validation_to_database(
+            conn=conn,
+            scenario_id=subscenarios.SCENARIO_ID,
+            subproblem_id=subproblem,
+            stage_id=stage,
+            gridpath_module=__name__,
+            db_table=table,
+            severity="Mid",
+            errors=reserve_errors
+        )
+

--- a/gridpath/project/operations/operational_types/gen_simple.py
+++ b/gridpath/project/operations/operational_types/gen_simple.py
@@ -652,21 +652,14 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     )
 
     # Check that there is only one load point (constant heat rate)
-    validation_errors = check_constant_heat_rate(hr_df,
-                                                 "gen_simple")
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "PROJECT_HEAT_RATE_CURVES",
-             "inputs_project_heat_rate_curves",
-             "Mid",
-             "Too many load points",
-             error
-             )
-        )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_heat_rate_curves",
+        severity="Mid",
+        errors=check_constant_heat_rate(hr_df, "gen_simple")
+    )
 
-    # Write all input validation errors to database
-    write_validation_to_database(validation_results, conn)

--- a/gridpath/project/operations/operational_types/gen_var_must_take.py
+++ b/gridpath/project/operations/operational_types/gen_var_must_take.py
@@ -382,27 +382,21 @@ def validate_module_specific_inputs(subscenarios, subproblem, stage, conn):
     # provide any reserves
     projects_by_reserve = get_projects_by_reserve(subscenarios, conn)
     for reserve, projects in projects_by_reserve.items():
-        project_ba_id = "project_" + reserve + "_ba_scenario_id"
         table = "inputs_project_" + reserve + "_bas"
-        validation_errors = check_projects_for_reserves(
+        reserve_errors = check_projects_for_reserves(
             projects_op_type=opchar_df["project"].tolist(),
             projects_w_ba=projects,
             operational_type="gen_var_must_take",
             reserve=reserve
         )
-        for error in validation_errors:
-            validation_results.append(
-                (subscenarios.SCENARIO_ID,
-                 subproblem,
-                 stage,
-                 __name__,
-                 project_ba_id.upper(),
-                 table,
-                 "Mid",
-                 "Invalid {} BA inputs".format(reserve),
-                 error
-                 )
-            )
 
-    # Write all input validation errors to database
-    write_validation_to_database(validation_results, conn)
+        write_validation_to_database(
+            conn=conn,
+            scenario_id=subscenarios.SCENARIO_ID,
+            subproblem_id=subproblem,
+            stage_id=stage,
+            gridpath_module=__name__,
+            db_table=table,
+            severity="Mid",
+            errors=reserve_errors
+        )

--- a/gridpath/transmission/__init__.py
+++ b/gridpath/transmission/__init__.py
@@ -247,7 +247,6 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     """
 
     c = conn.cursor()
-    validation_results = []
 
     # Get the transmission inputs
     transmission_lines = get_inputs_from_database(
@@ -265,39 +264,28 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
         """SELECT capacity_type, operational_type 
         FROM mod_tx_capacity_and_tx_operational_type_invalid_combos"""
     ).fetchall()
-    validation_errors = validate_op_cap_combos(df, invalid_combos)
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "TRANSMISSION_OPERATIONAL_CHARS, TRANSMISSION_PORTFOLIOS",
-             "inputs_transmission_operational_chars, inputs_tranmission_portfolios",
-             "High",
-             "Invalid combination of capacity type and operational type",
-             error
-             )
-        )
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_transmission_operational_chars, inputs_tranmission_portfolios",
+        severity="High",
+        errors=validate_op_cap_combos(df, invalid_combos)
+    )
 
     # Check reactance > 0
-    validation_errors = validate_reactance(df)
-    for error in validation_errors:
-        validation_results.append(
-            (subscenarios.SCENARIO_ID,
-             subproblem,
-             stage,
-             __name__,
-             "TRANSMISSION_OPERATIONAL_CHARS",
-             "inputs_transmission_operational_chars",
-             "High",
-             "Invalid reactance inputs",
-             error
-             )
-        )
-
-    # Write all input validation errors to database
-    write_validation_to_database(validation_results, conn)
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_transmission_operational_chars",
+        severity="High",
+        errors=validate_reactance(df)
+    )
 
 
 def validate_op_cap_combos(df, invalid_combos):


### PR DESCRIPTION
When we were writing out validation results to the status_validation table, we had to construct a list of validation errors, where each validation error was a list of tuples, and then feed this to the `write_validation_to_database()` function. To make this process a little less verbose, and to make it more explicit what we are passing to the writing function, I refactored the function to take in the list of validation errors, and the associated meta-data (what module, what database table, etc.) and have it create the database rows inside the function. If there are no errors (empty list), the function does nothing. 

I also simplified the status_validation schema somewhat by removing redundant columns (subscenario, and issue_type) and shortening the column headers. 