### PR TITLE
Test with coverage on one parallel run only

### DIFF
--- a/.github/workflows/test_gridpath.yml
+++ b/.github/workflows/test_gridpath.yml
@@ -56,11 +56,17 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install .[coverage] --upgrade pip
+    - name: Test GridPath w/o coverage on all but Linux with Python 3.13
+      if: ${{ runner.os == 'Windows' || runner.os == 'macOS' || matrix.python-version != '3.13' }}
+      run: |
+        python -m unittest discover tests
     - name: Test GridPath with coverage
+      if: ${{ runner.os == 'Linux' && matrix.python-version == '3.13' }}
       run: |
         coverage run -m unittest discover tests
     - name: Send coverage results to Coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ runner.os == 'Linux' && matrix.python-version == '3.13' }}
       run: |
         coveralls --service=github


### PR DESCRIPTION
Coverage adds a lot of overhead on recent Python versions, so only run with coverage on one of our parallel test runs (Linux, Python 3.13 currently).