### PR TITLE
Add transmission line validations

### DIFF
--- a/gridpath/transmission/operations/operational_types/__init__.py
+++ b/gridpath/transmission/operations/operational_types/__init__.py
@@ -94,7 +94,7 @@ def get_required_tx_opchar_modules(scenario_id, c):
             FROM 
             (SELECT transmission_line FROM inputs_transmission_portfolios
             WHERE transmission_portfolio_scenario_id = {}) AS prj_tbl
-            LEFT OUTER JOIN 
+            INNER JOIN 
             (SELECT transmission_line, operational_type
             FROM inputs_transmission_operational_chars
             WHERE transmission_operational_chars_scenario_id = {}) 


### PR DESCRIPTION
Similar to #634 for projects, this PR:
 - validates inputs_transmission_operational_chars includes all tx
 lines in the portfolio and have an operational type specified
 - validates inputs_transmission_load_zones includes all tx lines
 in the portfolio and that there is a load zone to/from specified.
 - changes the LEFT OUTER JOIN statements to INNER JOIN in
 get_required_tx_opchar_modules

We also change the INNER JOIN in get_inputs_from_database to LEFT OUTER
JOIN since this is needed to ge the proper table for input validation,
and it makes sure that missing projects are caught (model error) when
running the scenario since input validation is not strictly required.