### PR TITLE
Add objective costs table to results

### DIFF
--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -3213,6 +3213,38 @@ local_capacity_marginal_cost_per_mw FLOAT,
 PRIMARY KEY (scenario_id, local_capacity_zone, period, subproblem_id, stage_id)
 );
 
+
+-- Total Costs
+DROP TABLE IF EXISTS results_system_costs;
+CREATE TABLE  results_system_costs (
+scenario_id INTEGER,
+--period INTEGER,
+subproblem_id INTEGER,
+stage_id INTEGER,
+Total_Capacity_Costs Float,
+Total_Tx_Capacity_Costs Float,
+Total_PRM_Group_Costs Float,
+Total_Variable_OM_Cost Float,
+Total_Fuel_Cost Float,
+Total_Startup_Cost Float,
+Total_Shutdown_Cost Float,
+Total_Hurdle_Cost Float,
+Total_Load_Balance_Penalty_Costs Float,
+Frequency_Response_Penalty_Costs Float,
+LF_Reserves_Down_Penalty_Costs Float,
+LF_Reserves_Up_Penalty_Costs Float,
+Regulation_Down_Penalty_Costs Float,
+Regulation_Up_Penalty_Costs Float,
+Spinning_Reserves_Penalty_Costs Float,
+Total_PRM_Shortage_Penalty_Costs Float,
+Total_Local_Capacity_Shortage_Penalty_Costs Float,
+Total_Carbon_Cap_Balance_Penalty_Costs Float,
+Total_RPS_Balance_Penalty_Costs Float,
+Total_Dynamic_ELCC_Tuning_Cost Float,
+Total_Import_Carbon_Tuning_Cost Float,
+PRIMARY KEY (scenario_id, subproblem_id, stage_id)
+);
+
 ---------------
 --- OPTIONS ---
 ---------------

--- a/gridpath/objective/min_total_cost.py
+++ b/gridpath/objective/min_total_cost.py
@@ -6,9 +6,19 @@ This module adds an objective function to the model, minimizing total system
 cost.
 """
 
-from pyomo.environ import Objective, minimize
+import csv
+import pandas as pd
+import sqlite3
+import numpy as np
+import os
+
+
+from pyomo.environ import Objective, minimize, value
+
+from db.common_functions import spin_on_database_lock
 
 from gridpath.auxiliary.dynamic_components import total_cost_components
+from gridpath.auxiliary.auxiliary import setup_results_import
 
 
 def add_model_components(m, d):
@@ -34,3 +44,75 @@ def add_model_components(m, d):
                    for c in getattr(d, total_cost_components))
 
     m.Total_Cost = Objective(rule=total_cost_rule, sense=minimize)
+
+
+# Input-Output
+###############################################################################
+
+def export_results(scenario_directory, subproblem, stage, m, d):
+    """
+    Export objective function cost components
+    :param scenario_directory:
+    :param subproblem:
+    :param stage:
+    :param m:
+    The Pyomo abstract model
+    :param d:
+    Dynamic components
+    :return:
+    Nothing
+    """
+
+    with open(os.path.join(scenario_directory, str(subproblem), str(stage), "results",
+              "system_costs.csv"), "w", newline="") as f:
+        writer = csv.writer(f)
+        components = getattr(d, total_cost_components)
+        writer.writerow(components)
+        writer.writerow((value(getattr(m, c)) for c in components))
+
+
+# Database
+###############################################################################
+
+def import_results_into_database(
+        scenario_id, subproblem, stage, c, db, results_directory, quiet
+):
+    """
+
+    :param scenario_id:
+    :param c:
+    :param db:
+    :param results_directory:
+    :param quiet:
+    :return:
+    """
+    # Fuel burned by project and timepoint
+    if not quiet:
+        print("results system cost")
+    # Delete prior results and create temporary import table for ordering
+    setup_results_import(
+        conn=db, cursor=c,
+        table="results_system_costs",
+        scenario_id=scenario_id, subproblem=subproblem, stage=stage
+    )
+
+    df = pd.read_csv(os.path.join(results_directory, "system_costs.csv"))
+    df['scenario_id'] = scenario_id
+    df['subproblem_id'] = subproblem
+    df['stage_id'] = stage
+    results = df.to_records(index=False)
+
+    # Register numpy types with sqlite, so that they are properly inserted
+    # from pandas dataframes
+    # https://stackoverflow.com/questions/38753737/inserting-numpy-integer-types-into-sqlite-with-python3
+    sqlite3.register_adapter(np.int64, lambda val: int(val))
+    sqlite3.register_adapter(np.float64, lambda val: float(val))
+
+    insert_sql = """
+        INSERT INTO results_system_costs
+        ({})
+        VALUES ({});
+        """.format(", ".join(df.columns),
+                   ", ".join(["?"] * (len(df.columns))))
+    spin_on_database_lock(conn=db, cursor=c, sql=insert_sql, data=results)
+


### PR DESCRIPTION
This update adds a results table that lists all components of 
the objective function and their values for each scenario.

This required some small modifications to how the dynamic
components are populated. To be able to access the dynamic
component list of all cost components in the objective function
I moved the creation of any dynamically created list in the dynamic
components from `add_model_components` to 
 `determine_dynamic_components`. That way you have access 
to them without having to add the model components (and 
creating an abstract model).Let me know if you think it makes 
more sense to split out that change from the change that adds 
the cost results table. 

Note: I also moved the aggregating of the tx capacity costs from
the tx capacity module to the object module, to be consistent
with all other cost aggregations. 