### PR TITLE
Change default value of allow_startup_shutdown param to 1

### DIFF
--- a/gridpath/project/operations/operational_types/gen_commit_unit_common.py
+++ b/gridpath/project/operations/operational_types/gen_commit_unit_common.py
@@ -1182,7 +1182,7 @@ def add_model_components(
         Param(
             getattr(m, "GEN_COMMIT_{}".format(BIN_OR_LIN)),
             within=Boolean,
-            default=0,
+            default=1,
         ),
     )
 


### PR DESCRIPTION
Setting this parameter to 0, which is also its default value, could result in an infeasibility since max_shutdown_power_constraint_rule (which only allows Provide_Power_Shutdown_MW = 0) is incompatible with ramp_during_shutdown_constraint_rule (which enforces the Shutdown_Ramp_Rate_MW_Per_Tmp).

Fixes blue-marble/gridpath#1071