### PR TITLE
Fix get_inputs_from_database for carbon credits params AND avoid trying to load info from project_carbon_credits.tab if the file does not exist

### DIFF
--- a/gridpath/project/operations/carbon_credits.py
+++ b/gridpath/project/operations/carbon_credits.py
@@ -420,22 +420,21 @@ def load_model_data(
         None: list(data_portal.data()["carbon_credits_generation_zone"].keys())
     }
 
-    data_portal.load(
-        filename=os.path.join(
-            scenario_directory,
-            weather_iteration,
-            hydro_iteration,
-            availability_iteration,
-            subproblem,
-            stage,
-            "inputs",
-            "project_carbon_credits.tab",
-        ),
-        param=(
-            m.intensity_threshold_emissions_toCO2_per_MWh,
-            m.absolute_threshold_emissions_toCO2,
-        ),
+    prj_carbon_credits_file = os.path.join(
+        scenario_directory,
+        str(subproblem),
+        str(stage),
+        "inputs",
+        "project_carbon_credits.tab",
     )
+    if os.path.exists(prj_carbon_credits_file):
+        data_portal.load(
+            filename=prj_carbon_credits_file,
+            param=(
+                m.intensity_threshold_emissions_toCO2_per_MWh,
+                m.absolute_threshold_emissions_toCO2,
+            ),
+        )
 
     data_portal.load(
         filename=os.path.join(

--- a/gridpath/system/policy/carbon_credits/sell_and_buy_credits.py
+++ b/gridpath/system/policy/carbon_credits/sell_and_buy_credits.py
@@ -189,17 +189,23 @@ def get_inputs_from_database(
     c = conn.cursor()
     zones = c.execute(
         f"""SELECT carbon_credits_zone, period, allow_carbon_credits_infinite_demand, carbon_credits_demand_tco2,
-            carbon_credits_demand_price, allow_carbon_credits_infinite_supply, carbon_credits_supply_tco2, 
-            carbon_credits_supply_price
-        FROM inputs_system_carbon_credits_params
-        WHERE carbon_credits_params_scenario_id = 
-        {subscenarios.CARBON_CREDITS_PARAMS_SCENARIO_ID}
-        AND period IN (
-            SELECT period
-            FROM inputs_temporal_periods
-            WHERE temporal_scenario_id = {subscenarios.TEMPORAL_SCENARIO_ID}
-        );
-        """
+                carbon_credits_demand_price, allow_carbon_credits_infinite_supply, carbon_credits_supply_tco2, 
+                carbon_credits_supply_price
+            FROM
+            (SELECT carbon_credits_zone
+                FROM inputs_geography_carbon_credits_zones
+                WHERE carbon_credits_zone_scenario_id = {subscenarios.CARBON_CREDITS_ZONE_SCENARIO_ID}
+            ) as cc_zone_tbl
+            CROSS JOIN
+            (SELECT period
+                FROM inputs_temporal_periods
+                WHERE temporal_scenario_id = {subscenarios.TEMPORAL_SCENARIO_ID}
+            ) as period_tbl
+            LEFT OUTER JOIN
+            inputs_system_carbon_credits_params
+            USING (carbon_credits_zone, period)
+            WHERE carbon_credits_params_scenario_id = {subscenarios.CARBON_CREDITS_PARAMS_SCENARIO_ID};
+            """
     )
 
     return zones


### PR DESCRIPTION
Fix get_inputs_from_database for carbon credits params to only get the information for the relevant carbon credits zones. And avoid trying to load info from project_carbon_credits.tab if the file does not exist.