### PR TITLE
Fixes to SQL queries for fuel burn limits

### DIFF
--- a/gridpath/system/policy/fuel_burn_limits/aggregate_project_fuel_burn.py
+++ b/gridpath/system/policy/fuel_burn_limits/aggregate_project_fuel_burn.py
@@ -166,12 +166,28 @@ def get_inputs_from_database(scenario_id, subscenarios, subproblem, stage, conn)
         INNER JOIN (
             SELECT fuel, fuel_burn_limit_ba
                 FROM inputs_geography_fuel_burn_limit_balancing_areas
-                WHERE fuel_burn_limit_ba_scenario_id = {fuel_burn_limit_ba_scenario_id})
+                WHERE fuel_burn_limit_ba_scenario_id = {fuel_burn_limit_ba_scenario_id}
+                AND fuel in (
+                SELECT DISTINCT fuel
+                FROM inputs_project_fuels
+                WHERE (project, project_fuel_scenario_id) in (
+                    SELECT DISTINCT project, project_fuel_scenario_id
+                    FROM inputs_project_operational_chars
+                    WHERE project_operational_chars_scenario_id = {project_operational_chars_scenario_id}
+                    AND project in (
+                    SELECT DISTINCT project
+                    FROM inputs_project_portfolios
+                    WHERE project_portfolio_scenario_id = {project_portfolio_scenario_id}
+                    )
+                )
+                )
+                )
         USING (fuel, fuel_burn_limit_ba);
         """.format(
             project_portfolio_scenario_id=subscenarios.PROJECT_PORTFOLIO_SCENARIO_ID,
             project_fuel_burn_limit_ba_scenario_id=subscenarios.PROJECT_FUEL_BURN_LIMIT_BA_SCENARIO_ID,
             fuel_burn_limit_ba_scenario_id=subscenarios.FUEL_BURN_LIMIT_BA_SCENARIO_ID,
+            project_operational_chars_scenario_id=subscenarios.PROJECT_OPERATIONAL_CHARS_SCENARIO_ID,
         )
     )
 

--- a/gridpath/system/policy/fuel_burn_limits/fuel_burn_limits.py
+++ b/gridpath/system/policy/fuel_burn_limits/fuel_burn_limits.py
@@ -151,7 +151,22 @@ def get_inputs_from_database(scenario_id, subscenarios, subproblem, stage, conn)
         JOIN
         (SELECT fuel, fuel_burn_limit_ba
         FROM inputs_geography_fuel_burn_limit_balancing_areas
-        WHERE fuel_burn_limit_ba_scenario_id = {fuel_burn_limit_ba_scenario_id}) as 
+        WHERE fuel_burn_limit_ba_scenario_id = {fuel_burn_limit_ba_scenario_id}
+        AND fuel in (
+        SELECT DISTINCT fuel
+        FROM inputs_project_fuels
+        WHERE (project, project_fuel_scenario_id) in (
+            SELECT DISTINCT project, project_fuel_scenario_id
+            FROM inputs_project_operational_chars
+            WHERE project_operational_chars_scenario_id = {project_operational_chars_scenario_id}
+            AND project in (
+            SELECT DISTINCT project
+            FROM inputs_project_portfolios
+            WHERE project_portfolio_scenario_id = {project_portfolio_scenario_id}
+            )
+        )
+        )
+        ) as 
         relevant_zones
         USING (fuel, fuel_burn_limit_ba)
         WHERE fuel_burn_limit_scenario_id = {fuel_burn_limit_scenario_id}
@@ -161,6 +176,8 @@ def get_inputs_from_database(scenario_id, subscenarios, subproblem, stage, conn)
             temporal_scenario_id=subscenarios.TEMPORAL_SCENARIO_ID,
             fuel_burn_limit_ba_scenario_id=subscenarios.FUEL_BURN_LIMIT_BA_SCENARIO_ID,
             fuel_burn_limit_scenario_id=subscenarios.FUEL_BURN_LIMIT_SCENARIO_ID,
+            project_operational_chars_scenario_id=subscenarios.PROJECT_OPERATIONAL_CHARS_SCENARIO_ID,
+            project_portfolio_scenario_id=subscenarios.PROJECT_PORTFOLIO_SCENARIO_ID,
             subproblem_id=subproblem,
             stage_id=stage,
         )


### PR DESCRIPTION
Modified SQL queries used to generate tab files for fuel burn limits and project fuel burn limits. The change restricts input data to fuels used by projects in the scenario, like it is done for fuel burn limit balancing areas. Otherwise, an error occurs when fuel burn limits are defined for unused fuels (i.e., values cannot be added to sets outside of their domain).