### PR TITLE
Fixes in transmission targets

### DIFF
--- a/gridpath/transmission/operations/transmission_target_contributions.py
+++ b/gridpath/transmission/operations/transmission_target_contributions.py
@@ -302,8 +302,16 @@ def export_results(
         [
             tx,
             tmp,
-            value(m.TxSimpleBinary_Transmit_Power_Positive_Direction_MW[tx, tmp]),
-            value(m.TxSimpleBinary_Transmit_Power_Negative_Direction_MW[tx, tmp]),
+            (
+                value(m.TxSimpleBinary_Transmit_Power_Positive_Direction_MW[tx, tmp])
+                if float(m.contributes_net_flow_to_tx_target[tx]) == 0
+                else value(m.TxSimple_Transmit_Power_MW[tx, tmp])
+            ),
+            (
+                value(m.TxSimpleBinary_Transmit_Power_Negative_Direction_MW[tx, tmp])
+                if float(m.contributes_net_flow_to_tx_target[tx]) == 0
+                else value(-m.TxSimple_Transmit_Power_MW[tx, tmp])
+            ),
             (
                 value(m.Transmission_Target_Energy_MW_Pos_Dir[tx, tmp])
                 if float(m.contributes_net_flow_to_tx_target[tx]) == 0

--- a/gridpath/transmission/operations/transmission_target_contributions.py
+++ b/gridpath/transmission/operations/transmission_target_contributions.py
@@ -203,7 +203,7 @@ def add_model_components(
         else:
             return (
                 mod.Transmission_Target_Net_Energy_MW_Neg_Dir[tx, tmp]
-                == mod.Transmit_Power_MW[tx, tmp]
+                == -mod.Transmit_Power_MW[tx, tmp]
             )
 
     m.Transmission_Target_Net_Energy_MW_Neg_Dir_Constraint = Constraint(


### PR DESCRIPTION
-  Fix transmission min targets formulation in negative direction: Add a minus sign to determine the transmission contribution in the negative direction for net transmission.
- Fix exporting results for transmission targets contributions