### PR TITLE
Define elcc_simple_fraction over Reals

### DIFF
--- a/gridpath/project/reliability/prm/prm_simple.py
+++ b/gridpath/project/reliability/prm/prm_simple.py
@@ -52,9 +52,7 @@ def add_model_components(
     # The fraction of ELCC-eligible capacity that counts for the PRM via the
     # simple PRM method (whether or not project also contributes through the
     # ELCC surface)
-    m.elcc_simple_fraction = Param(
-        m.PRM_PROJECTS, m.PERIODS, within=Reals, default=0
-    )
+    m.elcc_simple_fraction = Param(m.PRM_PROJECTS, m.PERIODS, within=Reals, default=0)
 
     def elcc_simple_rule(mod, g, p):
         """

--- a/gridpath/project/reliability/prm/prm_simple.py
+++ b/gridpath/project/reliability/prm/prm_simple.py
@@ -22,7 +22,7 @@ defaults to 0 if not specified).
 
 import csv
 import os.path
-from pyomo.environ import Param, PercentFraction, Expression, value
+from pyomo.environ import Param, Reals, Expression, value
 
 from gridpath.auxiliary.auxiliary import cursor_to_df
 from gridpath.auxiliary.db_interface import import_csv, directories_to_db_values
@@ -53,7 +53,7 @@ def add_model_components(
     # simple PRM method (whether or not project also contributes through the
     # ELCC surface)
     m.elcc_simple_fraction = Param(
-        m.PRM_PROJECTS, m.PERIODS, within=PercentFraction, default=0
+        m.PRM_PROJECTS, m.PERIODS, within=Reals, default=0
     )
 
     def elcc_simple_rule(mod, g, p):


### PR DESCRIPTION
Allow elcc_simple_fraction to be negative for demand-side “projects” that increase the PRM requirements.