### PR TITLE
Outer join example [WIP]

### DIFF
--- a/gridpath/project/capacity/capacity_types/gen_new_lin.py
+++ b/gridpath/project/capacity/capacity_types/gen_new_lin.py
@@ -424,6 +424,12 @@ def load_module_specific_data(
     :return:
     """
 
+    # TODO: would have to rewrite this simple data_portal.load statement
+    #  into more complex manual loading to filter out "." values
+    #  Would also have to check consistency with the min/max inputs to avoid
+    #  avoid having GEN_NEW_LIN_VNTS_W_MIN_CONSTRAINT be larger than
+    #  GEN_NEW_LIN_VNTS (e.g. when project has an input for min/max but
+    #  not for cost).
     # TODO: throw an error when a generator of the 'gen_new_lin' capacity
     #   type is not found in new_build_option_vintage_costs.tab
     data_portal.load(filename=
@@ -626,7 +632,7 @@ def get_module_specific_inputs_from_database(
         (SELECT period AS vintage
         FROM inputs_temporal_periods
         WHERE temporal_scenario_id = {}) as relevant_vintages
-        INNER JOIN
+        LEFT OUTER JOIN
         (SELECT project, vintage, lifetime_yrs,
         annualized_real_cost_per_mw_yr
         FROM inputs_project_new_cost


### PR DESCRIPTION
As discussed, the requirements for updating the input treatment for specified and new build projects is as follows:

- model should run if some period inputs are missing (should input validation flag this with a low severity or simply ignore since it's allowed?)
- model should fail if ALL period inputs are missing (and once we add input validations, this should be caught there as well). 
- model should not create variables and constraints for missing periods (otherwise a LEFT OUTER JOIN and using default param values could work). 

This proof of concept PR shows what would need to be done when replacing the INNER JOINS with OUTER JOINS to make sure that the model fails when appropriate:

 - replace NULL/None with "." where appropriate
 - filter out the "." values (or None values if we don't replace with ".")
 - add a check comparing the gen_spec or gen_new_lin projects with what's actually in the 
   inputs after filtering out the "." values.
 - replace data_portal.load with manual loading and filtering for "." (gen_new_len)

To me, this shows that replacing the INNER JOINS doesn't really do anything useful and just creates more work. Unless of course we think it's okay to create variables and constraints for missing periods, in which case and outer join + setting appropriate default values is probably the cleanest (although it could get tricky with the "new" generators, since setting a default cost is tricky; you'd have to force the max build to zero and make sure the constraint/params are used, even if they are not in the inputs). 