### PR TITLE
Fix continuous availability path error

### DIFF
--- a/gridpath/project/availability/availability_types/continuous.py
+++ b/gridpath/project/availability/availability_types/continuous.py
@@ -457,7 +457,7 @@ def write_module_specific_model_inputs(
     # Check if project_availability_endogenous.tab exists; only write header
     # if the file wasn't already created
     availability_file = os.path.join(
-        scenario_directory, subproblem, stage,
+        scenario_directory, subproblem, stage, "inputs",
         "project_availability_endogenous.tab"
     )
 


### PR DESCRIPTION
Path was missing the inputs subfolder. 

Note: I cherry-picked this commit from the develop branch update and added this here as a hotfix to the master branch. Let me know if this is not the right process to do this. 