### PR TITLE
Fix bug in project reserve requirements related to project operating timepoints

### DIFF
--- a/gridpath/system/reserves/requirement/reserve_requirements.py
+++ b/gridpath/system/reserves/requirement/reserve_requirements.py
@@ -120,6 +120,7 @@ def generic_add_model_components(
                 * mod.Power_Provision_MW[prj, tmp]
                 for (_reserve_zone, prj) in getattr(mod, ba_prj_req_contribution_set)
                 if _reserve_zone == reserve_zone
+                if (prj, tmp) in mod.PRJ_OPR_TMPS
             )
 
             # Project contributions to requirement based on (available) capacity
@@ -130,6 +131,7 @@ def generic_add_model_components(
                 * mod.Availability_Derate[prj, tmp]
                 for (_reserve_zone, prj) in getattr(mod, ba_prj_req_contribution_set)
                 if _reserve_zone == reserve_zone
+                if (prj, tmp) in mod.PRJ_OPR_TMPS
             )
         else:
             prj_pwr_contribution = 0


### PR DESCRIPTION
When trying to use the prj reserve requirement feature, there was a problem of invalid indexed component for "Power_Provision_MW" because the project was not existing during some timepoints. Now, the requirements are defined only for the timepoints/periods for which the projects are existing (operating periods of the projects).