### PR TITLE
Fix port_csvs_to_db script

### DIFF
--- a/db/utilities/common_functions.py
+++ b/db/utilities/common_functions.py
@@ -1187,7 +1187,7 @@ def load_single_subscenario_id_from_dir_to_subscenario_table(
         subscenario_directories = [
             d
             for d in sorted(next(os.walk(inputs_dir))[1])
-            if d.startswith(str(subscenario_id_to_load))
+            if d.startswith("{}_".format(subscenario_id_to_load))
         ]
         if len(subscenario_directories) == 1:
             subscenario_directory = subscenario_directories[0]


### PR DESCRIPTION
There was a problem with the port_csvs_to_db script when there is more than 10 subscenario id for a dir subscenario. It was finding more than one directory with the same id. 
E.g.: If trying to import id 2, would find also id 20 and 21. It was raising an error than more than one csv was existing with the same id.