### PR TITLE
Improving script and function argument handling

### DIFF
--- a/gridpath/get_scenario_inputs.py
+++ b/gridpath/get_scenario_inputs.py
@@ -283,14 +283,10 @@ def delete_prior_inputs(inputs_directory):
     for f in prior_input_tab_files:
         os.remove(os.path.join(inputs_directory, f))
 
-
-def parse_arguments(args):
+def create_parser():
     """
-    :param args: the script arguments specified by the user
-    :return: the parsed known argument values (<class 'argparse.Namespace'>
-    Python object)
-
-    Parse the known arguments.
+    
+    :return: argument parser object
     """
     parser = ArgumentParser(
         add_help=True,
@@ -300,9 +296,27 @@ def parse_arguments(args):
             get_get_inputs_parser(),
         ],
     )
+    
+    return parser
 
-    parsed_arguments = parser.parse_known_args(args=args)[0]
+def parse_arguments(func_args):
+    """
+    :param args: the function arguments specified by the caller
+    :return: the parsed known argument values (<class 'argparse.Namespace'>
+    Python object)
 
+    Parse the known arguments.
+    """
+    parser = create_parser()
+    
+    is_cli_entry_point = func_args is None
+    if is_cli_entry_point:
+        args = sys.argv[1:]
+        parsed_arguments = parser.parse_args(args=args)
+    else:
+        args = func_args
+        parsed_arguments = parser.parse_known_args(args=args)[0]
+    
     return parsed_arguments
 
 
@@ -421,16 +435,14 @@ def write_linked_subproblems_map(scenario_directory, conn, subscenarios):
         )
 
 
-def main(args=None):
+def main(func_args=None):
     """
 
     :return:
     """
     # Retrieve DB location and scenario_id and/or name from args
-    if args is None:
-        args = sys.argv[1:]
 
-    parsed_arguments = parse_arguments(args=args)
+    parsed_arguments = parse_arguments(func_args=func_args)
 
     db_path = parsed_arguments.database
     scenario_id_arg = parsed_arguments.scenario_id


### PR DESCRIPTION
This is an initial attempt to resolve #111 . 

The first commit is an attempt to handle the need for strict handling of unrecognised arguments during command-line operation, while also being flexible when the scripts are being called internally - in this instance, when `get_scenario_inputs`. I am detecting whether arguments have been passed directly to the function argument, or via `sys.argv`. Based on that, I'm taking inspiration from @gerritdm 's posts in the issue and his work in the viz suite.

Please review. If this looks okay, I will do this for all the other argument parsing entry points. Other cleanup will then follow.