### PR TITLE
Add project validations

### DIFF
--- a/gridpath/auxiliary/validations.py
+++ b/gridpath/auxiliary/validations.py
@@ -411,6 +411,32 @@ def validate_idxs(actual_idxs, req_idxs=[], invalid_idxs=[],
     return results
 
 
+def validate_missing_inputs(df, col, idx_col="project", msg=""):
+    """
+    Check whether there aren't any NULL inputs in the specified column.
+    :param df:
+    :param col: str or list of str
+    :param idx_col: str
+    :param msg: str
+    :return:
+    """
+
+    results = []
+
+    cols = [col] if isinstance(col, str) else col
+    for c in cols:
+        invalids = df[c].isnull()
+        if invalids.any():
+            bad_idxs = df[idx_col][invalids].astype(str)
+            print_bad_idxs = ", ".join(bad_idxs)
+            results.append(
+                "Missing {} inputs for {}(s): {}. {}"
+                .format(c, idx_col, print_bad_idxs, msg)
+            )
+
+    return results
+
+
 def validate_single_input(df, idx_col="project", msg=""):
     """
     Check whether there is only 1 input per index.

--- a/gridpath/project/__init__.py
+++ b/gridpath/project/__init__.py
@@ -16,7 +16,8 @@ from gridpath.auxiliary.dynamic_components import required_capacity_modules, \
     required_availability_modules, required_operational_modules, \
     headroom_variables, footroom_variables
 from gridpath.auxiliary.validations import write_validation_to_database, \
-    validate_dtypes, get_expected_dtypes, validate_signs, validate_columns
+    validate_dtypes, get_expected_dtypes, validate_signs, validate_columns, \
+    validate_missing_inputs
 
 
 def determine_dynamic_components(d, scenario_directory, subproblem, stage):
@@ -437,4 +438,51 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
         severity="High",
         errors=validate_columns(df, "operational_type", valids=valid_op_types)
     )
+
+    # Check that all portfolio projects are present in the availability inputs
+    msg = "All projects in the portfolio should have an availability type " \
+          "specified in the inputs_project_availability table."
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_availability",
+        severity="High",
+        errors=validate_missing_inputs(df, "availability_type", msg=msg)
+    )
+
+    # Check that all portfolio projects are present in the opchar inputs
+    msg = "All projects in the portfolio should have an operational type " \
+          "and balancing type specified in the " \
+          "inputs_project_operational_chars table."
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_operational_chars",
+        severity="High",
+        errors=validate_missing_inputs(df,
+                                       ["operational_type",
+                                        "balancing_type_project"],
+                                       msg=msg)
+    )
+
+    # Check that all portfolio projects are present in the load zone inputs
+    msg = "All projects in the portfolio should have a load zone " \
+          "specified in the inputs_project_load_zones table."
+    write_validation_to_database(
+        conn=conn,
+        scenario_id=subscenarios.SCENARIO_ID,
+        subproblem_id=subproblem,
+        stage_id=stage,
+        gridpath_module=__name__,
+        db_table="inputs_project_load_zones",
+        severity="High",
+        errors=validate_missing_inputs(df, "load_zone", msg=msg)
+    )
+
 

--- a/gridpath/project/availability/availability.py
+++ b/gridpath/project/availability/availability.py
@@ -188,6 +188,7 @@ def validate_inputs(subscenarios, subproblem, stage, conn):
     scenario_id = subscenarios.SCENARIO_ID
     required_opchar_modules = get_required_availability_type_modules(
         scenario_id, c)
+
     imported_operational_modules = load_availability_type_modules(
         required_opchar_modules)
 
@@ -254,7 +255,7 @@ def get_required_availability_type_modules(scenario_id, c):
             FROM 
             (SELECT project FROM inputs_project_portfolios
             WHERE project_portfolio_scenario_id = {}) as prj_tbl
-            LEFT OUTER JOIN 
+            INNER JOIN 
             (SELECT project, availability_type
             FROM inputs_project_availability
             WHERE project_availability_scenario_id = {}) as av_type_tbl

--- a/gridpath/project/operations/operational_types/__init__.py
+++ b/gridpath/project/operations/operational_types/__init__.py
@@ -124,7 +124,7 @@ def get_required_opchar_modules(scenario_id, c):
             FROM 
             (SELECT project FROM inputs_project_portfolios
             WHERE project_portfolio_scenario_id = {}) as prj_tbl
-            LEFT OUTER JOIN 
+            INNER JOIN 
             (SELECT project, operational_type
             FROM inputs_project_operational_chars
             WHERE project_operational_chars_scenario_id = {}) as op_type_tbl

--- a/tests/auxiliary/test_validations.py
+++ b/tests/auxiliary/test_validations.py
@@ -727,6 +727,50 @@ class TestValidations(unittest.TestCase):
             )
             self.assertListEqual(expected_list, actual_list)
 
+    def test_validate_missing_inputs(self):
+        """
+        :return:
+        """
+
+        cols = ["project", "capacity_type", "operational_type"]
+
+        test_cases = {
+            # Make sure a case with only basic inputs doesn't throw errors
+            1: {"df": pd.DataFrame(
+                    columns=cols,
+                    data=[["gas_ct", "cap1", "op1"],
+                          ["gas_ct2", "cap2", "op1"]]),
+                "result_cap_col": [],
+                "result_both_cols": []
+                },
+            # Make sure missing inputs are detected
+            2: {"df": pd.DataFrame(
+                columns=cols,
+                data=[["gas_ct", "cap1", "op1"],
+                      ["gas_ct2", None, None]]),
+                "result_cap_col": ["Missing capacity_type inputs for project(s): gas_ct2. "],
+                "result_both_cols": ["Missing capacity_type inputs for project(s): gas_ct2. ",
+                                     "Missing operational_type inputs for project(s): gas_ct2. "]
+                }
+        }
+
+        for test_case in test_cases.keys():
+            # single column
+            expected_list = test_cases[test_case]["result_cap_col"]
+            actual_list = module_to_test.validate_missing_inputs(
+                df=test_cases[test_case]["df"],
+                col="capacity_type"
+            )
+            self.assertListEqual(expected_list, actual_list)
+
+            # multiple columns
+            expected_list = test_cases[test_case]["result_both_cols"]
+            actual_list = module_to_test.validate_missing_inputs(
+                df=test_cases[test_case]["df"],
+                col=["capacity_type", "operational_type"]
+            )
+            self.assertListEqual(expected_list, actual_list)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
 - validate projects in inputs_project_availability contain all
 projects in the portfolio and have an availability type specified
 - validate projects in inputs_project_operational_chars contain all
 projects in the portfolio and have an operational type and balancing
 type specified
 - validate projects in inputs_project_load_zones contain all projects
 in the portfolio and have a load zone specified.

This also requires changing the LEFT OUTER JOIN statements to INNER
JOINS in get_required_opchar_modules and get_required_availability_types
such that these functions wouldn't return any "None" values when there
are missing projects. The "None" values would result in an error when
importing the modules for the import validation.

In a next step we can further expand this to other project-related
inputs such as project_prm_types, project_rps_zones,
project_carbon_cap_zones, etc. We can also add this for transmission
portfolios and the transmission op-types.

Open question:
 - in this case we still use OUTER LEFT JOINS to get the inputs table
 that we are validating (see projects.init, line 247) and we check for
 NULL values. We could also do INNER JOINS everywhere and simply compare
 the resulting projects with the expected list (the full portfolio).
 This is what we've been doing for some of the previous validations and
 would allow us to re-use the validate_idxs() validation function.
 In that case the validation would probably go in the respective
 module (e.g. in project.operational_types.init) rather than in
 project.init and we'd have create new queries to collect the data to
 validate (e.g. the projects in the portfolio and the projects in the
 operational type table for the given operational_chars_scenario_id).  