### PR TITLE
Fix getting inputs from database for project cap factor limits

### DIFF
--- a/gridpath/project/operations/__init__.py
+++ b/gridpath/project/operations/__init__.py
@@ -908,9 +908,15 @@ def get_inputs_from_database(scenario_id, subscenarios, subproblem, stage, conn)
         INNER JOIN
         inputs_project_cap_factor_limits
         USING(project, cap_factor_limits_scenario_id)
+        JOIN
+        (SELECT balancing_type_horizon, horizon
+        FROM inputs_temporal_horizons
+        WHERE temporal_scenario_id = {temporal_scenario_id}) as relevant_horizons
+        USING (balancing_type_horizon, horizon)
         WHERE project_portfolio_scenario_id = {project_portfolio_scenario_id}
         AND cap_factor_limits_scenario_id IS NOT NULL
         """.format(
+            temporal_scenario_id=subscenarios.TEMPORAL_SCENARIO_ID,
             project_opchar_scenario_id=subscenarios.PROJECT_OPERATIONAL_CHARS_SCENARIO_ID,
             project_portfolio_scenario_id=subscenarios.PROJECT_PORTFOLIO_SCENARIO_ID,
         )


### PR DESCRIPTION
Get only relevant horizons while getting inputs from database for project_cap_factor_limits