### PR TITLE
Pandas 2.x int64 fix and hydro_balancing_type parameter

### DIFF
--- a/data_toolkit/project/opchar/eia860_to_project_opchar_input_csvs.py
+++ b/data_toolkit/project/opchar/eia860_to_project_opchar_input_csvs.py
@@ -107,6 +107,14 @@ def parse_arguments(args):
     )
     parser.add_argument("-hy_id", "--hydro_operational_chars_scenario_id", default=1)
 
+    parser.add_argument(
+        "-hydro_bt",
+        "--hydro_balancing_type",
+        default=None,
+        help="Override balancing_type_project for hydro projects. "
+        "If not specified, uses gridpath_balancing_type from the key table.",
+    )
+
     parser.add_argument("-q", "--quiet", default=False, action="store_true")
 
     parsed_arguments = parser.parse_known_args(args=args)[0]
@@ -131,6 +139,7 @@ def get_project_opchar(
     hr_id,
     var_id,
     hy_id,
+    hydro_balancing_type=None,
 ):
     # Wind, offshore wind, and PV are aggregated, so treated separately since
     # they are aggregated, so here we make a UNION between tables filtering
@@ -160,10 +169,15 @@ def get_project_opchar(
         variable_generator_profile_scenario_id=f"{var_id}",
     )
 
+    hydro_bt_expr = (
+        f"'{hydro_balancing_type}'"
+        if hydro_balancing_type
+        else "gridpath_balancing_type"
+    )
     hydro_opchars_str = make_opchar_sql_str(
         technology="gridpath_technology",
         operational_type="gridpath_operational_type",
-        balancing_type_project="gridpath_balancing_type",
+        balancing_type_project=hydro_bt_expr,
         variable_om_cost_per_mwh="default_variable_om_cost_per_mwh",
         hydro_operational_chars_scenario_id=f"{hy_id}",
     )
@@ -455,6 +469,7 @@ def main(args=None):
         hr_id=parsed_args.heat_rate_curves_scenario_id,
         var_id=parsed_args.variable_generator_profile_scenario_id,
         hy_id=parsed_args.hydro_operational_chars_scenario_id,
+        hydro_balancing_type=parsed_args.hydro_balancing_type,
     )
 
     conn.close()

--- a/data_toolkit/project/opchar/hydro/create_hydro_iteration_input_csvs.py
+++ b/data_toolkit/project/opchar/hydro/create_hydro_iteration_input_csvs.py
@@ -119,6 +119,15 @@ def parse_arguments(args):
     )
 
     parser.add_argument(
+        "-hydro_bt",
+        "--hydro_balancing_type",
+        default=None,
+        help="Filter to a specific balancing type (e.g., 'day', 'week', 'month'). "
+        "If not specified, all balancing types from "
+        "user_defined_balancing_type_horizons are included.",
+    )
+
+    parser.add_argument(
         "-parallel",
         "--n_parallel_projects",
         default=1,
@@ -140,6 +149,7 @@ def calculate_from_project_year_month_data(
     hydro_operational_chars_scenario_name,
     output_directory,
     overwrite,
+    hydro_balancing_type=None,
 ):
     """
     Create hydro project CSVs for a temporal subscenario and a balancing
@@ -153,9 +163,12 @@ def calculate_from_project_year_month_data(
     """).fetchall()]
 
     bt_horizons = [bt_h for bt_h in c.execute("""
-            SELECT DISTINCT balancing_type, horizon 
+            SELECT DISTINCT balancing_type, horizon
             FROM user_defined_balancing_type_horizons;
             """).fetchall()]
+
+    if hydro_balancing_type is not None:
+        bt_horizons = [bt_h for bt_h in bt_horizons if bt_h[0] == hydro_balancing_type]
 
     if overwrite:
         filename = get_filename(
@@ -266,6 +279,7 @@ def calculate_from_project_year_month_data_pool(pool_datum):
         output_directory,
         overwrite,
         stage_id,
+        hydro_balancing_type,
     ) = pool_datum
 
     calculate_from_project_year_month_data(
@@ -276,6 +290,7 @@ def calculate_from_project_year_month_data_pool(pool_datum):
         output_directory=output_directory,
         overwrite=overwrite,
         stage_id=stage_id,
+        hydro_balancing_type=hydro_balancing_type,
     )
 
 
@@ -341,6 +356,7 @@ def main(args=None):
                 parsed_args.output_directory,
                 parsed_args.overwrite,
                 parsed_args.stage_id,
+                parsed_args.hydro_balancing_type,
             ]
             for prj in projects
         ]

--- a/data_toolkit/raw_data/pudl/pudl_to_gridpath_raw_data.py
+++ b/data_toolkit/raw_data/pudl/pudl_to_gridpath_raw_data.py
@@ -214,11 +214,12 @@ def convert_ra_toolkit_profiles_to_csv(raw_data_directory, pudl_download_directo
         df["day_of_month_hs"] = pd.DatetimeIndex(df["datetime_pst_hs"]).day
         df["hour_of_day_hs"] = pd.DatetimeIndex(df["datetime_pst_hs"]).hour
 
-        # Populate initial values based on HE
-        df["year"] = df["year_he"]
-        df["month"] = df["month_he"]
-        df["day_of_month"] = df["day_of_month_he"]
-        df["hour_of_day"] = df["hour_of_day_he"]
+        # Populate initial values based on HE; use int64 to avoid
+        # LossySetitemError on pandas 2.x when overwriting with HS values
+        df["year"] = df["year_he"].astype("int64")
+        df["month"] = df["month_he"].astype("int64")
+        df["day_of_month"] = df["day_of_month_he"].astype("int64")
+        df["hour_of_day"] = df["hour_of_day_he"].astype("int64")
 
         # Go from HE timestamps to 1-24 timepoint indexing
         df.loc[
@@ -275,11 +276,12 @@ def convert_eia930_hourly_interchange_to_csv(
         df["day_of_month_hs"] = pd.DatetimeIndex(df["datetime_pst_hs"]).day
         df["hour_of_day_hs"] = pd.DatetimeIndex(df["datetime_pst_hs"]).hour
 
-        # Populate initial values based on HE
-        df["year"] = df["year_he"]
-        df["month"] = df["month_he"]
-        df["day_of_month"] = df["day_of_month_he"]
-        df["hour_of_day"] = df["hour_of_day_he"]
+        # Populate initial values based on HE; use int64 to avoid
+        # LossySetitemError on pandas 2.x when overwriting with HS values
+        df["year"] = df["year_he"].astype("int64")
+        df["month"] = df["month_he"].astype("int64")
+        df["day_of_month"] = df["day_of_month_he"].astype("int64")
+        df["hour_of_day"] = df["hour_of_day_he"].astype("int64")
 
         # Go from HE timestamps to 1-24 timepoint indexing
         df.loc[


### PR DESCRIPTION
## Summary
- Fixes `LossySetitemError` on pandas 2.x in `pudl_to_gridpath_raw_data.py` by casting datetime-derived columns to `int64` before overwriting with hour-start values
- Adds `--hydro_balancing_type` parameter to `create_hydro_iteration_input_csvs.py` and `eia860_to_project_opchar_input_csvs.py`, allowing users to filter hydro balancing horizons (e.g., `month`) and override `balancing_type_project` for hydro projects

## Test plan
- [x] All 3 data toolkit tests pass locally (`test_data_toolkit_ra`, `test_data_toolkit_ra_steps`, `test_data_toolkit_open_data`)
- [x] No test output CSV changes (default behavior preserved)
- [ ] CI should pass on all OS/Python matrix combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)