### PR TITLE
Temp fix of Pyomo version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,9 @@ setup(name="GridPath",
       ],
       packages=find_packages(),
       install_requires=[
-          "Pyomo",  # Optimization modeling language
-          "pandas",  # Data-processing
+          "Pyomo==5.6.9",  # Optimization modeling language
+          "PyUtilib==5.8.0",  # Temporary while fixing Pyomo 5.7 breaking changes
+	  "pandas",  # Data-processing
           "bokeh==1.3.4",  # Visualization library
           "pscript",  # Python to JavaScript compiler (for visualization)
           "networkx"  # network package for DC OPF


### PR DESCRIPTION
See #660 

This is just a temporary change in the Pyomo and PyUtilib version requirements in preparation for the v0.3 release. We should actually update the GridPath code to work with the latest version of Pyomo in the following release or a patch.