### PR TITLE
 Uninitialised variable prev_tmp_curtailment in gen_hydro (#1135)

### DIFF
--- a/gridpath/project/operations/operational_types/gen_hydro.py
+++ b/gridpath/project/operations/operational_types/gen_hydro.py
@@ -541,6 +541,9 @@ def ramp_up_rule(mod, g, tmp):
             prev_tmp_downwards_reserves = mod.GenHydro_Downwards_Reserves_MW[
                 g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]
             ]
+            prev_tmp_curtailment = mod.GenHydro_Curtail_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]
+            ]
         # If you can ramp up the the total project's capacity within the
         # previous timepoint, skip the constraint (it won't bind)
         if mod.gen_hydro_ramp_up_when_on_rate[g] * 60 * prev_tmp_hrs_in_tmp >= 1:
@@ -600,6 +603,9 @@ def ramp_down_rule(mod, g, tmp):
                 g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]
             ]
             prev_tmp_upwards_reserves = mod.GenHydro_Upwards_Reserves_MW[
+                g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]
+            ]
+            prev_tmp_curtailment = mod.GenHydro_Curtail_MW[
                 g, mod.prev_tmp[tmp, mod.balancing_type_project[g]]
             ]
         # If you can ramp down the the total project's capacity within the


### PR DESCRIPTION
 The variable prev_tmp_curtailment is used without initialising when
 the timepoint is not the first timepoint of the horizon and the entire
 project capacity cannot be ramped in one timepoint.

The issue exists on the tip of develop, hence the fix needs to be ported there as well.

Closes #1135