### PR TITLE
Move dynamic component list alterations

### DIFF
--- a/gridpath/auxiliary/module_list.py
+++ b/gridpath/auxiliary/module_list.py
@@ -129,6 +129,7 @@ def all_modules_list():
         "objective.project.aggregate_prm_group_costs",
         "objective.project.aggregate_operational_costs",
         "objective.project.aggregate_operational_tuning_costs",
+        "objective.transmission.aggregate_capacity_costs",
         "objective.transmission.aggregate_operational_costs",
         "objective.transmission.carbon_imports_tuning_costs",
         "objective.system.aggregate_load_balance_penalties",
@@ -165,7 +166,8 @@ def optional_modules_list():
              "transmission.capacity.capacity",
              "transmission.operations.operational_types",
              "transmission.operations.operations",
-             "system.load_balance.aggregate_transmission_power"],
+             "system.load_balance.aggregate_transmission_power",
+             "objective.transmission.aggregate_capacity_costs"],
         "lf_reserves_up":
             ["geography.load_following_up_balancing_areas",
              "system.reserves.requirement.lf_reserves_up",

--- a/gridpath/objective/project/aggregate_capacity_costs.py
+++ b/gridpath/objective/project/aggregate_capacity_costs.py
@@ -11,6 +11,16 @@ from pyomo.environ import Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add total capacity costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append("Total_Capacity_Costs")
+
+
 def add_model_components(m, d):
     """
     :param m: the Pyomo abstract model object we are adding the components to
@@ -31,4 +41,3 @@ def add_model_components(m, d):
                    * mod.number_years_represented[p]
                    for (g, p) in mod.PRJ_OPR_PRDS)
     m.Total_Capacity_Costs = Expression(rule=total_capacity_cost_rule)
-    getattr(d, total_cost_components).append("Total_Capacity_Costs")

--- a/gridpath/objective/project/aggregate_operational_costs.py
+++ b/gridpath/objective/project/aggregate_operational_costs.py
@@ -11,13 +11,25 @@ from pyomo.environ import Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add operational costs to the objective-function dynamic components.
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append("Total_Variable_OM_Cost")
+    getattr(d, total_cost_components).append("Total_Fuel_Cost")
+    getattr(d, total_cost_components).append("Total_Startup_Cost")
+    getattr(d, total_cost_components).append("Total_Shutdown_Cost")
+
+
 def add_model_components(m, d):
     """
     :param m: the Pyomo abstract model object we are adding the components to
     :param d: the DynamicComponents class object we are adding components to
 
-    Here, we sum up all operational costs and add them to the
-    objective-function dynamic components. Operational costs include
+    Here, we sum up all operational costs. Operational costs include
     variable O&M costs, fuel costs, startup costs, and shutdown costs.
 
     :math:`Total\_Variable\_OM\_Cost =
@@ -51,7 +63,6 @@ def add_model_components(m, d):
                    for (g, tmp) in mod.PRJ_OPR_TMPS)
 
     m.Total_Variable_OM_Cost = Expression(rule=total_variable_om_cost_rule)
-    getattr(d, total_cost_components).append("Total_Variable_OM_Cost")
 
     # Fuel cost
     def total_fuel_cost_rule(mod):
@@ -68,7 +79,6 @@ def add_model_components(m, d):
                    for (g, tmp) in mod.PRJ_OPR_TMPS)
 
     m.Total_Fuel_Cost = Expression(rule=total_fuel_cost_rule)
-    getattr(d, total_cost_components).append("Total_Fuel_Cost")
 
     # Startup and shutdown costs
     def total_startup_cost_rule(mod):
@@ -85,7 +95,6 @@ def add_model_components(m, d):
                    for (g, tmp)
                    in mod.PRJ_OPR_TMPS)
     m.Total_Startup_Cost = Expression(rule=total_startup_cost_rule)
-    getattr(d, total_cost_components).append("Total_Startup_Cost")
 
     def total_shutdown_cost_rule(mod):
         """
@@ -101,4 +110,3 @@ def add_model_components(m, d):
                    for (g, tmp)
                    in mod.PRJ_OPR_TMPS)
     m.Total_Shutdown_Cost = Expression(rule=total_shutdown_cost_rule)
-    getattr(d, total_cost_components).append("Total_Shutdown_Cost")

--- a/gridpath/objective/project/aggregate_operational_tuning_costs.py
+++ b/gridpath/objective/project/aggregate_operational_tuning_costs.py
@@ -14,6 +14,16 @@ from pyomo.environ import Param, Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add tuning costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append("Total_Ramp_Tuning_Cost")
+
+
 def add_model_components(m, d):
     """
 
@@ -42,4 +52,3 @@ def add_model_components(m, d):
     m.Total_Ramp_Tuning_Cost = Expression(
         rule=total_ramp_tuning_cost_rule
     )
-    getattr(d, total_cost_components).append("Total_Ramp_Tuning_Cost")

--- a/gridpath/objective/project/aggregate_prm_group_costs.py
+++ b/gridpath/objective/project/aggregate_prm_group_costs.py
@@ -10,6 +10,16 @@ from pyomo.environ import Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add total prm group costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append("Total_PRM_Group_Costs")
+
+
 def add_model_components(m, d):
     """
     Sum up all PRM group costs and add to the objective function.
@@ -28,6 +38,3 @@ def add_model_components(m, d):
                    for p in mod.PERIODS)
     m.Total_PRM_Group_Costs = Expression(
         rule=total_capacity_threshold_cost_rule)
-    getattr(d, total_cost_components).append(
-        "Total_PRM_Group_Costs"
-    )

--- a/gridpath/objective/system/aggregate_load_balance_penalties.py
+++ b/gridpath/objective/system/aggregate_load_balance_penalties.py
@@ -14,6 +14,18 @@ from pyomo.environ import Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add total load balance penalty costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append(
+        "Total_Load_Balance_Penalty_Costs"
+    )
+
+
 def add_model_components(m, d):
     """
     :param m: the Pyomo abstract model object we are adding components to
@@ -44,6 +56,3 @@ def add_model_components(m, d):
                    for z in mod.LOAD_ZONES for tmp in mod.TMPS)
     m.Total_Load_Balance_Penalty_Costs = Expression(
         rule=total_penalty_costs_rule)
-    getattr(d, total_cost_components).append(
-        "Total_Load_Balance_Penalty_Costs"
-    )

--- a/gridpath/objective/system/policy/aggregate_carbon_cap_violation_penalties.py
+++ b/gridpath/objective/system/policy/aggregate_carbon_cap_violation_penalties.py
@@ -11,6 +11,18 @@ from pyomo.environ import Param, Expression, NonNegativeReals
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add total carbon cap penalty costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append(
+        "Total_Carbon_Cap_Balance_Penalty_Costs"
+    )
+
+
 def add_model_components(m, d):
     """
     :param m: the Pyomo abstract model object we are adding components to
@@ -28,6 +40,3 @@ def add_model_components(m, d):
                    for (z, p) in mod.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP)
     m.Total_Carbon_Cap_Balance_Penalty_Costs = Expression(
         rule=total_penalty_costs_rule)
-    getattr(d, total_cost_components).append(
-        "Total_Carbon_Cap_Balance_Penalty_Costs"
-    )

--- a/gridpath/objective/system/policy/aggregate_rps_violation_penalties.py
+++ b/gridpath/objective/system/policy/aggregate_rps_violation_penalties.py
@@ -11,6 +11,18 @@ from pyomo.environ import Param, Expression, NonNegativeReals
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add total rps balance penalty costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append(
+        "Total_RPS_Balance_Penalty_Costs"
+    )
+
+
 def add_model_components(m, d):
     """
     :param m: the Pyomo abstract model object we are adding components to
@@ -27,6 +39,3 @@ def add_model_components(m, d):
                    for (z, p) in mod.RPS_ZONE_PERIODS_WITH_RPS)
     m.Total_RPS_Balance_Penalty_Costs = Expression(
         rule=total_penalty_costs_rule)
-    getattr(d, total_cost_components).append(
-        "Total_RPS_Balance_Penalty_Costs"
-    )

--- a/gridpath/objective/system/reliability/local_capacity/aggregate_local_capacity_violation_penalties.py
+++ b/gridpath/objective/system/reliability/local_capacity/aggregate_local_capacity_violation_penalties.py
@@ -6,6 +6,18 @@ from pyomo.environ import Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add local capacity shortage penalty costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append(
+        "Total_Local_Capacity_Shortage_Penalty_Costs"
+    )
+
+
 def add_model_components(m, d):
     """
 
@@ -21,8 +33,5 @@ def add_model_components(m, d):
                    * mod.discount_factor[p]
                    for (z, p) in
                    mod.LOCAL_CAPACITY_ZONE_PERIODS_WITH_REQUIREMENT)
-    m.Total_Load_Capacity_Shortage_Penalty_Costs = Expression(
+    m.Total_Local_Capacity_Shortage_Penalty_Costs = Expression(
         rule=total_penalty_costs_rule)
-    getattr(d, total_cost_components).append(
-        "Total_Load_Capacity_Shortage_Penalty_Costs"
-    )

--- a/gridpath/objective/system/reliability/prm/aggregate_prm_violation_penalties.py
+++ b/gridpath/objective/system/reliability/prm/aggregate_prm_violation_penalties.py
@@ -6,6 +6,18 @@ from pyomo.environ import Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add total prm shortage penalty costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append(
+        "Total_PRM_Shortage_Penalty_Costs"
+    )
+
+
 def add_model_components(m, d):
     """
 
@@ -23,6 +35,3 @@ def add_model_components(m, d):
                    mod.PRM_ZONE_PERIODS_WITH_REQUIREMENT)
     m.Total_PRM_Shortage_Penalty_Costs = Expression(
         rule=total_penalty_costs_rule)
-    getattr(d, total_cost_components).append(
-        "Total_PRM_Shortage_Penalty_Costs"
-    )

--- a/gridpath/objective/system/reliability/prm/dynamic_elcc_tuning_penalties.py
+++ b/gridpath/objective/system/reliability/prm/dynamic_elcc_tuning_penalties.py
@@ -16,6 +16,16 @@ from pyomo.environ import Param, Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add total dynamic ELCC tuning costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append("Total_Dynamic_ELCC_Tuning_Cost")
+
+
 def add_model_components(m, d):
     """
 
@@ -48,8 +58,7 @@ def add_model_components(m, d):
     m.Total_Dynamic_ELCC_Tuning_Cost = Expression(
         rule=total_elcc_tuning_cost_rule
     )
-    getattr(d, total_cost_components).append("Total_Dynamic_ELCC_Tuning_Cost")
-    
+
     
 def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):
     """

--- a/gridpath/objective/system/reserve_violation_penalties/aggregate_reserve_violation_penalties.py
+++ b/gridpath/objective/system/reserve_violation_penalties/aggregate_reserve_violation_penalties.py
@@ -7,6 +7,21 @@ from pyomo.environ import Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def generic_determine_dynamic_components(
+        d,
+        objective_function_reserve_penalty_cost_component
+):
+    """
+    Add total reserve penalty to cost components dynamic components
+
+    :param d:
+    :param objective_function_reserve_penalty_cost_component:
+    :return:
+    """
+    getattr(d, total_cost_components).append(
+        objective_function_reserve_penalty_cost_component)
+
+
 def generic_add_model_components(
         m,
         d,
@@ -16,7 +31,7 @@ def generic_add_model_components(
         objective_function_reserve_penalty_cost_component
 ):
     """
-    Aggregate reserve violation penalty costs and add to the objective function
+    Aggregate reserve violation penalty costs
     :param m:
     :param d:
     :param reserve_zone_set:
@@ -38,6 +53,3 @@ def generic_add_model_components(
                    )
     setattr(m, objective_function_reserve_penalty_cost_component,
             Expression(rule=penalty_costs_rule))
-
-    getattr(d, total_cost_components).append(
-        objective_function_reserve_penalty_cost_component)

--- a/gridpath/objective/system/reserve_violation_penalties/frequency_response.py
+++ b/gridpath/objective/system/reserve_violation_penalties/frequency_response.py
@@ -7,7 +7,11 @@ from pyomo.environ import Expression
 
 from gridpath.auxiliary.dynamic_components import total_cost_components
 from .aggregate_reserve_violation_penalties import \
-    generic_add_model_components
+    generic_determine_dynamic_components, generic_add_model_components
+
+
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    generic_determine_dynamic_components(d, "Frequency_Response_Penalty_Costs")
 
 
 def add_model_components(m, d):

--- a/gridpath/objective/system/reserve_violation_penalties/lf_reserves_down.py
+++ b/gridpath/objective/system/reserve_violation_penalties/lf_reserves_down.py
@@ -5,7 +5,11 @@
 from __future__ import absolute_import
 
 from .aggregate_reserve_violation_penalties import \
-    generic_add_model_components
+    generic_determine_dynamic_components, generic_add_model_components
+
+
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    generic_determine_dynamic_components(d, "LF_Reserves_Down_Penalty_Costs")
 
 
 def add_model_components(m, d):

--- a/gridpath/objective/system/reserve_violation_penalties/lf_reserves_up.py
+++ b/gridpath/objective/system/reserve_violation_penalties/lf_reserves_up.py
@@ -5,7 +5,11 @@
 from __future__ import absolute_import
 
 from .aggregate_reserve_violation_penalties import \
-    generic_add_model_components
+    generic_determine_dynamic_components, generic_add_model_components
+
+
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    generic_determine_dynamic_components(d, "LF_Reserves_Up_Penalty_Costs")
 
 
 def add_model_components(m, d):

--- a/gridpath/objective/system/reserve_violation_penalties/regulation_down.py
+++ b/gridpath/objective/system/reserve_violation_penalties/regulation_down.py
@@ -5,7 +5,11 @@
 from __future__ import absolute_import
 
 from .aggregate_reserve_violation_penalties import \
-    generic_add_model_components
+    generic_determine_dynamic_components, generic_add_model_components
+
+
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    generic_determine_dynamic_components(d, "Regulation_Down_Penalty_Costs")
 
 
 def add_model_components(m, d):

--- a/gridpath/objective/system/reserve_violation_penalties/regulation_up.py
+++ b/gridpath/objective/system/reserve_violation_penalties/regulation_up.py
@@ -5,7 +5,11 @@
 from __future__ import absolute_import
 
 from .aggregate_reserve_violation_penalties import \
-    generic_add_model_components
+    generic_determine_dynamic_components, generic_add_model_components
+
+
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    generic_determine_dynamic_components(d, "Regulation_Up_Penalty_Costs")
 
 
 def add_model_components(m, d):

--- a/gridpath/objective/system/reserve_violation_penalties/spinning_reserves.py
+++ b/gridpath/objective/system/reserve_violation_penalties/spinning_reserves.py
@@ -5,7 +5,11 @@
 from __future__ import absolute_import
 
 from .aggregate_reserve_violation_penalties import \
-    generic_add_model_components
+    generic_determine_dynamic_components, generic_add_model_components
+
+
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    generic_determine_dynamic_components(d, "Spinning_Reserves_Penalty_Costs")
 
 
 def add_model_components(m, d):

--- a/gridpath/objective/transmission/aggregate_capacity_costs.py
+++ b/gridpath/objective/transmission/aggregate_capacity_costs.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# Copyright 2017 Blue Marble Analytics LLC. All rights reserved.
+
+"""
+This module aggregates transmission-line-period-level capacity costs
+for use in the objective function.
+"""
+
+from pyomo.environ import Expression
+
+from gridpath.auxiliary.dynamic_components import total_cost_components
+
+
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add total transmission capacity costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append("Total_Tx_Capacity_Costs")
+
+
+def add_model_components(m, d):
+    """
+
+    :param m:
+    :param d:
+    :return:
+    """
+
+    def total_tx_capacity_cost_rule(mod):
+        """
+        **Expression Name**: Total_Tx_Capacity_Costs
+
+        The total transmission capacity cost is equal to the transmission
+        capacity cost times the period's discount factor times the number of
+        years represented in the period, summed up for each of the periods.
+        """
+        return sum(mod.Tx_Capacity_Cost_in_Prd[g, p]
+                   * mod.discount_factor[p]
+                   * mod.number_years_represented[p]
+                   for (g, p) in mod.TX_OPR_PRDS)
+    m.Total_Tx_Capacity_Costs = Expression(rule=total_tx_capacity_cost_rule)

--- a/gridpath/objective/transmission/aggregate_operational_costs.py
+++ b/gridpath/objective/transmission/aggregate_operational_costs.py
@@ -11,6 +11,16 @@ from pyomo.environ import Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add total transmission hurdle costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append("Total_Hurdle_Cost")
+
+
 def add_model_components(m, d):
     """
 
@@ -35,6 +45,5 @@ def add_model_components(m, d):
             for (tx, tmp) in mod.TX_OPR_TMPS)
 
     m.Total_Hurdle_Cost = Expression(rule=total_hurdle_cost_rule)
-    getattr(d, total_cost_components).append("Total_Hurdle_Cost")
 
 

--- a/gridpath/objective/transmission/carbon_imports_tuning_costs.py
+++ b/gridpath/objective/transmission/carbon_imports_tuning_costs.py
@@ -20,6 +20,16 @@ from pyomo.environ import Param, Expression
 from gridpath.auxiliary.dynamic_components import total_cost_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    Add carbon import tunings costs to cost components
+    :param d:
+    :return:
+    """
+
+    getattr(d, total_cost_components).append("Total_Import_Carbon_Tuning_Cost")
+
+
 def add_model_components(m, d):
     """
 
@@ -49,9 +59,6 @@ def add_model_components(m, d):
 
     m.Total_Import_Carbon_Tuning_Cost = Expression(
         rule=total_import_carbon_tuning_cost_rule
-    )
-    getattr(d, total_cost_components).append(
-        "Total_Import_Carbon_Tuning_Cost"
     )
 
 

--- a/gridpath/system/load_balance/aggregate_project_power.py
+++ b/gridpath/system/load_balance/aggregate_project_power.py
@@ -13,6 +13,16 @@ from gridpath.auxiliary.dynamic_components import \
     load_balance_production_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    This method adds the power production to the dynamic components.
+    :param d:
+    :return:
+    """
+    getattr(d, load_balance_production_components).append(
+        "Power_Production_in_Zone_MW")
+
+
 def add_model_components(m, d):
     """
     :param m: the Pyomo abstract model object we are adding the components to
@@ -38,5 +48,3 @@ def add_model_components(m, d):
     m.Power_Production_in_Zone_MW = \
         Expression(m.LOAD_ZONES, m.TMPS,
                    rule=total_power_production_rule)
-    getattr(d, load_balance_production_components).append(
-        "Power_Production_in_Zone_MW")

--- a/gridpath/system/load_balance/aggregate_transmission_power.py
+++ b/gridpath/system/load_balance/aggregate_transmission_power.py
@@ -21,6 +21,23 @@ from gridpath.auxiliary.dynamic_components import \
     load_balance_production_components, load_balance_consumption_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    This method adds the transmission to/from to the load balance dynamic
+    components.
+    :param d:
+    :return:
+    """
+
+    getattr(d, load_balance_production_components).append(
+        "Transmission_to_Zone_MW"
+    )
+
+    getattr(d, load_balance_consumption_components).append(
+        "Transmission_from_Zone_MW"
+    )
+
+
 def add_model_components(m, d):
     """
     Add net transmitted power to load balance
@@ -45,9 +62,6 @@ def add_model_components(m, d):
         )
     m.Transmission_to_Zone_MW = Expression(m.LOAD_ZONES, m.TMPS,
                                            rule=total_transmission_to_rule)
-    getattr(d, load_balance_production_components).append(
-        "Transmission_to_Zone_MW"
-    )
 
     def total_transmission_from_rule(mod, z, tmp):
         """
@@ -65,9 +79,6 @@ def add_model_components(m, d):
         )
     m.Transmission_from_Zone_MW = Expression(m.LOAD_ZONES, m.TMPS,
                                              rule=total_transmission_from_rule)
-    getattr(d, load_balance_consumption_components).append(
-        "Transmission_from_Zone_MW"
-    )
 
 
 def export_results(scenario_directory, subproblem, stage, m, d):

--- a/gridpath/system/load_balance/load_balance.py
+++ b/gridpath/system/load_balance/load_balance.py
@@ -19,6 +19,23 @@ from gridpath.auxiliary.dynamic_components import \
     load_balance_consumption_components, load_balance_production_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    This method adds the unserved energy and overgeneration to the load balance
+    dynamic components.
+
+    :param d:
+    :return:
+    """
+
+    getattr(d, load_balance_production_components).append(
+        "Unserved_Energy_MW_Expression"
+    )
+    getattr(d, load_balance_consumption_components).append(
+        "Overgeneration_MW_Expression"
+    )
+
+
 def add_model_components(m, d):
     """
     :param m: the Pyomo abstract model object we are adding the components to
@@ -26,10 +43,7 @@ def add_model_components(m, d):
 
     Here we add, the overgeneration and unserved-energy per unit costs
     are declared here as well as the overgeneration and unserved-energy
-    variables. Incurred violation costs are added to the objective function in
-    objective/aggregate_load_balance_penalties.py. Overgeneration is added
-    to the load-balance consumption components and unserved energy to the
-    load-balance production components.
+    variables.
 
     We also get all other production and consumption components and add them
     to the lhs and rhs of the load-balance constraint respectively. With the
@@ -75,13 +89,6 @@ def add_model_components(m, d):
     m.Unserved_Energy_MW_Expression = Expression(
         m.LOAD_ZONES, m.TMPS,
         rule=unserved_energy_expression_rule
-    )
-
-    getattr(d, load_balance_production_components).append(
-        "Unserved_Energy_MW_Expression"
-    )
-    getattr(d, load_balance_consumption_components).append(
-        "Overgeneration_MW_Expression"
     )
 
     def meet_load_rule(mod, z, tmp):

--- a/gridpath/system/load_balance/static_load_requirement.py
+++ b/gridpath/system/load_balance/static_load_requirement.py
@@ -14,6 +14,16 @@ from gridpath.auxiliary.dynamic_components import \
     load_balance_consumption_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    This method adds the static load to the load balance dynamic components.
+    :param d:
+    :return:
+    """
+
+    getattr(d, load_balance_consumption_components).append("static_load_mw")
+
+
 def add_model_components(m, d):
     """
     :param m: the Pyomo abstract model object we are adding the components to
@@ -29,7 +39,6 @@ def add_model_components(m, d):
     # Static load
     m.static_load_mw = Param(m.LOAD_ZONES, m.TMPS,
                              within=NonNegativeReals)
-    getattr(d, load_balance_consumption_components).append("static_load_mw")
 
 
 def load_model_data(m, d, data_portal, scenario_directory, subproblem, stage):

--- a/gridpath/system/policy/carbon_cap/aggregate_project_carbon_emissions.py
+++ b/gridpath/system/policy/carbon_cap/aggregate_project_carbon_emissions.py
@@ -20,6 +20,18 @@ from gridpath.auxiliary.dynamic_components import \
     carbon_cap_balance_emission_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    This method adds project emissions to carbon balance
+    :param d:
+    :return:
+    """
+
+    getattr(d, carbon_cap_balance_emission_components).append(
+        "Total_Carbon_Cap_Project_Emissions"
+    )
+
+
 def add_model_components(m, d):
     """
 
@@ -47,11 +59,6 @@ def add_model_components(m, d):
     m.Total_Carbon_Cap_Project_Emissions = Expression(
         m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP,
         rule=total_carbon_emissions_rule
-    )
-
-    # Add to emission imports to carbon balance
-    getattr(d, carbon_cap_balance_emission_components).append(
-        "Total_Carbon_Cap_Project_Emissions"
     )
 
 

--- a/gridpath/system/policy/carbon_cap/aggregate_transmission_carbon_emissions.py
+++ b/gridpath/system/policy/carbon_cap/aggregate_transmission_carbon_emissions.py
@@ -21,6 +21,18 @@ from gridpath.transmission.operations.carbon_emissions import \
     calculate_carbon_emissions_imports
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    This method adds emission imports to carbon balance
+    :param d:
+    :return:
+    """
+
+    getattr(d, carbon_cap_balance_emission_components).append(
+        "Total_Carbon_Emission_Imports_Tons"
+    )
+
+
 def add_model_components(m, d):
     """
     Aggregate total imports of emissions and add to carbon balance constraint
@@ -50,11 +62,6 @@ def add_model_components(m, d):
     m.Total_Carbon_Emission_Imports_Tons = Expression(
         m.CARBON_CAP_ZONE_PERIODS_WITH_CARBON_CAP,
         rule=total_carbon_emissions_imports_rule
-    )
-
-    # Add to emission imports to carbon balance
-    getattr(d, carbon_cap_balance_emission_components).append(
-        "Total_Carbon_Emission_Imports_Tons"
     )
 
 

--- a/gridpath/system/reliability/local_capacity/aggregate_local_capacity_contribution.py
+++ b/gridpath/system/reliability/local_capacity/aggregate_local_capacity_contribution.py
@@ -19,6 +19,18 @@ from gridpath.auxiliary.dynamic_components import \
     local_capacity_balance_provision_components
 
 
+def determine_dynamic_components(d, scenario_directory, subproblem, stage):
+    """
+    This method adds contribution to local capacity provision components
+    :param d:
+    :return:
+    """
+
+    getattr(d, local_capacity_balance_provision_components).append(
+        "Total_Local_Capacity_Contribution_MW"
+    )
+
+
 def add_model_components(m, d):
     """
 
@@ -44,11 +56,6 @@ def add_model_components(m, d):
     m.Total_Local_Capacity_Contribution_MW = Expression(
         m.LOCAL_CAPACITY_ZONE_PERIODS_WITH_REQUIREMENT,
         rule=total_local_capacity_provision_rule
-    )
-
-    # Add contribtion to local capacity provision components
-    getattr(d, local_capacity_balance_provision_components).append(
-        "Total_Local_Capacity_Contribution_MW"
     )
 
 

--- a/gridpath/transmission/capacity/capacity.py
+++ b/gridpath/transmission/capacity/capacity.py
@@ -181,32 +181,6 @@ def add_model_components(m, d):
         rule=tx_capacity_cost_rule
     )
 
-    m.Total_Tx_Capacity_Costs = Expression(
-        rule=total_tx_capacity_cost_rule
-    )
-
-    # Dynamic Components - Objective Function
-    ###########################################################################
-
-    getattr(d, total_cost_components).append("Total_Tx_Capacity_Costs")
-
-
-# Expression Rules
-###############################################################################
-
-def total_tx_capacity_cost_rule(mod):
-    """
-    **Expression Name**: Total_Tx_Capacity_Costs
-
-    The total transmission capacity cost is equal to the transmission capacity
-    cost times the period's discount factor times the number of years
-    represented in the period, summed up for each of the periods.
-    """
-    return sum(mod.Tx_Capacity_Cost_in_Prd[g, p]
-               * mod.discount_factor[p]
-               * mod.number_years_represented[p]
-               for (g, p) in mod.TX_OPR_PRDS)
-
 
 # Set Rules
 ###############################################################################

--- a/tests/objective/transmission/test_aggregate_capacity_costs.py
+++ b/tests/objective/transmission/test_aggregate_capacity_costs.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# Copyright 2017 Blue Marble Analytics LLC. All rights reserved.
+
+from __future__ import print_function
+
+from builtins import str
+from importlib import import_module
+import os.path
+import sys
+import unittest
+
+from tests.common_functions import create_abstract_model
+
+
+TEST_DATA_DIRECTORY = \
+    os.path.join(os.path.dirname(__file__), "..", "..", "test_data")
+
+# Import prerequisite modules
+PREREQUISITE_MODULE_NAMES = [
+    "temporal.operations.timepoints", "temporal.operations.horizons",
+    "temporal.investment.periods", "geography.load_zones",
+    "transmission", "transmission.capacity", "transmission.capacity.capacity"]
+NAME_OF_MODULE_BEING_TESTED = \
+    "objective.transmission.aggregate_capacity_costs"
+IMPORTED_PREREQ_MODULES = list()
+for mdl in PREREQUISITE_MODULE_NAMES:
+    try:
+        imported_module = import_module("." + str(mdl), package="gridpath")
+        IMPORTED_PREREQ_MODULES.append(imported_module)
+    except ImportError:
+        print("ERROR! Module " + str(mdl) + " not found.")
+        sys.exit(1)
+# Import the module we'll test
+try:
+    MODULE_BEING_TESTED = import_module("." + NAME_OF_MODULE_BEING_TESTED,
+                                        package="gridpath")
+except ImportError:
+    print("ERROR! Couldn't import module " + NAME_OF_MODULE_BEING_TESTED +
+          " to test.")
+
+
+class TestTxAggregateCosts(unittest.TestCase):
+    """
+
+    """
+    def test_add_model_components(self):
+        """
+        Test that there are no errors when adding model components
+        :return:
+        """
+        create_abstract_model(prereq_modules=IMPORTED_PREREQ_MODULES,
+                              module_to_test=MODULE_BEING_TESTED,
+                              test_data_dir=TEST_DATA_DIRECTORY,
+                              subproblem="",
+                              stage=""
+                              )


### PR DESCRIPTION
Instead of doing them in add_model_components, build the lists in
determine_dynamic_components so that you can access these when
you process results.

We also move tx capacity cost aggregations to the objective
folder to be consistent with the other aggregations.

This is a pre-requisite update for outputting total system
costs by component (#694). 