### PR TITLE
Fix some loose ends in the test example results

### DIFF
--- a/examples/2periods_new_build_capgroups/results/solver_status.txt
+++ b/examples/2periods_new_build_capgroups/results/solver_status.txt
@@ -1,0 +1,1 @@
+optimal

--- a/examples/2periods_new_build_rps_percent_target/results/summary_results.txt
+++ b/examples/2periods_new_build_rps_percent_target/results/summary_results.txt
@@ -26,5 +26,5 @@ Zone1     2020   Coal                       0.00           0.00
 ### RPS RESULTS ###
                  rps_target_mwh  delivered_rps_energy_mwh  curtailed_rps_energy_mwh  percent_curtailed    dual  rps_marginal_cost_per_mwh
 rps_zone period                                                                                                                          
-RPSZone1 2020              0.00                236,520.00                 31,471.11              11.74    0.00                       0.00
-         2030              0.00                219,000.00                157,096.00              41.77 -129.54                     -12.95
+RPSZone1 2020        219,000.00                236,520.00                 31,471.11              11.74    0.00                       0.00
+         2030        219,000.00                219,000.00                157,096.00              41.77 -129.54                     -12.95


### PR DESCRIPTION
Just a couple of files that need to be changed/added to the repo.

The RPS target is now correct in the summary file of the RPS example after Gerrit fixed the export to use the RPS_Target expression instead of the param.

The solver_status file was just missing from the repo.