### PR TITLE
Fix various errors and warnings while making Sphinx documentation

### DIFF
--- a/doc/source/advanced_docs.rst
+++ b/doc/source/advanced_docs.rst
@@ -59,7 +59,7 @@ Projects
 gridpath.project.__init__
 -------------------------
 .. automodule:: gridpath.project.__init__
-    :members: determine_dynamic_components, add_model_components
+    :members: add_model_components
 
 Project Capacity
 ----------------
@@ -362,7 +362,7 @@ gridpath.project.operations.reserves.reserve_provision
 ------------------------------------------------------
 
 .. automodule:: gridpath.project.operations.reserves.reserve_provision
-    :members: generic_determine_dynamic_components
+    :members: generic_record_dynamic_components
 
 
 

--- a/doc/source/architecture.rst
+++ b/doc/source/architecture.rst
@@ -37,7 +37,7 @@ gridpath.run_scenario
 .. automodule:: gridpath.run_scenario
     :members: main, parse_arguments, ScenarioStructure, run_scenario,
         run_optimization, create_and_solve_problem,
-        populate_dynamic_components, create_abstract_model,
+        create_abstract_model,
         load_scenario_data, create_problem_instance, fix_variables, solve
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -105,7 +105,7 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/doc/source/database.rst
+++ b/doc/source/database.rst
@@ -11,10 +11,10 @@ This chapter describes the following:
 * :ref:`database-testing-section-ref` : instructions on how to validate the
   database inputs
 
+.. _database-section-ref:
+
 Database Structure
 ##################
-
-.. _database-section-ref:
 
 .. automodule:: db
 
@@ -246,77 +246,86 @@ Requirement
 Regulation Down
 ***************
 
+===============
 Balancing Areas
 ===============
 
 .. automodule:: db.csvs_test_examples.reserves.regulation_down.geography_regulation_down_bas.doc
 
+=====================
 Contributing Projects
 =====================
 
 .. automodule:: db.csvs_test_examples.reserves.regulation_down.project_regulation_down_bas.doc
 
+===========
 Requirement
 ===========
 
 .. automodule:: db.csvs_test_examples.reserves.regulation_down.req.doc
 
 
-=================
 Spinning Reserves
-=================
+*****************
 
+===============
 Balancing Areas
 ===============
 
 .. automodule:: db.csvs_test_examples.reserves.spinning_reserves.geography_spinning_reserves_bas.doc
 
 
+=====================
 Contributing Projects
 =====================
 
 .. automodule:: db.csvs_test_examples.reserves.spinning_reserves.project_spinning_reserves_bas.doc
 
 
+===========
 Requirement
 ===========
 
 .. automodule:: db.csvs_test_examples.reserves.spinning_reserves.req.doc
 
-==========================
 Load-Following Reserves Up
-==========================
+**************************
 
+===============
 Balancing Areas
 ===============
 
 .. automodule:: db.csvs_test_examples.reserves.lf_reserves_up.geography_lf_reserves_up_bas.doc
 
+=====================
 Contributing Projects
 =====================
 
 .. automodule:: db.csvs_test_examples.reserves.lf_reserves_up.project_lf_reserves_up_bas.doc
 
+===========
 Requirement
 ===========
 
 .. automodule:: db.csvs_test_examples.reserves.lf_reserves_up.req.doc
 
 
-============================
 Load-Following Reserves Down
-============================
+****************************
 
+===============
 Balancing Areas
 ===============
 
 .. automodule:: db.csvs_test_examples.reserves.lf_reserves_down.geography_lf_reserves_down_bas.doc
 
+=====================
 Contributing Projects
 =====================
 
 .. automodule:: db.csvs_test_examples.reserves.lf_reserves_down.project_lf_reserves_down_bas.doc
 
+===========
 Requirement
 ===========
 
@@ -324,20 +333,22 @@ Requirement
 
 
 
-===========================
 Frequency Response Reserves
-===========================
+***************************
 
+===============
 Balancing Areas
 ===============
 
 .. automodule:: db.csvs_test_examples.reserves.frequency_response.geography_frequency_response_bas.doc
 
+=====================
 Contributing Projects
 =====================
 
 .. automodule:: db.csvs_test_examples.reserves.frequency_response.project_frequency_response_bas.doc
 
+===========
 Requirement
 ===========
 
@@ -396,6 +407,7 @@ Once you have built the database with a set of scenarios and associated inputs,
 you can test the inputs for a given scenario by running the inputs validation
 suite. This suite will extract the inputs for the scenario of interest and
 check whether the inputs are valid. A few examples of invalid inputs are:
+
  - required inputs are missing
  - inputs are the wrong datatype or not in the expected range
  - inputs are inconsistent with a related set of inputs

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -33,10 +33,10 @@ Git to download the source code.
 
 Installing Git
 --------------
-Git installation instructions are `here <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_
+Git installation instructions are `here <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`__
 
 On Windows, use the Git installer available `here <https://git-scm
-.com/download/win>`_.
+.com/download/win>`__.
 
 On MacOS, type :code:`git --version` on the command line; if you don't have
 Git installed already, you will be prompted to install it.
@@ -58,7 +58,7 @@ Once you have Git installed, clone the repository with::
 the current directory.)
 
 For more info on cloning repositories, see `the instructions on GitHub
-<https://help.github.com/en/articles/cloning-a-repository>`_.
+<https://help.github.com/en/articles/cloning-a-repository>`__.
 
 We will eventually distribute GridPath through pypi and conda, so cloning the
 repository will not be required except for users who want to edit the source
@@ -73,8 +73,8 @@ Python
 
 Running GridPath requires a Python 3 installation and several Python
 packages. You can get the official CPython distribution `here
-<https://www.python.org/downloads/>`_, the Anaconda Python distribution
-`here <https://www.anaconda.com/distribution/>`_, or `another Python
+<https://www.python.org/downloads/>`__, the Anaconda Python distribution
+`here <https://www.anaconda.com/distribution/>`__, or `another Python
 distribution <https://wiki.python.org/moin/PythonDistributions>`_. GridPath
 is written and tested in Python 3.8 and we do not recommend using other Python
 versions.
@@ -213,13 +213,13 @@ is `supported by Pyomo <https://pyomo.readthedocs
 e.g. GLPK, CPLEX, Gurobi, etc.
 
 You can find the latest instructions for installing Cbc `here
-<https://github.com/coin-or/Cbc#download>`_. On Windows, you can also
+<https://github.com/coin-or/Cbc#download>`__. On Windows, you can also
 download the Cbc executable from the `AMPL website <https://ampl
 .com/products/solvers/open-source/#cbc>`_. GridPath allows you to specify
 the location of the solver executable; to get it to be recognized,
 automatically, you can also add it to your PATH system variables (see
 instructions for Windows `here <https://www.java.com/en/download/help/path
-.xml>`_).
+.xml>`__).
 
 
 Testing Your Installation

--- a/gridpath/project/capacity/capacity_types/gen_new_bin.py
+++ b/gridpath/project/capacity/capacity_types/gen_new_bin.py
@@ -135,7 +135,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     +=========================================================================+
     | | :code:`GenNewBin_Build`                                               |
     | | *Defined over*: :code:`GEN_NEW_BIN_VNTS`                              |
-    | | *Within*: :code:`Binary          `                                    |
+    | | *Within*: :code:`Binary`                                              |
     |                                                                         |
     | Binary build decision for each project-vintage combination (1=build).   |
     +-------------------------------------------------------------------------+

--- a/gridpath/project/capacity/capacity_types/gen_ret_bin.py
+++ b/gridpath/project/capacity/capacity_types/gen_ret_bin.py
@@ -107,7 +107,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     |                                                                         |
     | The binary decision variable has to be less than or equal to the binary |
     | decision variable in the previous period. This will prevent capacity    |
-    |from co ming back online after it has been retired.                      |
+    | from coming back online after it has been retired.                      |
     +-------------------------------------------------------------------------+
 
     """

--- a/gridpath/project/capacity/capacity_types/stor_new_bin.py
+++ b/gridpath/project/capacity/capacity_types/stor_new_bin.py
@@ -114,7 +114,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
         the user to ensure that the
         :code:`stor_new_bin_lifetime_yrs`,
         :code:`stor_new_bin_annualized_real_cost_per_mw_yr`, and
-        :code:`stor_new_bin_annualized_real_cost_per_mwh_yr' parameters are
+        :code:`stor_new_bin_annualized_real_cost_per_mwh_yr` parameters are
         consistent.
 
     +-------------------------------------------------------------------------+

--- a/gridpath/project/capacity/capacity_types/stor_new_lin.py
+++ b/gridpath/project/capacity/capacity_types/stor_new_lin.py
@@ -139,7 +139,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
         the user to ensure that the
         :code:`stor_new_lin_lifetime_yrs`,
         :code:`stor_new_lin_annualized_real_cost_per_mw_yr`, and
-        :code:`stor_new_lin_annualized_real_cost_per_mwh_yr' parameters are
+        :code:`stor_new_lin_annualized_real_cost_per_mwh_yr` parameters are
         consistent.
 
     +-------------------------------------------------------------------------+

--- a/gridpath/project/capacity/capacity_types/stor_spec.py
+++ b/gridpath/project/capacity/capacity_types/stor_spec.py
@@ -44,7 +44,7 @@ from gridpath.auxiliary.validations import get_projects, get_expected_dtypes, \
 
 def add_model_components(m, d, scenario_directory, subproblem, stage):
     """
-     The following Pyomo model components are defined in this module:
+    The following Pyomo model components are defined in this module:
 
     +-------------------------------------------------------------------------+
     | Sets                                                                    |

--- a/gridpath/project/operations/costs.py
+++ b/gridpath/project/operations/costs.py
@@ -39,7 +39,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     """
     The following Pyomo model components are defined in this module:
 
-     +-------------------------------------------------------------------------+
+    +-------------------------------------------------------------------------+
     | Sets                                                                    |
     +=========================================================================+
     | | :code:`VAR_OM_COST_SIMPLE_PRJ_OPR_TMPS`                               |
@@ -92,7 +92,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | incurred along with their operational timepoints.                       |
     +-------------------------------------------------------------------------+
 
-    |                                                                         |
+    |
 
     +-------------------------------------------------------------------------+
     | Variables                                                               |
@@ -105,7 +105,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | curve.                                                                  |
     +-------------------------------------------------------------------------+
 
-    |                                                                         |
+    |
 
     +-------------------------------------------------------------------------+
     | Constraints                                                             |
@@ -117,7 +117,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | its VOM curve.                                                          |
     +-------------------------------------------------------------------------+
 
-    |                                                                         |
+    |
 
     +-------------------------------------------------------------------------+
     | Expressions                                                             |

--- a/gridpath/project/operations/fuel_burn.py
+++ b/gridpath/project/operations/fuel_burn.py
@@ -63,7 +63,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | specified and their operational timepoints.                             |
     +-------------------------------------------------------------------------+
 
-    |                                                                         |
+    |
 
     +-------------------------------------------------------------------------+
     | Variables                                                               |
@@ -76,7 +76,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | curve.                                                                  |
     +-------------------------------------------------------------------------+
 
-    |                                                                         |
+    |
 
     +-------------------------------------------------------------------------+
     | Constraints                                                             |
@@ -88,7 +88,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | heat rate curve.                                                        |
     +-------------------------------------------------------------------------+
 
-    |                                                                         |
+    |
 
     +-------------------------------------------------------------------------+
     | Expressions                                                             |

--- a/gridpath/project/operations/operational_types/gen_commit_bin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_bin.py
@@ -105,7 +105,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | | *Defined over*: :code:`GEN_COMMIT_BIN`                                |
     |                                                                         |
     | Indexed set that describes the startup types for each project of the    |
-    | :code:`gen_commit_bin`operational type.                                 |
+    | :code:`gen_commit_bin` operational type.                                |
     +-------------------------------------------------------------------------+
     | | :code:`GEN_COMMIT_BIN_LINKED_TMPS`                                    |
     |                                                                         |
@@ -490,7 +490,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | :code:`gen_commit_bin_shutdown_plus_ramp_down_rate`, the availability   |
     | and capacity in the timepoint, and the timepoint's duration.            |
     +-------------------------------------------------------------------------+
-    | | :code:`GenCommitBin_Active_Startup_Type          `                    |
+    | | :code:`GenCommitBin_Active_Startup_Type`                              |
     | | *Defined over*: :code:`GEN_COMMIT_BIN_OPR_TMPS`                       |
     |                                                                         |
     | The project's active startup type in each operational timepoint,        |

--- a/gridpath/project/operations/operational_types/gen_commit_lin.py
+++ b/gridpath/project/operations/operational_types/gen_commit_lin.py
@@ -81,7 +81,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | | *Defined over*: :code:`GEN_COMMIT_LIN`                                |
     |                                                                         |
     | Indexed set that describes the startup types for each project of the    |
-    | :code:`gen_commit_lin`operational type.                                 |
+    | :code:`gen_commit_lin` operational type.                                |
     +-------------------------------------------------------------------------+
     | | :code:`GEN_COMMIT_LIN_LINKED_TMPS`                                    |
     |                                                                         |
@@ -454,7 +454,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     |                                                                         |
     | The project's upward ramp-able capacity (in MW) during startup in each  |
     | operational timepoint. Depends on the                                   |
-    | :code:`gen_commit_lin_startup_plus_ramp_up_rate_by_st                   |
+    | :code:`gen_commit_lin_startup_plus_ramp_up_rate_by_st`                  |
     | availability and capacity in the timepoint, and the timepoint's         |
     | duration.                                                               |
     +-------------------------------------------------------------------------+
@@ -466,7 +466,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | :code:`gen_commit_lin_shutdown_plus_ramp_down_rate`, the availability   |
     | and capacity in the timepoint, and the timepoint's duration.            |
     +-------------------------------------------------------------------------+
-    | | :code:`GenCommitLin_Active_Startup_Type          `                    |
+    | | :code:`GenCommitLin_Active_Startup_Type`                              |
     | | *Defined over*: :code:`GEN_COMMIT_LIN_OPR_TMPS`                       |
     |                                                                         |
     | The project's active startup type in each operational timepoint,        |

--- a/gridpath/project/operations/operational_types/gen_hydro.py
+++ b/gridpath/project/operations/operational_types/gen_hydro.py
@@ -151,6 +151,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     |                                                                         |
     | The project's downward reserve provision in the linked timepoints.      |
     +-------------------------------------------------------------------------+
+
     |
 
     +-------------------------------------------------------------------------+

--- a/gridpath/project/operations/operational_types/gen_hydro_must_take.py
+++ b/gridpath/project/operations/operational_types/gen_hydro_must_take.py
@@ -140,6 +140,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     |                                                                         |
     | The project's downward reserve provision in the linked timepoints.      |
     +-------------------------------------------------------------------------+
+
     |
 
     +-------------------------------------------------------------------------+

--- a/gridpath/project/operations/operational_types/stor.py
+++ b/gridpath/project/operations/operational_types/stor.py
@@ -216,7 +216,7 @@ def add_model_components(m, d, scenario_directory, subproblem, stage):
     | | *Defined over*: :code:`STOR_OPR_TMPS`                                 |
     |                                                                         |
     | Can't provide more upward reserves (times sustained duration required)  |
-    |than available energy in storage in that timepoint.                      |
+    | than available energy in storage in that timepoint.                     |
     +-------------------------------------------------------------------------+
     | | :code:`Stor_Max_Footroom_Energy_Constraint`                           |
     | | *Defined over*: :code:`STOR_OPR_TMPS`                                 |

--- a/gridpath/run_scenario.py
+++ b/gridpath/run_scenario.py
@@ -808,7 +808,7 @@ def parse_arguments(args):
     """
     :param args: the script arguments specified by the user
     :return: the parsed known argument values (<class 'argparse.Namespace'>
-    Python object)
+        Python object)
 
     Parse the known arguments.
     """


### PR DESCRIPTION
There are a bunch of errors and warnings that occur when running `make html` in the `doc` folder. Mere curiosity led me to find that there were some very minor rST and Sphinx syntax errors. I cleaned up those typos, and also some less trivial documentation linkage changes. With these changes, I now don't get any errors or warnings.

Kindly review. Hope this helps.