### PR TITLE
minor db merge queries

### DIFF
--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -8945,7 +8945,7 @@ FROM results_project_costs_capacity_agg AS a
          AND a.stage_id = b.stage_id
          AND a.period = b.period
          AND a.load_zone = b.load_zone
-         AND a.spinup_or_lookahead = b.spinup_or_lookahead
+         AND COALESCE(a.spinup_or_lookahead, 0) = COALESCE(b.spinup_or_lookahead, 0)
          )
 
          LEFT JOIN
@@ -8963,7 +8963,7 @@ FROM results_project_costs_capacity_agg AS a
          AND a.stage_id = c.stage_id
          AND a.period = c.period
          AND a.load_zone = c.load_zone
-         AND a.spinup_or_lookahead = c.spinup_or_lookahead
+         AND COALESCE(a.spinup_or_lookahead, 0) = COALESCE(c.spinup_or_lookahead, 0)
          )
 
          LEFT JOIN
@@ -8973,17 +8973,17 @@ FROM results_project_costs_capacity_agg AS a
          AND a.stage_id = d.stage_id
          AND a.period = d.period
          AND a.load_zone = d.load_zone
-         AND a.spinup_or_lookahead = d.spinup_or_lookahead
+         AND COALESCE(a.spinup_or_lookahead, 0) = COALESCE(d.spinup_or_lookahead, 0)
          )
 
          LEFT JOIN
      results_transmission_hurdle_costs_by_timepoint_agg as e
-     ON (a.scenario_id = d.scenario_id
-         AND a.subproblem_id = d.subproblem_id
-         AND a.stage_id = d.stage_id
-         AND a.period = d.period
-         AND a.load_zone = d.load_zone
-         AND a.spinup_or_lookahead = d.spinup_or_lookahead
+     ON (a.scenario_id = e.scenario_id
+         AND a.subproblem_id = e.subproblem_id
+         AND a.stage_id = e.stage_id
+         AND a.period = e.period
+         AND a.load_zone = e.load_zone
+         AND COALESCE(a.spinup_or_lookahead, 0) = COALESCE(e.spinup_or_lookahead, 0)
          )
 ;
 

--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -8934,8 +8934,7 @@ SELECT a.scenario_id,
        startup_cost,
        shutdown_cost,
        tx_capacity_cost,
-       tx_hurdle_cost,
-       tx_hurdle_cost_by_timepoint
+       tx_hurdle_cost
 FROM results_project_costs_capacity_agg AS a
 
          LEFT JOIN
@@ -8975,16 +8974,6 @@ FROM results_project_costs_capacity_agg AS a
          AND a.load_zone = d.load_zone
          AND COALESCE(a.spinup_or_lookahead, 0) = COALESCE(d.spinup_or_lookahead, 0)
          )
-
-         LEFT JOIN
-     results_transmission_hurdle_costs_by_timepoint_agg as e
-     ON (a.scenario_id = e.scenario_id
-         AND a.subproblem_id = e.subproblem_id
-         AND a.stage_id = e.stage_id
-         AND a.period = e.period
-         AND a.load_zone = e.load_zone
-         AND COALESCE(a.spinup_or_lookahead, 0) = COALESCE(e.spinup_or_lookahead, 0)
-         )
 ;
 
 
@@ -9003,7 +8992,6 @@ SELECT a.scenario_id,
        shutdown_cost,
        tx_capacity_cost,
        tx_hurdle_cost,
-       tx_hurdle_cost_by_timepoint,
        deliverable_capacity_cost
 FROM (SELECT scenario_id,
              subproblem_id,
@@ -9016,8 +9004,7 @@ FROM (SELECT scenario_id,
              SUM(startup_cost)                AS startup_cost,
              SUM(shutdown_cost)               AS shutdown_cost,
              SUM(tx_capacity_cost)            AS tx_capacity_cost,
-             SUM(tx_hurdle_cost)              AS tx_hurdle_cost,
-             SUM(tx_hurdle_cost_by_timepoint) AS tx_hurdle_cost_by_timepoint
+             SUM(tx_hurdle_cost)              AS tx_hurdle_cost
       FROM results_costs_by_period_load_zone
       GROUP BY scenario_id, subproblem_id, stage_id, period,
                spinup_or_lookahead) AS a

--- a/gridpath/project/operations/costs.py
+++ b/gridpath/project/operations/costs.py
@@ -745,10 +745,10 @@ def process_results(db, c, scenario_id, subscenarios, quiet):
         variable_om_cost, fuel_cost, startup_cost, shutdown_cost)
         SELECT scenario_id, subproblem_id, stage_id, period, load_zone,
         spinup_or_lookahead,
-        SUM(fuel_cost * timepoint_weight * number_of_hours_in_timepoint) 
-        AS fuel_cost,
-        SUM(variable_om_cost * timepoint_weight * number_of_hours_in_timepoint) 
+        SUM(variable_om_cost * timepoint_weight * number_of_hours_in_timepoint)
         AS variable_om_cost,
+        SUM(fuel_cost * timepoint_weight * number_of_hours_in_timepoint)
+        AS fuel_cost,
         SUM(startup_cost * timepoint_weight) AS startup_cost,
         SUM(shutdown_cost * timepoint_weight) AS shutdown_cost
         FROM results_project_timepoint


### PR DESCRIPTION
Minor SQL cost query fixes

1. in costs.py, INSERT INTO `results_project_costs_operations_agg`
   lists columns as (... variable_om_cost, fuel_cost, ...) but selects
   SUM(fuel_cost) AS fuel_cost first and
   SUM(variable_om_cost) AS variable_om_cost second. SQLite's INSERT
   is positional so the columns are stored swapped: the column named
   variable_om_cost actually holds period-aggregated fuel cost and
   vice versa. Reorder the SELECT to match the column list.
2. `results_project_costs_capacity_agg` writes
   spinup_or_lookahead = 0 for non-spinup rows while
   results_project_costs_operations_agg (tx as well) write NULL,
   so the view's a.spinup_or_lookahead = b.spinup_or_lookahead join
   fails (NULL = 0 is UNKNOWN) and every operations / tx
   row is silently dropped. These are wrapped in  COALESCE(..., 0) so
   the condition is robust to either convention.
3. Views `results_costs_by_period_load_zone`
and `results_costs_by_period` aggregate by period and included
either joins or summation over
`results_transmission_hurdle_costs_by_timepoint_agg`.
However, this view does not include period.
This was silently ignored before and is now removed for clarity.