### PR TITLE
Auto calculate hours_in_period from temporal structure

### DIFF
--- a/db/csvs_test_examples/temporal/1_1horizon_1period/period_params.csv
+++ b/db/csvs_test_examples/temporal/1_1horizon_1period/period_params.csv
@@ -1,2 +1,2 @@
-period,discount_factor,number_years_represented,hours_in_full_period
-2020,1,1,8760
+period,discount_factor,number_years_represented
+2020,1,1

--- a/db/csvs_test_examples/temporal/2_2horizons_1period/period_params.csv
+++ b/db/csvs_test_examples/temporal/2_2horizons_1period/period_params.csv
@@ -1,2 +1,2 @@
-period,discount_factor,number_years_represented,hours_in_full_period
-2020,1,1,8760
+period,discount_factor,number_years_represented
+2020,1,1

--- a/db/csvs_test_examples/temporal/3_1horizon_2periods/period_params.csv
+++ b/db/csvs_test_examples/temporal/3_1horizon_2periods/period_params.csv
@@ -1,3 +1,3 @@
-period,discount_factor,number_years_represented,hours_in_full_period
-2020,1,10,8760
-2030,1,10,8760
+period,discount_factor,number_years_represented
+2020,1,10
+2030,1,10

--- a/db/csvs_test_examples/temporal/4_1horizon_1period_3subproblems/period_params.csv
+++ b/db/csvs_test_examples/temporal/4_1horizon_1period_3subproblems/period_params.csv
@@ -1,2 +1,2 @@
-period,discount_factor,number_years_represented,hours_in_full_period
-2020,1,1,8760
+period,discount_factor,number_years_represented
+2020,1,1

--- a/db/csvs_test_examples/temporal/5_1horizon_1period_3subproblems_3stages/period_params.csv
+++ b/db/csvs_test_examples/temporal/5_1horizon_1period_3subproblems_3stages/period_params.csv
@@ -1,2 +1,2 @@
-period,discount_factor,number_years_represented,hours_in_full_period
-2020,1,1,8760
+period,discount_factor,number_years_represented
+2020,1,1

--- a/db/csvs_test_examples/temporal/6_1horizon_2periods_10yrs/period_params.csv
+++ b/db/csvs_test_examples/temporal/6_1horizon_2periods_10yrs/period_params.csv
@@ -1,3 +1,3 @@
-period,discount_factor,number_years_represented,hours_in_full_period
-2020,1,10,8760
-2030,1,10,8760
+period,discount_factor,number_years_represented
+2020,1,10
+2030,1,10

--- a/db/csvs_test_examples/temporal/7_1horizon_12timepoints/period_params.csv
+++ b/db/csvs_test_examples/temporal/7_1horizon_12timepoints/period_params.csv
@@ -1,2 +1,2 @@
-period,discount_factor,number_years_represented,hours_in_full_period
-2020,1,1,8760
+period,discount_factor,number_years_represented
+2020,1,1

--- a/db/csvs_test_examples/temporal/8_1horizon_1period_3subproblems_linked/period_params.csv
+++ b/db/csvs_test_examples/temporal/8_1horizon_1period_3subproblems_linked/period_params.csv
@@ -1,2 +1,2 @@
-period,discount_factor,number_years_represented,hours_in_full_period
-2020,1,1,8760
+period,discount_factor,number_years_represented
+2020,1,1

--- a/db/csvs_test_examples/temporal/9_1horizon_1period_3subproblems_3stages_linked/period_params.csv
+++ b/db/csvs_test_examples/temporal/9_1horizon_1period_3subproblems_3stages_linked/period_params.csv
@@ -1,2 +1,2 @@
-period,discount_factor,number_years_represented,hours_in_full_period
-2020,1,1,8760
+period,discount_factor,number_years_represented
+2020,1,1

--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -236,7 +236,6 @@ temporal_scenario_id INTEGER,
 period INTEGER,
 discount_factor FLOAT,
 number_years_represented FLOAT,
-hours_in_full_period FLOAT,
 PRIMARY KEY (temporal_scenario_id, period),
 FOREIGN KEY (temporal_scenario_id) REFERENCES subscenarios_temporal
 (temporal_scenario_id)

--- a/gridpath/auxiliary/validations.py
+++ b/gridpath/auxiliary/validations.py
@@ -250,7 +250,6 @@ def validate_dtypes(df, expected_dtypes):
         Error message specifies the column and the expected data type.
         List of columns with erroneous data types.
     """
-
     result = []
     columns = []
     for column in df.columns:

--- a/gridpath/validate_inputs.py
+++ b/gridpath/validate_inputs.py
@@ -77,62 +77,6 @@ def validate_inputs(subproblems, loaded_modules, scenario_id, subscenarios, conn
             #    ... (see Evernote validation list)
             #    create separate function for each validation that you call here
 
-    # Validation across subproblems and stages:
-    validate_hours_in_subproblem_period(scenario_id, subscenarios, conn)
-
-
-def validate_hours_in_subproblem_period(scenario_id, subscenarios, conn):
-    """
-
-    :param subscenarios:
-    :param conn:
-    :return:
-    """
-
-    sql = """
-        SELECT stage_id, period, n_hours, hours_in_full_period
-        FROM
-            (SELECT temporal_scenario_id, stage_id, period,
-            sum(number_of_hours_in_timepoint * timepoint_weight) as n_hours
-            FROM inputs_temporal
-            WHERE spinup_or_lookahead = 0
-            AND temporal_scenario_id = {}
-            GROUP BY temporal_scenario_id, stage_id, period
-            ) AS tmp_table
-    
-        INNER JOIN
-        
-        (SELECT temporal_scenario_id, period, hours_in_full_period
-        FROM inputs_temporal_periods) AS period_tbl
-    
-        USING (temporal_scenario_id, period)
-    
-    """.format(subscenarios.TEMPORAL_SCENARIO_ID)
-
-    df = pd.read_sql(sql, con=conn)
-
-    msg = """Total number of hours in timepoints adjusted for timepoint weight
-          and duration and excluding spinup and lookahead timepoints should 
-          match hours_in_full_period."""
-    write_validation_to_database(
-        conn=conn,
-        scenario_id=scenario_id,
-        subproblem_id="N/A",
-        stage_id="N/A",
-        gridpath_module="N/A",
-        db_table="inputs_temporal",
-        severity="Mid",
-        errors=validate_cols_equal(
-            df=df,
-            col1="n_hours",
-            col2="hours_in_full_period",
-            idx_col=["stage_id", "period"],
-            msg=msg
-        )
-    )
-
-    # TODO: check that subproblems don't straddle periods
-
 
 def validate_subscenario_ids(scenario_id, subscenarios, optional_features, conn):
     """


### PR DESCRIPTION
Having the user input hours_in_period is prone to error, even with the validation in place. Instead, we can automatically calculate the hours in period across subproblems from the temporal structure.

This will require deleting the hours_in_full_period column from periods.csv in the temporal scenario directories as well as dropping the column from the inputs_temporal_periods. This is the query to do the latter:

```sql
PRAGMA foreign_keys = 0;

CREATE TABLE sqlitestudio_temp_table AS SELECT *
                                          FROM inputs_temporal_periods;

DROP TABLE inputs_temporal_periods;

CREATE TABLE inputs_temporal_periods (
    temporal_scenario_id     INTEGER,
    period                   INTEGER,
    discount_factor          FLOAT,
    number_years_represented FLOAT,
    PRIMARY KEY (
        temporal_scenario_id,
        period
    ),
    FOREIGN KEY (
        temporal_scenario_id
    )
    REFERENCES subscenarios_temporal (temporal_scenario_id) 
);

INSERT INTO inputs_temporal_periods (
                                        temporal_scenario_id,
                                        period,
                                        discount_factor,
                                        number_years_represented
                                    )
                                    SELECT temporal_scenario_id,
                                           period,
                                           discount_factor,
                                           number_years_represented
                                      FROM sqlitestudio_temp_table;

DROP TABLE sqlitestudio_temp_table;

PRAGMA foreign_keys = 1;

```