### PR TITLE
Allow soft startup and shutdown ramp constraints

### DIFF
--- a/gridpath/project/operations/operational_types/gen_commit_bin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_bin.py
@@ -1778,7 +1778,9 @@ def ramp_during_startup_by_st_constraint_rule(mod, g, tmp, s):
         return \
             mod.GenCommitBin_Provide_Power_Startup_By_ST_MW[g, tmp, s] \
             - prev_tmp_provide_power_startup \
-            <= prev_tmp_startup_ramp_rate_mw_per_tmp
+            <= prev_tmp_startup_ramp_rate_mw_per_tmp \
+            + mod.gen_commit_bin_allow_ramp_up_violation[g] * \
+            mod.GenCommitBin_Ramp_Up_Violation_MW[g, tmp]
 
 
 def increasing_startup_power_by_st_constraint_rule(mod, g, tmp, s):
@@ -1939,7 +1941,9 @@ def ramp_during_shutdown_constraint_rule(mod, g, tmp):
 
         return prev_tmp_provide_power_shutdown \
             - mod.GenCommitBin_Provide_Power_Shutdown_MW[g, tmp] \
-            <= prev_tmp_shutdown_ramp_rate_mw_per_tmp
+            <= prev_tmp_shutdown_ramp_rate_mw_per_tmp + \
+            mod.gen_commit_bin_allow_ramp_down_violation[g] * \
+            mod.GenCommitBin_Ramp_Down_Violation_MW[g, tmp]
 
 
 def decreasing_shutdown_power_constraint_rule(mod, g, tmp):

--- a/gridpath/project/operations/operational_types/gen_commit_lin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_lin.py
@@ -1755,7 +1755,9 @@ def ramp_during_startup_by_st_constraint_rule(mod, g, tmp, s):
         return \
             mod.GenCommitLin_Provide_Power_Startup_By_ST_MW[g, tmp, s] \
             - prev_tmp_provide_power_startup \
-            <= prev_tmp_startup_ramp_rate_mw_per_tmp
+            <= prev_tmp_startup_ramp_rate_mw_per_tmp + \
+            mod.gen_commit_lin_allow_ramp_up_violation[g] * \
+            mod.GenCommitLin_Ramp_Up_Violation_MW[g, tmp]
 
 
 def increasing_startup_power_by_st_constraint_rule(mod, g, tmp, s):
@@ -1916,7 +1918,9 @@ def ramp_during_shutdown_constraint_rule(mod, g, tmp):
 
         return prev_tmp_provide_power_shutdown \
             - mod.GenCommitLin_Provide_Power_Shutdown_MW[g, tmp] \
-            <= prev_tmp_shutdown_ramp_rate_mw_per_tmp
+            <= prev_tmp_shutdown_ramp_rate_mw_per_tmp + \
+            mod.gen_commit_lin_allow_ramp_down_violation[g] * \
+            mod.GenCommitLin_Ramp_Down_Violation_MW[g, tmp]
 
 
 def decreasing_shutdown_power_constraint_rule(mod, g, tmp):


### PR DESCRIPTION
Use the same violation penalty as for the normal operations ramp constraints.